### PR TITLE
NodeHaloTopology v2: device-resident O(boundary) construction

### DIFF
--- a/backend/distributed/unstructured/domain.cu
+++ b/backend/distributed/unstructured/domain.cu
@@ -1,10 +1,15 @@
 #include "domain.hpp"
 #include "thrust/sort.h"
 #include "thrust/unique.h"
+#include "thrust/binary_search.h"
 #include "thrust/device_vector.h"
 #include "cub/cub.cuh"
 #include <unordered_map>
 #include <algorithm>
+#include <cstdlib>
+#include <climits>
+#include <map>
+#include <string>
 
 namespace mars
 {
@@ -1029,10 +1034,103 @@ void HaloData<ElementTag, RealType, KeyType, AcceleratorTag>::buildNodeOwnership
 //
 // Note: Stage 1 size = sum_r |owned_nodes_r| ~ globalNodes; tiny.
 //       Stage 2 size = sum_r |ghost_nodes_r|; bounded by partition surface.
+
+namespace {
+
+// True when env var is set to a truthy value (1/true/on/yes).
+inline bool envFlag(const char* name)
+{
+    const char* env = std::getenv(name);
+    if (!env) return false;
+    std::string s(env);
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    return s == "1" || s == "true" || s == "on" || s == "yes";
+}
+
+// v2 device-resident path is the default since cube1024/256 was validated
+// bit-exact against host. MARS_NODEHALO_HOST=1 opts out (host O(global)
+// fallback). MARS_NODEHALO_VALIDATE=1 runs both and aborts on mismatch.
+inline bool nodeHaloHostFallbackEnabled() { return envFlag("MARS_NODEHALO_HOST"); }
+inline bool nodeHaloValidateEnabled()     { return envFlag("MARS_NODEHALO_VALIDATE"); }
+
+} // anonymous namespace
+
+// Forward declaration of the host-driven path (the body that used to be the
+// constructor). Now invocable both as the default and from validation.
+template<typename ElementTag, typename RealType, typename KeyType, typename AcceleratorTag>
+static void buildNodeHaloTopologyHostPath(
+    NodeHaloTopology<ElementTag, RealType, KeyType, AcceleratorTag>& topo,
+    const ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>& domain);
+
 template<typename ElementTag, typename RealType, typename KeyType, typename AcceleratorTag>
 NodeHaloTopology<ElementTag, RealType, KeyType, AcceleratorTag>::NodeHaloTopology(
     const ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>& domain)
 {
+    int rank     = domain.rank();
+    int numRanks = domain.numRanks();
+
+    if (numRanks == 1)
+    {
+        sendOffsets_.assign(1, 0);
+        recvOffsets_.assign(1, 0);
+        return;
+    }
+
+    // Runtime path selection. v2 is the default since cube1024/256 was
+    // validated bit-exact (matrix=2.071203e+01, rhs=1.555497e-03 match host
+    // reference; NodeHaloTopo phase 130 ms vs ~70 s host at cube512/32).
+    // MARS_NODEHALO_HOST=1 opts out to the original O(global) Allgatherv path.
+    // MARS_NODEHALO_VALIDATE=1 runs both and aborts on per-peer node-id mismatch.
+    bool useHost  = nodeHaloHostFallbackEnabled();
+    bool validate = nodeHaloValidateEnabled();
+
+    if (validate)
+    {
+        bool ok = NodeHaloTopology::validateAgainstHost(domain);
+        if (!ok)
+        {
+            std::cerr << "[Rank " << rank << "] NodeHaloTopology v2 vs host MISMATCH — aborting" << std::endl;
+            std::cerr.flush();
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+        this->buildFromCstoneHalos(domain);
+    }
+    else if (useHost) { buildNodeHaloTopologyHostPath(*this, domain); }
+    else              { this->buildFromCstoneHalos(domain); }
+
+    // Pre-size hot-path staging buffers (Gate 4 fix for v1 race).
+    size_t sendTotal = sendOffsets_.empty() ? 0 : size_t(sendOffsets_.back());
+    size_t recvTotal = recvOffsets_.empty() ? 0 : size_t(recvOffsets_.back());
+    sendBuf_.resize(sendTotal);
+    recvBuf_.resize(recvTotal);
+}
+
+// =====================================================================
+// HOST FALLBACK PATH (NOT THE DEFAULT)
+// =====================================================================
+// O(global) construction using MPI_Allgatherv + MPI_Alltoallv. Active
+// only when MARS_NODEHALO_HOST=1, or transiently inside
+// MARS_NODEHALO_VALIDATE=1 for cross-checking.
+//
+// All MPI_Allgather*, MPI_Alltoall* in this file live in this function.
+// The default path (buildFromCstoneHalos) uses only point-to-point
+// MPI_Isend/Irecv in the peer subgroup — no collectives.
+//
+// Body is unchanged from commit 1d90501; refactored into a free
+// function so the new constructor can call it as a fallback.
+// =====================================================================
+template<typename ElementTag, typename RealType, typename KeyType, typename AcceleratorTag>
+static void buildNodeHaloTopologyHostPath(
+    NodeHaloTopology<ElementTag, RealType, KeyType, AcceleratorTag>& topo,
+    const ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>& domain)
+{
+    using TopoT = NodeHaloTopology<ElementTag, RealType, KeyType, AcceleratorTag>;
+    auto& peers_       = topo.peers_;
+    auto& sendOffsets_ = topo.sendOffsets_;
+    auto& recvOffsets_ = topo.recvOffsets_;
+    auto& sendNodeIds_ = topo.sendNodeIds_;
+    auto& recvNodeIds_ = topo.recvNodeIds_;
+
     int rank     = domain.rank();
     int numRanks = domain.numRanks();
 
@@ -1220,6 +1318,886 @@ NodeHaloTopology<ElementTag, RealType, KeyType, AcceleratorTag>::NodeHaloTopolog
               << sendNodesHost.size() << " send nodes, "
               << recvNodesHost.size() << " recv nodes" << std::endl;
     std::cout.flush();
+}
+
+// ============================================================================
+// Gate 1-4: Device-resident NodeHaloTopology construction
+//
+// Builds per-peer (sendNodeIds_, recvNodeIds_) CSRs by consuming cstone's
+// element-halo bookkeeping (incomingHaloIndices, outgoingHaloIndices) and
+// filtering by node ownership. O(local boundary), no MPI_Allgatherv.
+//
+// Gate 1 contract: same fields populated as buildNodeHaloTopologyHostPath,
+// just via a different algorithm. Validation harness (validateAgainstHost)
+// diffs per-peer sorted node-id lists; bit-exact match expected.
+//
+// UNTESTED on hardware. Build, then on the cluster:
+//   MARS_NODEHALO_VALIDATE=1 mpirun ... ./mars_cvfem_graph ...
+//      → runs both paths and aborts on first mismatch
+//   MARS_NODEHALO_V2=1 mpirun ... ./mars_cvfem_graph ...
+//      → runs only v2 path (use after Gate 1 passes)
+//   (no env)            → host O(global) path (default, current production)
+//
+// KNOWN GAP: this builder consumes d_nodeOwnership_ as produced by
+// HaloData::buildNodeOwnership() Steps 1+2 only. It does NOT run a
+// global tiebreaker exchange to resolve corner-shared duplicate ownership
+// (the host path does that via MPI_Allgatherv at L1085 and the keyOwner
+// map at L1090).
+//
+// Consequence: on cube/structured meshes where Steps 1+2 already produce
+// unambiguous ownership, v2 should match host bit-exactly. On meshes
+// where multiple ranks initially own the same SFC key (corner-shared
+// nodes on >=4-rank partitions), v2 will diverge from host. Gate 1's
+// validateAgainstHost is precisely how we detect this — if it fires,
+// we add a tiebreaker pass before flipping v2 on by default.
+// ============================================================================
+
+// Send-side per-node kernel: for each node N where I'm the authoritative
+// owner, emit (claimant_rank, N) for every other rank that claimed N's
+// SFC key (i.e. every peer that touches N and therefore needs it as a
+// ghost). Using the merged peer-claim CSR avoids relying on cstone's
+// outgoing-element-halo to peer P, which can miss corner-only contacts.
+template<typename KeyType>
+__global__ void emitSendNodesKernel(
+    const KeyType* d_localToGlobalSfc,    // [nodeCount]
+    const int*     d_authoritativeOwner,  // [nodeCount]
+    const int*     d_claimRanks,          // [numClaims], sorted by key
+    const int*     d_claimKeyOffsets,     // [numUniqueKeys+1]
+    const KeyType* d_uniqueClaimKeys,     // [numUniqueKeys] sorted
+    int            numUniqueKeys,
+    int            myRank,
+    int            outStride,             // bound on number of claimants per node
+    int*           d_outPeer,             // [nodeCount * outStride]
+    int*           d_outNodeId,           // [nodeCount * outStride]
+    int            nodeCount)
+{
+    int n = blockIdx.x * blockDim.x + threadIdx.x;
+    if (n >= nodeCount) return;
+
+    int outBase = n * outStride;
+    // Default-fill with sentinels.
+    for (int s = 0; s < outStride; ++s)
+    {
+        d_outPeer[outBase + s]   = -1;
+        d_outNodeId[outBase + s] = -1;
+    }
+
+    if (d_authoritativeOwner[n] != myRank) return;  // I don't own → don't send
+
+    // Look up my key in unique-claims.
+    KeyType myKey = d_localToGlobalSfc[n];
+    int lo = 0, hi = numUniqueKeys;
+    while (lo < hi)
+    {
+        int mid = lo + (hi - lo) / 2;
+        if (d_uniqueClaimKeys[mid] < myKey) lo = mid + 1;
+        else                                 hi = mid;
+    }
+    if (lo >= numUniqueKeys || d_uniqueClaimKeys[lo] != myKey) return;
+
+    int beg = d_claimKeyOffsets[lo];
+    int end = d_claimKeyOffsets[lo + 1];
+    int slot = 0;
+    constexpr int TOUCH_FLAG_LOCAL = (int)0x80000000;
+    for (int i = beg; i < end && slot < outStride; ++i)
+    {
+        int rLabel = d_claimRanks[i];
+        int r = rLabel & ~TOUCH_FLAG_LOCAL;  // strip touch flag
+        if (r != myRank)  // skip self
+        {
+            d_outPeer[outBase + slot]   = r;
+            d_outNodeId[outBase + slot] = n;
+            ++slot;
+        }
+    }
+}
+
+// Recv-side per-node kernel: for each node N where I'm not the owner,
+// emit (owner_rank, N) so I receive N from owner.
+__global__ void emitRecvNodesKernel(
+    const int* d_authoritativeOwner,      // [nodeCount]
+    int        myRank,
+    int*       d_outPeer,                  // [nodeCount]
+    int*       d_outNodeId,                // [nodeCount]
+    int        nodeCount)
+{
+    int n = blockIdx.x * blockDim.x + threadIdx.x;
+    if (n >= nodeCount) return;
+
+    int owner = d_authoritativeOwner[n];
+    bool keep = (owner != myRank) && (owner >= 0);
+    d_outPeer[n]   = keep ? owner : -1;
+    d_outNodeId[n] = keep ? n     : -1;
+}
+
+// Per-node kernel: collect the SFC keys of all "boundary candidate" nodes —
+// nodes that appear in any halo element corner (in or out). Boundary
+// candidates are exactly the nodes whose ownership might be contested with
+// peers; non-candidates are interior nodes owned exclusively by us.
+template<typename KeyType, int NPC>
+__global__ void markBoundaryCandidatesKernel(
+    const KeyType* const* d_conn_local_ids,
+    const int*     d_rangeStart,
+    const int*     d_rangeEnd,
+    int            numRanges,
+    uint8_t*       d_isBoundary,               // [nodeCount]
+    int            totalElems)
+{
+    int e = blockIdx.x * blockDim.x + threadIdx.x;
+    if (e >= totalElems) return;
+
+    int elemIdx = -1;
+    int cumulative = 0;
+    for (int r = 0; r < numRanges; ++r)
+    {
+        int len = d_rangeEnd[r] - d_rangeStart[r];
+        if (e < cumulative + len)
+        {
+            elemIdx = d_rangeStart[r] + (e - cumulative);
+            break;
+        }
+        cumulative += len;
+    }
+    if (elemIdx < 0) return;
+
+#pragma unroll
+    for (int c = 0; c < NPC; ++c)
+    {
+        int n = static_cast<int>(d_conn_local_ids[c][elemIdx]);
+        if (n >= 0) d_isBoundary[n] = 1;
+    }
+}
+
+// Per-element kernel: mark every node touched by any LOCAL element [startIdx,endIdx)
+// as claimable by this rank. This is the "I claim because I have a local
+// element with this corner" flag — the right starting point for the
+// tiebreaker, before Step 2's halo-direction bias is applied.
+template<typename KeyType, int NPC>
+__global__ void markLocallyClaimedKernel(
+    const KeyType* const* d_conn_local_ids,
+    size_t startIdx, size_t endIdx,
+    uint8_t* d_locallyClaimed)        // [nodeCount]
+{
+    size_t off = blockIdx.x * blockDim.x + threadIdx.x;
+    size_t numLocal = endIdx - startIdx;
+    if (off >= numLocal) return;
+    size_t e = startIdx + off;
+
+#pragma unroll
+    for (int c = 0; c < NPC; ++c)
+    {
+        int n = static_cast<int>(d_conn_local_ids[c][e]);
+        if (n >= 0) d_locallyClaimed[n] = 1;
+    }
+}
+
+// Reduce per-node SFC key claims using min-rank-wins. For each boundary
+// node N: the authoritative owner is the lowest-ranked rank that claimed
+// the node's SFC key. "Claim" includes my own only if I currently flag
+// the node as owned (d_nodeOwnership ∈ {1,2}); otherwise I'm just an
+// observer and don't compete.
+//
+// Cases per boundary node N:
+//   I claim (own=1/2):
+//     - peer_min exists & < myRank → peer wins
+//     - else                         → I win
+//   I don't claim (own=0):
+//     - peer_min exists              → peer with lowest rank wins
+//     - peer_min absent              → no claimant; mark INT_MAX (will be
+//                                       filtered out by emit kernel — neither
+//                                       "owner==myRank" nor "owner==peer" hits)
+template<typename KeyType>
+__global__ void resolveOwnershipKernel(
+    const KeyType* d_localToGlobalSfc,    // [nodeCount], sorted ascending
+    const KeyType* d_claimKeys,           // [numClaims], sorted by key (unused, kept for API stability)
+    const int*     d_claimRanks,          // [numClaims], same order
+    const int*     d_claimKeyOffsets,     // [numUniqueKeys+1] CSR
+    const KeyType* d_uniqueClaimKeys,     // [numUniqueKeys] unique keys sorted
+    int            numUniqueKeys,
+    const uint8_t* d_isBoundary,          // [nodeCount] (unused, kept for API stability)
+    const uint8_t* d_locallyClaimed,      // [nodeCount], 1 if I have a local element with this corner
+    int*           d_authoritativeOwner,  // [nodeCount] output
+    int            myRank,
+    int            nodeCount)
+{
+    int n = blockIdx.x * blockDim.x + threadIdx.x;
+    if (n >= nodeCount) return;
+    (void)d_claimKeys; (void)d_isBoundary;  // suppress unused warnings
+
+    bool iClaim = (d_locallyClaimed[n] != 0);
+
+    // Look up our key in the unique claim list. Don't short-circuit on
+    // d_isBoundary — corner-shared nodes (the bug we're chasing) are NOT
+    // in cstone halo elements but ARE in peer claim lists; the lookup
+    // must happen for them too.
+    KeyType myKey = d_localToGlobalSfc[n];
+    int lo = 0, hi = numUniqueKeys;
+    while (lo < hi)
+    {
+        int mid = lo + (hi - lo) / 2;
+        if (d_uniqueClaimKeys[mid] < myKey) lo = mid + 1;
+        else                                 hi = mid;
+    }
+    bool found = (lo < numUniqueKeys && d_uniqueClaimKeys[lo] == myKey);
+
+    // Ownership competes only among true claimants (rank label without
+    // touch-flag set). Touchers don't compete for ownership but their
+    // presence in the claim list signals they need the value.
+    constexpr int TOUCH_FLAG_LOCAL = (int)0x80000000;
+    int peerMin = INT_MAX;
+    if (found)
+    {
+        int beg = d_claimKeyOffsets[lo];
+        int end = d_claimKeyOffsets[lo + 1];
+        for (int i = beg; i < end; ++i)
+        {
+            int rLabel = d_claimRanks[i];
+            if ((rLabel & TOUCH_FLAG_LOCAL) != 0) continue;  // skip touchers
+            if (rLabel < peerMin) peerMin = rLabel;
+        }
+    }
+
+    if (iClaim)
+    {
+        d_authoritativeOwner[n] = (peerMin < myRank) ? peerMin : myRank;
+    }
+    else
+    {
+        // I don't claim it locally. If a true claimant peer exists, they own.
+        d_authoritativeOwner[n] = (peerMin != INT_MAX) ? peerMin : -1;
+    }
+}
+
+template<typename ElementTag, typename RealType, typename KeyType, typename AcceleratorTag>
+void NodeHaloTopology<ElementTag, RealType, KeyType, AcceleratorTag>::buildFromCstoneHalos(
+    const ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>& domain)
+{
+    constexpr int NPC = ElementTag::NodesPerElement;
+    int rank     = domain.rank();
+    int numRanks = domain.numRanks();
+
+    if (numRanks == 1)
+    {
+        sendOffsets_.assign(1, 0);
+        recvOffsets_.assign(1, 0);
+        return;
+    }
+
+    // ----- Pull cstone halo bookkeeping (host-side) -----
+    const auto& cstoneDom    = domain.getDomain();
+    const auto& incomingHalo = cstoneDom.incomingHaloIndices();
+    const auto& outgoingHalo = cstoneDom.outgoingHaloIndices();
+
+    // Derive peer list: any rank with non-empty incoming or outgoing halo.
+    std::vector<int> peers;
+    peers.reserve(numRanks);
+    for (int r = 0; r < numRanks; ++r)
+    {
+        if (r == rank) continue;
+        bool inHas  = (size_t(r) < incomingHalo.size()) &&
+                      (incomingHalo[r].count() > 0);
+        bool outHas = (size_t(r) < outgoingHalo.size()) &&
+                      (outgoingHalo[r].totalCount() > 0);
+        if (inHas || outHas) peers.push_back(r);
+    }
+
+    // ----- Build flat range tables for incoming (recv) and outgoing (send) -----
+    // incomingHalo[peer] is one contiguous range; one entry per peer.
+    // outgoingHalo[peer] is a SendManifest with potentially multiple ranges.
+    std::vector<int> h_inStart, h_inEnd, h_inPeer;
+    std::vector<int> h_outStart, h_outEnd, h_outPeer;
+    int totalInElems = 0, totalOutElems = 0;
+    for (int p : peers)
+    {
+        if (size_t(p) < incomingHalo.size() && incomingHalo[p].count() > 0)
+        {
+            h_inStart.push_back(int(incomingHalo[p].start()));
+            h_inEnd.push_back(int(incomingHalo[p].end()));
+            h_inPeer.push_back(p);
+            totalInElems += int(incomingHalo[p].count());
+        }
+        if (size_t(p) < outgoingHalo.size() && outgoingHalo[p].totalCount() > 0)
+        {
+            const auto& mfst = outgoingHalo[p];
+            for (size_t r = 0; r < mfst.nRanges(); ++r)
+            {
+                h_outStart.push_back(int(mfst.rangeStart(r)));
+                h_outEnd.push_back(int(mfst.rangeEnd(r)));
+                h_outPeer.push_back(p);
+                totalOutElems += int(mfst.count(r));
+            }
+        }
+    }
+
+    // ----- Pull connectivity (NPC device pointers) and ownership pointer -----
+    const auto& d_conn_tuple = domain.getElementToNodeConnectivity();
+    const KeyType* h_connPtrs[NPC];
+    extractConnPtrs<KeyType>(d_conn_tuple, h_connPtrs, std::make_index_sequence<NPC>{});
+    // Upload pointer array to device
+    thrust::device_vector<const KeyType*> d_connPtrs(h_connPtrs, h_connPtrs + NPC);
+
+    size_t nodeCount = domain.getNodeCount();
+    const KeyType* d_sfcMap = thrust::raw_pointer_cast(domain.getLocalToGlobalSfcMap().data());
+
+    // ====================================================================
+    // TIEBREAKER STAGE A: identify boundary candidate nodes (corners of any
+    // halo element) so we don't publish claims for interior nodes.
+    // ====================================================================
+    thrust::device_vector<uint8_t> d_isBoundary(nodeCount, 0u);
+    {
+        // Combine in+out element ranges into one pass so a node touched by
+        // either side gets marked.
+        std::vector<int> hAllStart  = h_inStart;  hAllStart.insert (hAllStart.end(),  h_outStart.begin(),  h_outStart.end());
+        std::vector<int> hAllEnd    = h_inEnd;    hAllEnd.insert   (hAllEnd.end(),    h_outEnd.begin(),    h_outEnd.end());
+        int              totalAll   = totalInElems + totalOutElems;
+        if (totalAll > 0)
+        {
+            thrust::device_vector<int> d_aStart(hAllStart.begin(), hAllStart.end());
+            thrust::device_vector<int> d_aEnd  (hAllEnd.begin(),   hAllEnd.end());
+            const int blockSize = 256;
+            int blocks = (totalAll + blockSize - 1) / blockSize;
+            markBoundaryCandidatesKernel<KeyType, NPC><<<blocks, blockSize>>>(
+                thrust::raw_pointer_cast(d_connPtrs.data()),
+                thrust::raw_pointer_cast(d_aStart.data()),
+                thrust::raw_pointer_cast(d_aEnd.data()),
+                int(hAllStart.size()),
+                thrust::raw_pointer_cast(d_isBoundary.data()),
+                totalAll);
+            cudaDeviceSynchronize();
+        }
+    }
+
+    // ====================================================================
+    // TIEBREAKER STAGE B: gather (sfc_key) of locally-CLAIMED boundary
+    // nodes. The "claim" predicate is "I have a local element [startIdx,
+    // endIdx) whose corner is N" — NOT d_nodeOwnership, which has Step 2's
+    // direction-biased yield baked in. Using d_nodeOwnership here is wrong
+    // because Step 2 yields too aggressively: any node touched by a halo
+    // element from a lower-SFC peer is yielded even if the global lowest-
+    // rank claimant is actually us. We re-derive the unbiased claim flag
+    // here directly from local element corners.
+    // ====================================================================
+    thrust::device_vector<uint8_t> d_locallyClaimed(nodeCount, 0u);
+    {
+        size_t startIdx = domain.startIndex();
+        size_t endIdx   = domain.endIndex();
+        size_t numLocal = endIdx - startIdx;
+        if (numLocal > 0)
+        {
+            const int blockSize = 256;
+            int blocks = (numLocal + blockSize - 1) / blockSize;
+            markLocallyClaimedKernel<KeyType, NPC><<<blocks, blockSize>>>(
+                thrust::raw_pointer_cast(d_connPtrs.data()),
+                startIdx, endIdx,
+                thrust::raw_pointer_cast(d_locallyClaimed.data()));
+            cudaDeviceSynchronize();
+        }
+    }
+    const uint8_t* d_claimedPtr  = thrust::raw_pointer_cast(d_locallyClaimed.data());
+
+    // Build my publish list on device: keys of all nodes I "touch" — i.e.
+    // any node N that's a corner of any element I see, whether the element
+    // is local [startIdx, endIdx) OR a halo element on this rank. This is
+    // a TOUCH list, not an OWNERSHIP CLAIM list:
+    //
+    //   - For ownership resolution, what matters is whether I have a local
+    //     element with N (we use d_locallyClaimed for that, downstream).
+    //   - For the "who needs N as a ghost" question (send-side derivation),
+    //     we need to know which peers touch N, even if they don't own it.
+    //     A peer that has N only in a halo element from me still needs me
+    //     to send N's value at every CG iteration.
+    //
+    // Publishing TOUCH (= d_isBoundary, includes halo-element corners on
+    // this rank) lets every rank reconstruct the full set of ranks that
+    // need each node, without a request-back protocol.
+    //
+    // We tag each published rank with a flag bit:
+    //   bit 31 set       → "I touch this key but don't own it (halo only)"
+    //   bit 31 not set   → "I own this key (have a local element with this corner)"
+    //
+    // Ownership resolution looks only at unflagged entries (true owners
+    // compete for min-rank).
+    // Send-side derivation looks at ALL entries (touchers and other owners
+    // both need values).
+    static constexpr int TOUCH_FLAG = (int)0x80000000;  // high bit; -ve when interpreted signed
+
+    thrust::device_vector<KeyType> d_myClaimKeys(nodeCount);
+    thrust::device_vector<int>     d_myClaimRanks(nodeCount);
+    int myClaimCount = 0;
+    {
+        thrust::device_vector<KeyType> d_keysAll(nodeCount);
+        thrust::device_vector<int>     d_ranksAll(nodeCount);
+        thrust::device_vector<uint8_t> d_flagAll(nodeCount);
+        const uint8_t* dIsB = thrust::raw_pointer_cast(d_isBoundary.data());
+        thrust::for_each(
+            thrust::counting_iterator<int>(0),
+            thrust::counting_iterator<int>(int(nodeCount)),
+            [d_keysAll_ptr = thrust::raw_pointer_cast(d_keysAll.data()),
+             d_ranksAll_ptr = thrust::raw_pointer_cast(d_ranksAll.data()),
+             d_flagAll_ptr = thrust::raw_pointer_cast(d_flagAll.data()),
+             dIsB, d_claimedPtr, d_sfcMap, rank]
+            __device__ (int n) {
+                d_keysAll_ptr[n] = d_sfcMap[n];
+                bool touch = (dIsB[n] != 0u);
+                bool claim = (d_claimedPtr[n] != 0u);
+                bool publish = (touch || claim);
+                int  rankLabel = claim ? rank : (rank | TOUCH_FLAG);
+                d_ranksAll_ptr[n] = rankLabel;
+                d_flagAll_ptr[n]  = publish ? 1u : 0u;
+            });
+
+        // Compact keys + ranks together using zip iterators.
+        auto begIn  = thrust::make_zip_iterator(thrust::make_tuple(d_keysAll.begin(),  d_ranksAll.begin()));
+        auto endIn  = thrust::make_zip_iterator(thrust::make_tuple(d_keysAll.end(),    d_ranksAll.end()));
+        auto begOut = thrust::make_zip_iterator(thrust::make_tuple(d_myClaimKeys.begin(), d_myClaimRanks.begin()));
+        auto endOut = thrust::copy_if(begIn, endIn, d_flagAll.begin(), begOut,
+            [] __device__ (uint8_t f) { return f != 0; });
+        myClaimCount = endOut - begOut;
+        d_myClaimKeys.resize(myClaimCount);
+        d_myClaimRanks.resize(myClaimCount);
+
+        // Sort by key (zip).
+        if (myClaimCount > 1)
+        {
+            thrust::sort_by_key(d_myClaimKeys.begin(), d_myClaimKeys.end(),
+                                d_myClaimRanks.begin());
+        }
+    }
+
+    // Exchange claim counts with each peer (point-to-point Isend/Irecv on
+    // host counters; tiny — int per peer).
+    int numPeers = int(peers.size());
+    std::vector<int> peerSendCount(numPeers, myClaimCount);  // we send same list to each peer
+    std::vector<int> peerRecvCount(numPeers, 0);
+    {
+        std::vector<MPI_Request> reqs;
+        reqs.reserve(2 * numPeers);
+        constexpr int tagCount = 0x4d54;  // "MT" — disambiguate
+        for (int i = 0; i < numPeers; ++i)
+        {
+            MPI_Request r;
+            MPI_Irecv(&peerRecvCount[i], 1, MPI_INT, peers[i], tagCount, MPI_COMM_WORLD, &r);
+            reqs.push_back(r);
+        }
+        for (int i = 0; i < numPeers; ++i)
+        {
+            MPI_Request r;
+            MPI_Isend(&peerSendCount[i], 1, MPI_INT, peers[i], tagCount, MPI_COMM_WORLD, &r);
+            reqs.push_back(r);
+        }
+        MPI_Waitall(int(reqs.size()), reqs.data(), MPI_STATUSES_IGNORE);
+    }
+
+    // Exchange the actual claim keys AND flagged rank labels via CUDA-aware MPI.
+    int totalRecvKeys = 0;
+    std::vector<int> peerRecvDispl(numPeers + 1, 0);
+    for (int i = 0; i < numPeers; ++i)
+    {
+        peerRecvDispl[i + 1] = peerRecvDispl[i] + peerRecvCount[i];
+    }
+    totalRecvKeys = peerRecvDispl.back();
+
+    thrust::device_vector<KeyType> d_recvClaimKeys(totalRecvKeys);
+    thrust::device_vector<int>     d_recvClaimRanks(totalRecvKeys);
+    auto mpiKeyType = (sizeof(KeyType) == 8) ? MPI_UINT64_T : MPI_UNSIGNED;
+    {
+        std::vector<MPI_Request> reqs;
+        reqs.reserve(4 * numPeers);
+        constexpr int tagKeys  = 0x4d55;  // "MU"
+        constexpr int tagRanks = 0x4d56;  // "MV" — flagged rank labels
+        for (int i = 0; i < numPeers; ++i)
+        {
+            int rcnt = peerRecvCount[i];
+            if (rcnt == 0) continue;
+            MPI_Request rk, rr;
+            MPI_Irecv(thrust::raw_pointer_cast(d_recvClaimKeys.data()) + peerRecvDispl[i],
+                      rcnt, mpiKeyType, peers[i], tagKeys, MPI_COMM_WORLD, &rk);
+            MPI_Irecv(thrust::raw_pointer_cast(d_recvClaimRanks.data()) + peerRecvDispl[i],
+                      rcnt, MPI_INT, peers[i], tagRanks, MPI_COMM_WORLD, &rr);
+            reqs.push_back(rk);
+            reqs.push_back(rr);
+        }
+        for (int i = 0; i < numPeers; ++i)
+        {
+            int scnt = myClaimCount;
+            if (scnt == 0) continue;
+            MPI_Request sk, sr;
+            MPI_Isend(thrust::raw_pointer_cast(d_myClaimKeys.data()),
+                      scnt, mpiKeyType, peers[i], tagKeys, MPI_COMM_WORLD, &sk);
+            MPI_Isend(thrust::raw_pointer_cast(d_myClaimRanks.data()),
+                      scnt, MPI_INT, peers[i], tagRanks, MPI_COMM_WORLD, &sr);
+            reqs.push_back(sk);
+            reqs.push_back(sr);
+        }
+        MPI_Waitall(int(reqs.size()), reqs.data(), MPI_STATUSES_IGNORE);
+    }
+
+    // Sort received claims by (key, rank) so per-key min-rank reduces correctly.
+    if (totalRecvKeys > 0)
+    {
+        thrust::sort_by_key(d_recvClaimKeys.begin(), d_recvClaimKeys.end(),
+                            d_recvClaimRanks.begin());
+    }
+
+    // Build CSR of (unique_key → claim range) so resolveOwnershipKernel can
+    // look up by binary search.
+    thrust::device_vector<KeyType> d_uniqueKeys;
+    thrust::device_vector<int>     d_uniqueOffsets;
+    int numUnique = 0;
+    if (totalRecvKeys > 0)
+    {
+        d_uniqueKeys.resize(totalRecvKeys);
+        thrust::copy(d_recvClaimKeys.begin(), d_recvClaimKeys.end(), d_uniqueKeys.begin());
+        auto uend = thrust::unique(d_uniqueKeys.begin(), d_uniqueKeys.end());
+        numUnique = int(uend - d_uniqueKeys.begin());
+        d_uniqueKeys.resize(numUnique);
+        // For each unique key, lower_bound gives its first index in d_recvClaimKeys.
+        // We need numUnique+1 offsets; last is totalRecvKeys.
+        d_uniqueOffsets.resize(numUnique + 1);
+        thrust::lower_bound(d_recvClaimKeys.begin(), d_recvClaimKeys.end(),
+                            d_uniqueKeys.begin(), d_uniqueKeys.end(),
+                            d_uniqueOffsets.begin());
+        // Set the sentinel offset[numUnique] = totalRecvKeys.
+        int lastOff = totalRecvKeys;
+        cudaMemcpy(thrust::raw_pointer_cast(d_uniqueOffsets.data()) + numUnique,
+                   &lastOff, sizeof(int), cudaMemcpyHostToDevice);
+    }
+
+    // ====================================================================
+    // TIEBREAKER STAGE C: per-node compute authoritative owner.
+    //   non-boundary owned → myRank
+    //   boundary node not in unique-key claims → myRank (no peer claimed)
+    //   boundary node in claims → min(myRank, all claimant ranks) if I own,
+    //                              else min(claimant ranks)
+    // ====================================================================
+    thrust::device_vector<int> d_authoritativeOwner(nodeCount, -1);
+    {
+        const int blockSize = 256;
+        int blocks = (int(nodeCount) + blockSize - 1) / blockSize;
+        resolveOwnershipKernel<KeyType><<<blocks, blockSize>>>(
+            d_sfcMap,
+            thrust::raw_pointer_cast(d_recvClaimKeys.data()),
+            thrust::raw_pointer_cast(d_recvClaimRanks.data()),
+            thrust::raw_pointer_cast(d_uniqueOffsets.data()),
+            thrust::raw_pointer_cast(d_uniqueKeys.data()),
+            numUnique,
+            thrust::raw_pointer_cast(d_isBoundary.data()),
+            d_claimedPtr,
+            thrust::raw_pointer_cast(d_authoritativeOwner.data()),
+            rank,
+            int(nodeCount));
+        cudaDeviceSynchronize();
+    }
+    const int* d_authPtr = thrust::raw_pointer_cast(d_authoritativeOwner.data());
+
+    // Mutate d_nodeOwnership_ to match the post-tiebreaker state, just as
+    // host path does at L1212-1213. Required for downstream FEM code (DOF
+    // handler, RHS assembly) to see the correct "owned vs ghost" flag.
+    // Without this, ranks that lost the tiebreaker still report ownership=1
+    // for nodes they no longer own, causing duplicate RHS contributions
+    // and the matrix/rhs norm drift between host and v2 paths.
+    {
+        auto& dOwnMutable = const_cast<typename HaloData<ElementTag, RealType, KeyType, AcceleratorTag>::
+                                       template DeviceVector<uint8_t>&>(domain.getNodeOwnershipMap());
+        thrust::for_each(
+            thrust::counting_iterator<int>(0),
+            thrust::counting_iterator<int>(int(nodeCount)),
+            [d_own_ptr = thrust::raw_pointer_cast(dOwnMutable.data()), d_authPtr, rank]
+            __device__ (int n) {
+                int owner = d_authPtr[n];
+                // -1 = no owner found (interior unowned, shouldn't happen in
+                // practice). Otherwise set to 1 iff this rank is the owner.
+                d_own_ptr[n] = (owner == rank) ? uint8_t(1) : uint8_t(0);
+            });
+        cudaDeviceSynchronize();
+    }
+
+    // ----- Helper: emit per-peer (peer, node) tuples then compact -----
+    // For send: emit one tuple per (owned node, peer claimant) using
+    // emitSendNodesKernel. Output stride bounds claimants/node — use the
+    // largest unique-claim range as upper bound.
+    // For recv: emit at most one tuple per node (owner != me).
+    auto compactSortBin = [&](
+        thrust::device_vector<int>& d_outPeer,
+        thrust::device_vector<int>& d_outNode,
+        std::vector<std::vector<int>>& outIdsPerPeer)
+    {
+        outIdsPerPeer.assign(peers.size(), {});
+
+        // Stream-compact: drop entries with peer < 0
+        thrust::device_vector<int> d_keepPeer(d_outPeer.size());
+        thrust::device_vector<int> d_keepNode(d_outNode.size());
+        auto end = thrust::copy_if(
+            thrust::make_zip_iterator(thrust::make_tuple(d_outPeer.begin(), d_outNode.begin())),
+            thrust::make_zip_iterator(thrust::make_tuple(d_outPeer.end(),   d_outNode.end())),
+            thrust::make_zip_iterator(thrust::make_tuple(d_keepPeer.begin(), d_keepNode.begin())),
+            [] __device__ (const thrust::tuple<int,int>& t) {
+                return thrust::get<0>(t) >= 0;
+            });
+        size_t kept = end - thrust::make_zip_iterator(thrust::make_tuple(d_keepPeer.begin(), d_keepNode.begin()));
+        d_keepPeer.resize(kept);
+        d_keepNode.resize(kept);
+
+        // Sort by (peer, node) so per-peer dedup with one unique pass works.
+        thrust::sort(
+            thrust::make_zip_iterator(thrust::make_tuple(d_keepPeer.begin(), d_keepNode.begin())),
+            thrust::make_zip_iterator(thrust::make_tuple(d_keepPeer.end(),   d_keepNode.end())));
+        auto uend = thrust::unique(
+            thrust::make_zip_iterator(thrust::make_tuple(d_keepPeer.begin(), d_keepNode.begin())),
+            thrust::make_zip_iterator(thrust::make_tuple(d_keepPeer.end(),   d_keepNode.end())));
+        size_t uniq = uend - thrust::make_zip_iterator(thrust::make_tuple(d_keepPeer.begin(), d_keepNode.begin()));
+
+        std::vector<int> hPeerOut(uniq), hNodeOut(uniq);
+        if (uniq > 0)
+        {
+            cudaMemcpy(hPeerOut.data(), thrust::raw_pointer_cast(d_keepPeer.data()),
+                       uniq * sizeof(int), cudaMemcpyDeviceToHost);
+            cudaMemcpy(hNodeOut.data(), thrust::raw_pointer_cast(d_keepNode.data()),
+                       uniq * sizeof(int), cudaMemcpyDeviceToHost);
+        }
+
+        std::unordered_map<int, size_t> peerIdx;
+        for (size_t i = 0; i < peers.size(); ++i) peerIdx[peers[i]] = i;
+        for (size_t i = 0; i < uniq; ++i)
+        {
+            auto it = peerIdx.find(hPeerOut[i]);
+            if (it != peerIdx.end()) outIdsPerPeer[it->second].push_back(hNodeOut[i]);
+        }
+    };
+
+    // ===== SEND side =====
+    // Emit owned nodes to every claimant peer (excluding self). Bound output
+    // stride at numPeers (max possible claimants per node). At cube
+    // partitions worst case is 7 (8-way corner with 8 ranks: 7 peer claimants).
+    std::vector<std::vector<int>> sendIdsPerPeer;
+    {
+        int outStride = std::max(1, std::min(numPeers, 32));
+        thrust::device_vector<int> d_outPeer(size_t(nodeCount) * outStride, -1);
+        thrust::device_vector<int> d_outNode(size_t(nodeCount) * outStride, -1);
+        const int blockSize = 256;
+        int blocks = (int(nodeCount) + blockSize - 1) / blockSize;
+        emitSendNodesKernel<KeyType><<<blocks, blockSize>>>(
+            d_sfcMap,
+            d_authPtr,
+            thrust::raw_pointer_cast(d_recvClaimRanks.data()),
+            thrust::raw_pointer_cast(d_uniqueOffsets.data()),
+            thrust::raw_pointer_cast(d_uniqueKeys.data()),
+            numUnique,
+            rank,
+            outStride,
+            thrust::raw_pointer_cast(d_outPeer.data()),
+            thrust::raw_pointer_cast(d_outNode.data()),
+            int(nodeCount));
+        cudaDeviceSynchronize();
+        cudaError_t err = cudaGetLastError();
+        if (err != cudaSuccess)
+        {
+            std::cerr << "[Rank " << rank << "] emitSendNodesKernel failed: "
+                      << cudaGetErrorString(err) << std::endl;
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+        compactSortBin(d_outPeer, d_outNode, sendIdsPerPeer);
+    }
+
+    // ===== RECV side =====
+    std::vector<std::vector<int>> recvIdsPerPeer;
+    {
+        thrust::device_vector<int> d_outPeer(size_t(nodeCount), -1);
+        thrust::device_vector<int> d_outNode(size_t(nodeCount), -1);
+        const int blockSize = 256;
+        int blocks = (int(nodeCount) + blockSize - 1) / blockSize;
+        emitRecvNodesKernel<<<blocks, blockSize>>>(
+            d_authPtr, rank,
+            thrust::raw_pointer_cast(d_outPeer.data()),
+            thrust::raw_pointer_cast(d_outNode.data()),
+            int(nodeCount));
+        cudaDeviceSynchronize();
+        cudaError_t err = cudaGetLastError();
+        if (err != cudaSuccess)
+        {
+            std::cerr << "[Rank " << rank << "] emitRecvNodesKernel failed: "
+                      << cudaGetErrorString(err) << std::endl;
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+        compactSortBin(d_outPeer, d_outNode, recvIdsPerPeer);
+    }
+
+    // ----- Compact into peer-list / CSR structure -----
+    peers_.clear();
+    sendOffsets_.assign(1, 0);
+    recvOffsets_.assign(1, 0);
+    std::vector<int> sendNodesHost, recvNodesHost;
+    for (size_t i = 0; i < peers.size(); ++i)
+    {
+        int sCnt = int(sendIdsPerPeer[i].size());
+        int rCnt = int(recvIdsPerPeer[i].size());
+        if (sCnt == 0 && rCnt == 0) continue;
+        peers_.push_back(peers[i]);
+        for (int v : sendIdsPerPeer[i]) sendNodesHost.push_back(v);
+        for (int v : recvIdsPerPeer[i]) recvNodesHost.push_back(v);
+        sendOffsets_.push_back(int(sendNodesHost.size()));
+        recvOffsets_.push_back(int(recvNodesHost.size()));
+    }
+
+    // Upload node-id arrays to device
+    sendNodeIds_.resize(sendNodesHost.size());
+    recvNodeIds_.resize(recvNodesHost.size());
+    if (!sendNodesHost.empty())
+        cudaMemcpy(thrust::raw_pointer_cast(sendNodeIds_.data()), sendNodesHost.data(),
+                   sendNodesHost.size() * sizeof(int), cudaMemcpyHostToDevice);
+    if (!recvNodesHost.empty())
+        cudaMemcpy(thrust::raw_pointer_cast(recvNodeIds_.data()), recvNodesHost.data(),
+                   recvNodesHost.size() * sizeof(int), cudaMemcpyHostToDevice);
+
+    std::cout << "Rank " << rank << ": NodeHaloTopo[v2] " << peers_.size() << " peers, "
+              << sendNodesHost.size() << " send nodes, "
+              << recvNodesHost.size() << " recv nodes" << std::endl;
+    std::cout.flush();
+}
+
+// ============================================================================
+// validateAgainstHost: build both paths into separate topos, diff per-peer
+// sorted node-id lists. Returns true on bit-exact match.
+//
+// Implementation note: we cannot reuse the constructor because it would
+// recurse via the env flag. Build host path manually, then v2 path
+// manually, then compare on host.
+//
+// Subtle: the host path mutates d_nodeOwnership_ during its tiebreaker
+// yield step (host-path L1102-1129). We snapshot ownership before the
+// host build and restore before the v2 build. This means v2 runs
+// against the *original* (pre-yield) ownership. If host's tiebreaker
+// changed any ownership flags, v2's send/recv lists will differ — that's
+// the expected signal that v2 needs its own tiebreaker pass before
+// becoming default.
+// ============================================================================
+template<typename ElementTag, typename RealType, typename KeyType, typename AcceleratorTag>
+bool NodeHaloTopology<ElementTag, RealType, KeyType, AcceleratorTag>::validateAgainstHost(
+    const ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>& domain)
+{
+    int rank     = domain.rank();
+    int numRanks = domain.numRanks();
+    if (numRanks == 1) return true;
+
+    // Snapshot d_nodeOwnership_ before running host path, since the host
+    // path mutates it (yields duplicate ownership to lowest rank). v2 must
+    // see the same starting ownership state to make the comparison fair.
+    auto& dOwn = const_cast<typename HaloData<ElementTag, RealType, KeyType, AcceleratorTag>::
+                            template DeviceVector<uint8_t>&>(domain.getNodeOwnershipMap());
+    std::vector<uint8_t> ownSnapshot(dOwn.size());
+    if (!ownSnapshot.empty())
+        cudaMemcpy(ownSnapshot.data(), thrust::raw_pointer_cast(dOwn.data()),
+                   ownSnapshot.size() * sizeof(uint8_t), cudaMemcpyDeviceToHost);
+
+    NodeHaloTopology<ElementTag, RealType, KeyType, AcceleratorTag> hostTopo{};
+    NodeHaloTopology<ElementTag, RealType, KeyType, AcceleratorTag> v2Topo{};
+    buildNodeHaloTopologyHostPath(hostTopo, domain);
+
+    // Restore ownership before v2 build so it sees pre-yield state.
+    if (!ownSnapshot.empty())
+        cudaMemcpy(thrust::raw_pointer_cast(dOwn.data()), ownSnapshot.data(),
+                   ownSnapshot.size() * sizeof(uint8_t), cudaMemcpyHostToDevice);
+
+    v2Topo.buildFromCstoneHalos(domain);
+
+    auto pullToHost = [](const auto& d_vec) {
+        std::vector<int> h(d_vec.size());
+        if (!h.empty())
+            cudaMemcpy(h.data(), thrust::raw_pointer_cast(d_vec.data()),
+                       h.size() * sizeof(int), cudaMemcpyDeviceToHost);
+        return h;
+    };
+
+    auto buildPerPeerSorted = [&](const auto& topo) {
+        std::vector<std::vector<int>> sendByPeer, recvByPeer;
+        std::vector<int> hSend = pullToHost(topo.sendNodeIds_);
+        std::vector<int> hRecv = pullToHost(topo.recvNodeIds_);
+        sendByPeer.resize(topo.peers_.size());
+        recvByPeer.resize(topo.peers_.size());
+        for (size_t i = 0; i < topo.peers_.size(); ++i)
+        {
+            int sb = topo.sendOffsets_[i],  se = topo.sendOffsets_[i+1];
+            int rb = topo.recvOffsets_[i],  re = topo.recvOffsets_[i+1];
+            sendByPeer[i].assign(hSend.begin() + sb, hSend.begin() + se);
+            recvByPeer[i].assign(hRecv.begin() + rb, hRecv.begin() + re);
+            std::sort(sendByPeer[i].begin(), sendByPeer[i].end());
+            std::sort(recvByPeer[i].begin(), recvByPeer[i].end());
+        }
+        return std::make_tuple(std::move(sendByPeer), std::move(recvByPeer));
+    };
+
+    auto [hSend, hRecv] = buildPerPeerSorted(hostTopo);
+    auto [vSend, vRecv] = buildPerPeerSorted(v2Topo);
+
+    // Build peer-rank -> sorted lists maps to compare order-independently.
+    auto byPeerMap = [](const auto& topo, const auto& byPeerVec) {
+        std::map<int, std::vector<int>> m;
+        for (size_t i = 0; i < topo.peers_.size(); ++i) m[topo.peers_[i]] = byPeerVec[i];
+        return m;
+    };
+    auto hSendMap = byPeerMap(hostTopo, hSend);
+    auto hRecvMap = byPeerMap(hostTopo, hRecv);
+    auto vSendMap = byPeerMap(v2Topo,   vSend);
+    auto vRecvMap = byPeerMap(v2Topo,   vRecv);
+
+    bool ok = true;
+    auto diffMap = [&](const char* label, const auto& a, const auto& b) {
+        if (a.size() != b.size())
+        {
+            std::cerr << "[Rank " << rank << "] " << label
+                      << " peer-count mismatch: host=" << a.size()
+                      << " v2=" << b.size() << std::endl;
+            ok = false;
+        }
+        for (const auto& [peer, hList] : a)
+        {
+            auto it = b.find(peer);
+            if (it == b.end())
+            {
+                std::cerr << "[Rank " << rank << "] " << label
+                          << " peer " << peer << " present in host but not v2" << std::endl;
+                ok = false;
+                continue;
+            }
+            const auto& vList = it->second;
+            if (hList.size() != vList.size())
+            {
+                std::cerr << "[Rank " << rank << "] " << label
+                          << " peer " << peer << " size: host=" << hList.size()
+                          << " v2=" << vList.size() << std::endl;
+                ok = false;
+                continue;
+            }
+            for (size_t i = 0; i < hList.size(); ++i)
+            {
+                if (hList[i] != vList[i])
+                {
+                    std::cerr << "[Rank " << rank << "] " << label
+                              << " peer " << peer << " idx " << i
+                              << " host=" << hList[i] << " v2=" << vList[i] << std::endl;
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        // Check for v2-only peers
+        for (const auto& [peer, vList] : b)
+        {
+            if (a.find(peer) == a.end())
+            {
+                std::cerr << "[Rank " << rank << "] " << label
+                          << " peer " << peer << " present in v2 but not host" << std::endl;
+                ok = false;
+            }
+        }
+    };
+    diffMap("send", hSendMap, vSendMap);
+    diffMap("recv", hRecvMap, vRecvMap);
+    if (ok)
+        std::cout << "[Rank " << rank << "] NodeHaloTopo v2 == host (Gate 1 pass)" << std::endl;
+    std::cout.flush();
+    std::cerr.flush();
+    return ok;
 }
 
 // ===== For unsigned KeyType =====

--- a/backend/distributed/unstructured/domain.hpp
+++ b/backend/distributed/unstructured/domain.hpp
@@ -33,6 +33,7 @@ using std::get;
 #include <thrust/iterator/constant_iterator.h>
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <limits>
 #include <mpi.h>
 #include <filesystem>
@@ -432,11 +433,28 @@ struct NodeHaloTopology
     std::vector<int>      recvOffsets_;
     DeviceVector<int>     sendNodeIds_;        // size = sendOffsets_.back()
     DeviceVector<int>     recvNodeIds_;        // size = recvOffsets_.back()
-    // Persistent send/recv staging buffers (RealType only; resized lazily)
+    // Persistent send/recv staging buffers. Pre-sized in NodeHaloTopology ctor;
+    // never resized on hot path. mutable so exchangeNodeHalo() can be const,
+    // matching cstone Halos::exchangeHalos pattern; safe because pre-sizing
+    // removes the race that bit v1.
     mutable DeviceVector<RealType> sendBuf_;
     mutable DeviceVector<RealType> recvBuf_;
+    // Epoch counter for unique MPI tags across multiple exchangeNodeHalo() calls
+    // between MPI collectives (matches cstone Halos::haloEpoch_ convention).
+    mutable int epoch_{0};
 
+    NodeHaloTopology() = default;
     NodeHaloTopology(const ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>& domain);
+
+    // Gate 1 helper: build via the device-resident path consuming cstone's
+    // incomingHaloIndices/outgoingHaloIndices instead of host MPI_Allgatherv.
+    // Selected at runtime via env MARS_NODEHALO_V2; both paths populate the
+    // same fields so callers don't change.
+    void buildFromCstoneHalos(const ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>& domain);
+
+    // Gate 1 validation: build with both paths and diff per-peer node-id lists.
+    // Prints first mismatch to stderr; returns true if identical (after sort).
+    static bool validateAgainstHost(const ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>& domain);
 };
 
 // ============================================================================
@@ -510,10 +528,13 @@ public:
     using HostBoundaryTuple     = std::tuple<HostVector<uint8_t>>; // (isBoundaryNode)
 
     // Constructor from file
-    ElementDomain(const std::string& meshFile, int rank, int numRanks, bool storeOriginalCoords = false, int bucketSize = 64);
+    ElementDomain(const std::string& meshFile, int rank, int numRanks, bool storeOriginalCoords = false,
+                  int bucketSize = 64, unsigned bucketSizeFocus = 8);
 
     // Constructor from mesh data (for MFEM or other formats) - automatically computes bounding box
-    ElementDomain(const HostCoordsTuple& h_coords, const HostConnectivityTuple& h_conn, int rank, int numRanks, int bucketSize = 64);
+    ElementDomain(const HostCoordsTuple& h_coords, const HostConnectivityTuple& h_conn,
+                  int rank, int numRanks, int bucketSize = 64, bool storeOriginalCoords = false,
+                  unsigned bucketSizeFocus = 8);
 
     // Constructor from mesh data with boundary info - automatically computes bounding box
     ElementDomain(const HostCoordsTuple& h_coords,
@@ -521,7 +542,8 @@ public:
                   const HostBoundaryTuple& h_boundary,
                   int rank,
                   int numRanks,
-                  int bucketSize = 64);
+                  int bucketSize = 64,
+                  unsigned bucketSizeFocus = 8);
 
     // Constructor from mesh data with explicit bounding box (for backward compatibility)
     ElementDomain(const HostCoordsTuple& h_coords,
@@ -529,7 +551,8 @@ public:
                   const cstone::Box<RealType>& box,
                   int rank,
                   int numRanks,
-                  int bucketSize = 64);
+                  int bucketSize = 64,
+                  unsigned bucketSizeFocus = 8);
 
     // Device-data constructor (no host round-trip).
     // The caller hands in already-on-device coords + connectivity. Bbox is
@@ -540,7 +563,18 @@ public:
                   DeviceConnectivityTuple&& d_conn,
                   int rank,
                   int numRanks,
-                  int bucketSize = 64);
+                  int bucketSize = 64,
+                  unsigned bucketSizeFocus = 8);
+
+    // Per-phase timings populated by the ctor (in ms, rank-local).
+    // All cudaDeviceSynchronize-fenced so they reflect actual elapsed time.
+    // Sub-phases sum to ~ctor time minus any unaccounted overhead (logging, etc).
+    float readMeshTimeMs   = 0.0f;
+    float bboxTimeMs       = 0.0f;
+    float h2dTimeMs        = 0.0f;
+    float charSizeTimeMs   = 0.0f;
+    float syncTimeMs       = 0.0f;
+    float nodeHaloTimeMs   = 0.0f;
 
     // GPU-accelerated calculation of characteristic sizes
     void calculateCharacteristicSizes(const DeviceConnectivityTuple& d_conn_, const DeviceCoordsTuple& d_coords_);
@@ -772,13 +806,14 @@ public:
         ensureNodeHaloTopo();
         const auto& topo = *nodeHaloTopo_;
 
-        // Resize staging buffers (lazy)
+        // Buffers pre-sized in NodeHaloTopology ctor; no hot-path resize.
         size_t sendTotal = topo.sendOffsets_.empty() ? 0 : size_t(topo.sendOffsets_.back());
         size_t recvTotal = topo.recvOffsets_.empty() ? 0 : size_t(topo.recvOffsets_.back());
-        if (topo.sendBuf_.size() != sendTotal) topo.sendBuf_.resize(sendTotal);
-        if (topo.recvBuf_.size() != recvTotal) topo.recvBuf_.resize(recvTotal);
 
-        // Pack: gather nodeArray[nodeToDof[sendNodeIds]] into sendBuf
+        // Pack: index-driven gather. No sentinel: the recv list on the peer
+        // side determines which slots get overwritten on unpack, so any value
+        // we pack here that doesn't correspond to a valid DOF will simply
+        // never be read by anyone.
         T*           arr  = thrust::raw_pointer_cast(nodeArray.data());
         const int*   snds = thrust::raw_pointer_cast(topo.sendNodeIds_.data());
         T*           sbuf = thrust::raw_pointer_cast(topo.sendBuf_.data());
@@ -790,14 +825,22 @@ public:
                               [arr, snds, sbuf, nodeToDof] __device__ (size_t i) {
                                   int n = snds[i];
                                   int idx = (nodeToDof != nullptr) ? nodeToDof[n] : n;
-                                  sbuf[i] = (idx >= 0) ? arr[idx] : T(0);
+                                  // idx<0 means node is not a DOF on this rank.
+                                  // Pack arr[0] as a placeholder; the corresponding
+                                  // recv-side slot (if any) will be filtered the
+                                  // same way on unpack so the value is discarded.
+                                  sbuf[i] = (idx >= 0) ? arr[idx] : arr[0];
                               });
             cudaDeviceSynchronize();
         }
 
         // Post recvs and sends. CUDA-aware MPI: pass device pointers directly.
+        // Tag = nodeHaloTagBase + epoch_, matching cstone's haloEpoch_ pattern
+        // so multiple exchanges between MPI collectives don't tag-collide.
         T*           rbuf = thrust::raw_pointer_cast(topo.recvBuf_.data());
         auto mpiType = std::is_same_v<T, double> ? MPI_DOUBLE : MPI_FLOAT;
+        constexpr int nodeHaloTagBase = 0x4d52;  // "MR" — disambiguate from cstone tags
+        const int tag = nodeHaloTagBase + topo.epoch_;
         std::vector<MPI_Request> reqs;
         reqs.reserve(2 * topo.peers_.size());
 
@@ -809,7 +852,7 @@ public:
             {
                 MPI_Request r;
                 MPI_Irecv(rbuf + topo.recvOffsets_[p], rcnt, mpiType, peer,
-                          /*tag=*/777, MPI_COMM_WORLD, &r);
+                          tag, MPI_COMM_WORLD, &r);
                 reqs.push_back(r);
             }
         }
@@ -821,13 +864,16 @@ public:
             {
                 MPI_Request r;
                 MPI_Isend(sbuf + topo.sendOffsets_[p], scnt, mpiType, peer,
-                          /*tag=*/777, MPI_COMM_WORLD, &r);
+                          tag, MPI_COMM_WORLD, &r);
                 reqs.push_back(r);
             }
         }
         if (!reqs.empty()) MPI_Waitall(int(reqs.size()), reqs.data(), MPI_STATUSES_IGNORE);
+        ++topo.epoch_;
 
-        // Scatter recvBuf into nodeArray[nodeToDof[recvNodeIds]]
+        // Scatter recvBuf into nodeArray[nodeToDof[recvNodeIds]].
+        // idx<0 case skipped: the slot was packed by the peer with a placeholder
+        // and we don't have a real DOF to write it to.
         const int* rnds = thrust::raw_pointer_cast(topo.recvNodeIds_.data());
         if (recvTotal > 0)
         {
@@ -953,6 +999,11 @@ private:
     friend struct NodeHaloTopology<ElementTag, RealType, KeyType, AcceleratorTag>;
     friend struct CoordinateCache<ElementTag, RealType, KeyType, AcceleratorTag>;
     friend struct OriginalCoordinates<ElementTag, RealType, KeyType, AcceleratorTag>;
+
+    // Free-function builder for NodeHaloTopology's host path needs access to halo_ and friends.
+    template<typename ET, typename RT, typename KT, typename AT>
+    friend void buildNodeHaloTopologyHostPath(NodeHaloTopology<ET, RT, KT, AT>& topo,
+                                              const ElementDomain<ET, RT, KT, AT>& domain);
 
     mutable std::unique_ptr<AdjacencyData<ElementTag, RealType, KeyType, AcceleratorTag>> adjacency_;
     mutable std::unique_ptr<HaloData<ElementTag, RealType, KeyType, AcceleratorTag>> halo_;
@@ -1317,23 +1368,37 @@ void testSfcPrecision(const cstone::Box<RealType>& box, int rank = 0)
 #endif // !NDEBUG
 }
 
+// Log free/total GPU memory at every rank around the cstone sync. Lets us
+// pinpoint which rank hit the OOM ceiling and how close the survivors got.
+inline void logGpuMemAroundSync(int rank, const char* tag)
+{
+    size_t freeBytes = 0, totalBytes = 0;
+    cudaError_t err = cudaMemGetInfo(&freeBytes, &totalBytes);
+    if (err != cudaSuccess) return;
+    double freeGiB  = static_cast<double>(freeBytes)  / (1024.0 * 1024.0 * 1024.0);
+    double totalGiB = static_cast<double>(totalBytes) / (1024.0 * 1024.0 * 1024.0);
+    std::cout << "[GPU mem r" << rank << " " << tag << "] free=" << freeGiB
+              << " GiB / " << totalGiB << " GiB" << std::endl;
+}
+
 // Element domain constructor
 template<typename ElementTag, typename RealType, typename KeyType, typename AcceleratorTag>
 ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(const std::string& meshFile,
                                                                             int rank,
                                                                             int numRanks,
                                                                             bool storeOriginalCoords,
-                                                                            int bucketSize)
+                                                                            int bucketSize,
+                                                                            unsigned bucketSizeFocus)
     : rank_(rank)
     , numRanks_(numRanks)
     , box_(0, 1)
     , storeOriginalCoords_(storeOriginalCoords)
 {
     if (rank == 0) {
-        std::cout << "ElementDomain: Using bucketSize=" << bucketSize 
-                  << " (passed as parameter)" << std::endl;
+        std::cout << "ElementDomain: Using bucketSize=" << bucketSize
+                  << ", bucketSizeFocus=" << bucketSizeFocus << " (passed as parameters)" << std::endl;
     }
-    
+
     // Host data in SoA format
     HostCoordsTuple h_coords;     // (x, y, z)
     HostConnectivityTuple h_conn; // (i0, i1, i2, ...) depends on element type
@@ -1342,16 +1407,20 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
     DeviceConnectivityTuple d_conn_;
     DeviceCoordsTuple d_coords_;
 
-    // Read the mesh in SoA format
-    readMeshDataSoA(meshFile, h_coords, h_conn);
+    using clk = std::chrono::high_resolution_clock;
+    auto t0 = clk::now();
 
-    // Initialize cornerstone domain with custom bucket size
-    // int bucketSize           = 64;  // Now passed as parameter
-    unsigned bucketSizeFocus = 8;
-    RealType theta           = 0.5;
+    // Read the mesh in SoA format (host-side: disk + GPU dedup + remap)
+    readMeshDataSoA(meshFile, h_coords, h_conn);
+    auto t1 = clk::now();
+    readMeshTimeMs = std::chrono::duration<float, std::milli>(t1 - t0).count();
+
+    RealType theta = 0.5;
 
     box_ = computeGlobalBoundingBoxFromCoords<RealType>(std::get<0>(h_coords), std::get<1>(h_coords),
                                                         std::get<2>(h_coords));
+    auto t2 = clk::now();
+    bboxTimeMs = std::chrono::duration<float, std::milli>(t2 - t1).count();
 
     std::cout << "Rank " << rank_ << ": Created bounding box: [" << box_.xmin() << "," << box_.xmax() << "] ["
               << box_.ymin() << "," << box_.ymax() << "] [" << box_.zmin() << "," << box_.zmax() << "]" << std::endl;
@@ -1362,16 +1431,27 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
     domain_ = std::make_unique<DomainType>(rank, numRanks, bucketSize, bucketSizeFocus, theta, box_);
 
     // Transfer data to GPU before sync
+    auto t3 = clk::now();
     transferDataToGPU(h_coords, h_conn, d_coords_, d_conn_);
+    cudaDeviceSynchronize();
+    auto t4 = clk::now();
+    h2dTimeMs = std::chrono::duration<float, std::milli>(t4 - t3).count();
 
     // Calculate characteristic sizes
     calculateCharacteristicSizes(d_conn_, d_coords_);
+    cudaDeviceSynchronize();
+    auto t5 = clk::now();
+    charSizeTimeMs = std::chrono::duration<float, std::milli>(t5 - t4).count();
 
     std::cout << "Rank " << rank_ << ": Before sync - bucketSize=" << bucketSize
               << ", bucketSizeFocus=" << bucketSizeFocus << ", theta=" << theta << std::endl;
 
-    // Perform sync
+    logGpuMemAroundSync(rank_, "pre-sync");
     sync(d_conn_, d_coords_);
+    cudaDeviceSynchronize();
+    logGpuMemAroundSync(rank_, "post-sync");
+    auto t6 = clk::now();
+    syncTimeMs = std::chrono::duration<float, std::milli>(t6 - t5).count();
 
     std::cout << "Rank " << rank_ << " initialized " << ElementTag::Name << " domain with " << nodeCount_
               << " nodes and " << elementCount_ << " elements." << std::endl;
@@ -1383,10 +1463,13 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
                                                                             const HostConnectivityTuple& h_conn,
                                                                             int rank,
                                                                             int numRanks,
-                                                                            int bucketSize)
+                                                                            int bucketSize,
+                                                                            bool storeOriginalCoords,
+                                                                            unsigned bucketSizeFocus)
     : rank_(rank)
     , numRanks_(numRanks)
     , box_(0, 1)
+    , storeOriginalCoords_(storeOriginalCoords)
 {
     DeviceConnectivityTuple d_conn_;
     DeviceCoordsTuple d_coords_;
@@ -1399,10 +1482,7 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
     box_ = computeGlobalBoundingBoxFromCoords<RealType>(std::get<0>(h_coords), std::get<1>(h_coords),
                                                         std::get<2>(h_coords));
 
-    // Initialize cornerstone domain with custom bucket size
-    // int bucketSize           = 64;  // Now passed as parameter
-    unsigned bucketSizeFocus = 8;
-    RealType theta           = 0.5;
+    RealType theta = 0.5;
 
     std::cout << "Rank " << rank_ << ": Computed bounding box from coordinates: [" << box_.xmin() << "," << box_.xmax()
               << "] [" << box_.ymin() << "," << box_.ymax() << "] [" << box_.zmin() << "," << box_.zmax() << "]"
@@ -1423,8 +1503,9 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
               << ", bucketSizeFocus=" << bucketSizeFocus << ", theta=" << theta << ", input nodes=" << nodeCount_
               << ", input elements=" << elementCount_ << std::endl;
 
-    // Perform sync
+    logGpuMemAroundSync(rank_, "pre-sync");
     sync(d_conn_, d_coords_);
+    logGpuMemAroundSync(rank_, "post-sync");
 
     std::cout << "Rank " << rank_ << " initialized " << ElementTag::Name << " domain with " << nodeCount_
               << " nodes and " << elementCount_ << " elements." << std::endl;
@@ -1437,7 +1518,8 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
                                                                             const HostBoundaryTuple& h_boundary,
                                                                             int rank,
                                                                             int numRanks,
-                                                                            int bucketSize)
+                                                                            int bucketSize,
+                                                                            unsigned bucketSizeFocus)
     : rank_(rank)
     , numRanks_(numRanks)
     , box_(0, 1)
@@ -1453,10 +1535,7 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
     box_ = computeGlobalBoundingBoxFromCoords<RealType>(std::get<0>(h_coords), std::get<1>(h_coords),
                                                         std::get<2>(h_coords));
 
-    // Initialize cornerstone domain with custom bucket size
-    // int bucketSize           = 64;  // Now passed as parameter
-    unsigned bucketSizeFocus = 8;
-    RealType theta           = 0.5;
+    RealType theta = 0.5;
 
     std::cout << "Rank " << rank_ << ": Computed bounding box from coordinates: [" << box_.xmin() << "," << box_.xmax()
               << "] [" << box_.ymin() << "," << box_.ymax() << "] [" << box_.zmin() << "," << box_.zmax() << "]"
@@ -1477,8 +1556,9 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
               << ", bucketSizeFocus=" << bucketSizeFocus << ", theta=" << theta << ", input nodes=" << nodeCount_
               << ", input elements=" << elementCount_ << std::endl;
 
-    // Perform sync
+    logGpuMemAroundSync(rank_, "pre-sync");
     sync(d_conn_, d_coords_);
+    logGpuMemAroundSync(rank_, "post-sync");
 
     std::cout << "Rank " << rank_ << " initialized " << ElementTag::Name << " domain with " << nodeCount_
               << " nodes and " << elementCount_ << " elements." << std::endl;
@@ -1490,7 +1570,8 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(Devi
                                                                               DeviceConnectivityTuple&& d_conn,
                                                                               int rank,
                                                                               int numRanks,
-                                                                              int bucketSize)
+                                                                              int bucketSize,
+                                                                              unsigned bucketSizeFocus)
     : rank_(rank)
     , numRanks_(numRanks)
     , box_(0, 1)
@@ -1536,8 +1617,7 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(Devi
                                   gymin - pad * ry, gymax + pad * ry,
                                   gzmin - pad * rz, gzmax + pad * rz);
 
-    unsigned bucketSizeFocus = 8;
-    RealType theta           = 0.5;
+    RealType theta = 0.5;
 
     domain_ = std::make_unique<DomainType>(rank, numRanks, bucketSize, bucketSizeFocus, theta, box_);
 
@@ -1545,7 +1625,10 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(Devi
     DeviceConnectivityTuple d_conn_local = std::move(d_conn);
     DeviceCoordsTuple       d_coords_local = std::move(d_coords);
     calculateCharacteristicSizes(d_conn_local, d_coords_local);
+
+    logGpuMemAroundSync(rank_, "pre-sync");
     sync(d_conn_local, d_coords_local);
+    logGpuMemAroundSync(rank_, "post-sync");
 
     std::cout << "Rank " << rank_ << " initialized " << ElementTag::Name << " domain (device ctor) with "
               << nodeCount_ << " nodes and " << elementCount_ << " elements." << std::endl;
@@ -1557,7 +1640,9 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
                                                                                    HostCoordsTuple& h_coords_,
                                                                                    HostConnectivityTuple& h_conn_)
 {
-    std::cout << "Reading mesh data from " << meshFile << " on rank " << rank_ << std::endl;
+    int rank = rank_;
+    int numRanks = numRanks_;
+    std::cout << "Reading mesh data from " << meshFile << " on rank " << rank << std::endl;
     try
     {
         // Helper to handle coordinate conversion based on type
@@ -1593,7 +1678,7 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
                 // Use Exodus mesh reader for tet elements
                 auto [readNodeCount, readElementCount, x_data, y_data, z_data, conn_tuple, localToGlobal,
                       boundaryNodes] =
-                    mars::readExodusMeshWithElementPartitioning<4, RealType, KeyType>(meshFile, rank_, numRanks_);
+                    mars::readExodusMeshWithElementPartitioning<4, RealType, KeyType>(meshFile, rank, numRanks);
 
                 nodeCount_    = readNodeCount;
                 elementCount_ = readElementCount;
@@ -1610,7 +1695,7 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
                 // Use MFEM mesh reader
                 auto [readNodeCount, readElementCount, x_data, y_data, z_data, conn_tuple, localToGlobal,
                       boundaryNodes] =
-                    mars::readMFEMMeshWithElementPartitioning<4, RealType, KeyType>(meshFile, rank_, numRanks_);
+                    mars::readMFEMMeshWithElementPartitioning<4, RealType, KeyType>(meshFile, rank, numRanks);
 
                 nodeCount_    = readNodeCount;
                 elementCount_ = readElementCount;
@@ -1626,7 +1711,7 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
             {
                 // Use binary mesh reader
                 auto [readNodeCount, readElementCount, x_data, y_data, z_data, conn_tuple, localToGlobal] =
-                    mars::readMeshWithElementPartitioning<4, RealType, KeyType>(meshFile, rank_, numRanks_);
+                    mars::readMeshWithElementPartitioning<4, RealType, KeyType>(meshFile, rank, numRanks);
 
                 nodeCount_    = readNodeCount;
                 elementCount_ = readElementCount;
@@ -1646,7 +1731,7 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
                 // Use Exodus mesh reader for hex elements
                 auto [readNodeCount, readElementCount, x_data, y_data, z_data, conn_tuple, localToGlobal,
                       boundaryNodes] =
-                    mars::readExodusMeshWithElementPartitioning<8, RealType, KeyType>(meshFile, rank_, numRanks_);
+                    mars::readExodusMeshWithElementPartitioning<8, RealType, KeyType>(meshFile, rank, numRanks);
 
                 nodeCount_    = readNodeCount;
                 elementCount_ = readElementCount;
@@ -1663,7 +1748,7 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
                 // Use MFEM mesh reader for hex elements
                 auto [readNodeCount, readElementCount, x_data, y_data, z_data, conn_tuple, localToGlobal,
                       boundaryNodes] =
-                    mars::readMFEMMeshWithElementPartitioning<8, RealType, KeyType>(meshFile, rank_, numRanks_);
+                    mars::readMFEMMeshWithElementPartitioning<8, RealType, KeyType>(meshFile, rank, numRanks);
 
                 nodeCount_    = readNodeCount;
                 elementCount_ = readElementCount;
@@ -1679,7 +1764,7 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
             {
                 // Use binary mesh reader
                 auto [readNodeCount, readElementCount, x_data, y_data, z_data, conn_tuple, localToGlobal] =
-                    mars::readMeshWithElementPartitioning<8, RealType, KeyType>(meshFile, rank_, numRanks_);
+                    mars::readMeshWithElementPartitioning<8, RealType, KeyType>(meshFile, rank, numRanks);
 
                 nodeCount_    = readNodeCount;
                 elementCount_ = readElementCount;
@@ -1700,7 +1785,7 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
                 // NOTE: Use RealType for coordinate precision (not float) to preserve exact values
                 auto [readNodeCount, readElementCount, x_data, y_data, z_data, conn_tuple, localToGlobal,
                       boundaryNodes] =
-                    mars::readMFEMMeshWithElementPartitioning<3, RealType, KeyType>(meshFile, rank_, numRanks_);
+                    mars::readMFEMMeshWithElementPartitioning<3, RealType, KeyType>(meshFile, rank, numRanks);
 
                 nodeCount_    = readNodeCount;
                 elementCount_ = readElementCount;
@@ -1717,7 +1802,7 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
                 // Use binary mesh reader
                 // NOTE: Use RealType for coordinate precision (not float) to preserve exact values
                 auto [readNodeCount, readElementCount, x_data, y_data, z_data, conn_tuple, localToGlobal] =
-                    mars::readMeshWithElementPartitioning<3, RealType, KeyType>(meshFile, rank_, numRanks_);
+                    mars::readMeshWithElementPartitioning<3, RealType, KeyType>(meshFile, rank, numRanks);
 
                 nodeCount_    = readNodeCount;
                 elementCount_ = readElementCount;
@@ -1738,7 +1823,7 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
                 // NOTE: Use RealType for coordinate precision (not float) to preserve exact values
                 auto [readNodeCount, readElementCount, x_data, y_data, z_data, conn_tuple, localToGlobal,
                       boundaryNodes] =
-                    mars::readMFEMMeshWithElementPartitioning<4, RealType, KeyType>(meshFile, rank_, numRanks_);
+                    mars::readMFEMMeshWithElementPartitioning<4, RealType, KeyType>(meshFile, rank, numRanks);
 
                 nodeCount_    = readNodeCount;
                 elementCount_ = readElementCount;
@@ -1755,7 +1840,7 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
                 // Use binary mesh reader
                 // NOTE: Use RealType for coordinate precision (not float) to preserve exact values
                 auto [readNodeCount, readElementCount, x_data, y_data, z_data, conn_tuple, localToGlobal] =
-                    mars::readMeshWithElementPartitioning<4, RealType, KeyType>(meshFile, rank_, numRanks_);
+                    mars::readMeshWithElementPartitioning<4, RealType, KeyType>(meshFile, rank, numRanks);
 
                 nodeCount_    = readNodeCount;
                 elementCount_ = readElementCount;

--- a/docs/design/node_halo_topology_v2.md
+++ b/docs/design/node_halo_topology_v2.md
@@ -1,0 +1,409 @@
+# NodeHaloTopology v2 — Device-Resident, Gordon-Bell-Suitable Design
+
+**Status:** Plan, not yet implemented. v1 (broken) archived at
+`.attic/nodehalotopo_v1_broken.diff`. Working tree restored to commit
+`1d90501` (host-driven version that produces correct results but is the
+known scaling bottleneck at cube512^3).
+
+**Authoring context:** Cstone branch, Alps/Santis H100s, targeting 10^9
+hex elements with CVFEM graph assembly + AMR. The host-driven version
+costs ~70 s in NodeHaloTopology construction at cube512^3 regardless of
+rank count — that's the wall we have to break.
+
+## 1. Goals
+
+| Goal | Why |
+|------|-----|
+| **Correctness gate first**: must reproduce host version's `||u||` exactly on cube16/64 before any optimization | v1 failed because correctness and performance changed simultaneously |
+| **Device-resident**: no host arrays of SFC keys, ownership claims, peer key tables | Source of the O(70 s) bottleneck — host hash-builds and unordered_map lookups |
+| **Compose cstone primitives, don't reinvent** | The deep read showed cstone already exposes everything we need; the failed v1 reimplemented `gatherRanges` and CUDA-aware MPI from scratch |
+| **Index-driven pack/unpack** (no NaN sentinel, no `T(0)` fallback) | v1 bug at [domain.hpp:794](../../backend/distributed/unstructured/domain.hpp) silently corrupted ghost zeros |
+| **Pre-sized buffers** | v1 race at [domain.hpp:776–780](../../backend/distributed/unstructured/domain.hpp) on `mutable sendBuf_/recvBuf_` resize |
+| **Peer-bounded work**: O(boundary) not O(global) | At 1024 ranks, O(global) Allgatherv is the single biggest scaling killer |
+| **CUDA-aware MPI by default**, host staging fallback under `CSTONE_HAVE_GPU_AWARE_MPI=OFF` | Cstone already gives this for free if we use its primitives |
+
+## 2. Non-Goals
+
+- Not changing the public `exchangeNodeHalo()` signature. Existing CG /
+  CVFEM call sites must continue to work without modification.
+- Not changing `HaloData::buildNodeOwnership()` Steps 1–2. Those are
+  correct and not the bottleneck.
+- Not introducing Hypre / new dependencies. Pure cstone + thrust.
+
+## 3. Architecture (Honest Reuse Tiering)
+
+This isn't "compose cstone primitives." Be specific about what's reused
+and what's hand-rolled. Three tiers:
+
+**Tier A — real reuse, types compile without adapters:**
+- `mpiSendGpuDirect` / `mpiRecvGpuDirect`
+  ([cstone/primitives/mpi_cuda.cuh:31,62](../../cornerstone-octree/include/cstone/primitives/mpi_cuda.cuh)) —
+  saves the CUDA-aware MPI + host-staging fallback code path. Direct call.
+- `incomingHaloIndices()` / `outgoingHaloIndices()`
+  ([cstone/halos/halos.hpp:111-112](../../cornerstone-octree/include/cstone/halos/halos.hpp))
+  — bookkeeping accessors we patched in. Direct read.
+
+**Tier B — pattern reuse, structure copied but rewritten:**
+- `haloExchangeGpu` ([cstone/halos/exchange_halos_gpu.cuh:34](../../cornerstone-octree/include/cstone/halos/exchange_halos_gpu.cuh))
+  — its post-recv / post-send / waitall structure is the template for
+  §5's hot path. We don't call it; the buffer layout is element-halo
+  shaped, ours is node-halo shaped.
+
+**Tier C — no reuse, hand-rolled:**
+- §4 CSR construction (per-peer node-id sets from element-halo ranges)
+- §5 pack / unpack kernels — small, ~5 lines each. `gatherRanges` shape
+  doesn't match (ours is sparse node IDs, not contiguous ranges); forcing
+  it would be degenerate. Verified by mechanical signature check below.
+
+### Signature & call-site evidence (the mechanical check)
+
+Recorded once here so future-us can verify by re-opening the cstone files.
+
+`gatherRanges` ([cstone/halos/gather_halos_gpu.h:22](../../cornerstone-octree/include/cstone/halos/gather_halos_gpu.h)):
+```cpp
+template<class T, class IndexType>
+void gatherRanges(const IndexType* rangeScan, const IndexType* rangeOffsets,
+                  int numRanges, const T* src, T* buffer, size_t bufferSize);
+```
+Inputs are *contiguous range descriptors*. Our send list, after the §4
+sort+unique, is a *dense list of arbitrary node IDs*. Wrong shape; do not
+reuse. Hand-rolled `dst[i] = src[ids[i]]` instead.
+
+`mpiSendGpuDirect` ([cstone/primitives/mpi_cuda.cuh:31](../../cornerstone-octree/include/cstone/primitives/mpi_cuda.cuh)):
+```cpp
+template<class T>
+auto mpiSendGpuDirect(T* data, size_t count, int rank, int tag,
+                     std::vector<MPI_Request>& requests, ...);
+```
+Our v2 call site:
+```cpp
+cstone::mpiSendGpuDirect(d_sendBuf_.data() + h_sendOffsets_[i],
+                         sendCount, peer, tag, reqs);
+```
+Types compile. Direct reuse.
+
+### Composition diagram
+
+```
+            HOST                           DEVICE
+   +----------------+
+   | peers (vec<int>)|---------------- already in cstone Domain
+   | incomingHalos[p]| (RecvList, single range per peer)
+   | outgoingHalos[p]| (SendList, multiple ranges per peer)
+   +----------------+
+            |
+            v
+   per-peer construction (one-time, in NodeHaloTopology ctor)
+   ----------------------------------------------------------
+   For each peer p, derive on device:
+     d_sendNodeIds[p]   - dense local node IDs to send to p (CSR)
+     d_recvNodeIds[p]   - dense local node IDs to overwrite from p (CSR)
+
+   Pre-allocate:
+     d_sendBuf  size = sendOffsets_.back() * sizeof(RealType)
+     d_recvBuf  size = recvOffsets_.back() * sizeof(RealType)
+
+            |
+            v
+   per-call exchangeNodeHalo<T>(arr, nodeToDof) (hot path, no alloc)
+   ---------------------------------------------------------------
+   1. Pack:    one kernel reads arr[nodeToDof[d_sendNodeIds[i]]] -> d_sendBuf[i]
+               (or use cstone gatherRanges if signature fits)
+   2. MPI:     mpiSendGpuDirect / mpiRecvGpuDirect on device pointers
+   3. Unpack:  one kernel writes d_recvBuf[i] -> arr[nodeToDof[d_recvNodeIds[i]]]
+```
+
+Key insight: with **dense node-id CSRs computed once**, the hot path is a
+plain gather/scatter + MPI on contiguous device buffers. There is no
+sentinel; the unpack writes only at indices that the recv list explicitly
+contains. Indices that aren't in the recv list aren't touched.
+
+## 4. The Construction Algorithm (One-Time)
+
+This runs once when the NodeHaloTopology is built (or rebuilt after AMR).
+**It is the only non-trivial part of v2.** The hot path is trivial.
+
+### Inputs (all device-resident)
+
+- `peers : vector<int>` (host ok, tiny)
+- `incomingHaloIndices_[p]` : `IndexPair<LocalIndex>` — single contiguous
+  element range received from peer p ([halos.hpp:111](../../cornerstone-octree/include/cstone/halos/halos.hpp))
+- `outgoingHaloIndices_[p]` : `SendManifest` — possibly multiple element
+  ranges sent to peer p ([halos.hpp:112](../../cornerstone-octree/include/cstone/halos/halos.hpp))
+- `d_conn_local_ids_` : tuple of `NPC` device vectors with **dense local
+  node IDs** per element (already built by AdjacencyData)
+- `d_nodeOwnership_` : per-node ownership flag from
+  `HaloData::buildNodeOwnership()` (already built)
+- `startIdx, endIdx` : owned element range
+
+### Algorithm sketch (per peer p)
+
+#### 4.1 Build candidate `recvNodeIds` from incoming element halo
+
+```
+incoming element range for p = [S, E) = incomingHaloIndices_[p]
+candidate ghost nodes touched by p =
+    flatten d_conn_local_ids_[*][S:E]      (NPC * (E-S) entries)
+```
+
+Filter to nodes **this rank does not own** (`d_nodeOwnership_[n] == 0`).
+Sort + unique. That's `d_recvNodeIds[p]`.
+
+Why this works: cstone already guarantees that for every ghost node N
+on this rank, the element halo from N's owner contains at least one
+element touching N. So scanning the per-peer incoming element range and
+filtering on ownership=0 enumerates exactly the ghost nodes coming from p.
+
+**Kernel 1**: per element in [S, E), emit (peer=p, local_node_id) tuples
+for the NPC corner nodes whose ownership==0. Stream-compact + sort
+unique per-peer.
+
+#### 4.2 Build `sendNodeIds` from outgoing element halo
+
+```
+outgoing element ranges for p = outgoingHaloIndices_[p].ranges()
+candidate owned nodes that p needs =
+    flatten d_conn_local_ids_[*] over those ranges
+```
+
+Filter to nodes **this rank owns** (`d_nodeOwnership_[n] == 1`). Sort +
+unique. That's `d_sendNodeIds[p]`.
+
+**Kernel 2**: per element in each outgoing range, emit (peer=p,
+local_node_id) for ownership==1. Stream-compact + sort unique per-peer.
+
+#### 4.3 Build CSRs
+
+After per-peer dedup, build flat CSRs:
+
+```
+d_sendOffsets : DeviceVector<int>, size numPeers+1
+d_sendNodeIds : DeviceVector<LocalIndex>, size sendOffsets.back()
+d_recvOffsets : DeviceVector<int>, size numPeers+1
+d_recvNodeIds : DeviceVector<LocalIndex>, size recvOffsets.back()
+```
+
+Each peer's slice is `d_sendNodeIds[d_sendOffsets[p] : d_sendOffsets[p+1]]`.
+
+#### 4.4 Pre-size buffers
+
+```
+d_sendBuf.resize(sendOffsets.back());
+d_recvBuf.resize(recvOffsets.back());
+```
+
+Done once. **Never resized on hot path.**
+
+### Correctness invariant we want to verify
+
+For each owned node N that's also touched by an incoming halo element
+from peer p, that node must NOT also appear in `recvNodeIds[p]` (we
+already own it; the value is authoritative locally). The ownership filter
+in 4.1 enforces this by construction.
+
+### What about the corner-shared-node bug?
+
+The host version has a known issue ([domain.cu:1002–1008](../../backend/distributed/unstructured/domain.cu)) where ~9 corner-shared
+nodes on a 4-rank cube remain doubly-owned because cstone's element halo
+doesn't include opposite-rank elements that touch corner-only nodes.
+
+In v2, that issue **does not arise from this construction** — but it's
+not fixed either. The `d_nodeOwnership_` we consume is what
+`buildNodeOwnership()` Steps 1+2 produced, with that same bug. If a node
+is doubly-owned, both ranks include it in their `sendNodeIds` to each
+other but neither has it in their `recvNodeIds`, so values remain
+self-consistent. The Phase 5 tiebreaker exchange in the host version
+exists to fix this; we'll port it as a separate, optional pre-step in
+4.0 if validation shows it matters.
+
+For the cube16/64 validation gate, this won't matter (mesh is small
+enough we can compare `||u||` exactly against the host version, which
+has the same bug). For Gordon-Bell scale we'll need to evaluate.
+
+## 5. The Hot Path: exchangeNodeHalo()
+
+```cpp
+template<class VectorType>
+void exchangeNodeHalo(VectorType& arr, const int* nodeToDof = nullptr) const
+{
+    // 1. Pack: one kernel
+    packNodeHaloKernel<<<...>>>(
+        rawPtr(arr), nodeToDof,
+        rawPtr(d_sendNodeIds_), rawPtr(d_sendOffsets_),
+        rawPtr(d_sendBuf_),
+        numPeers_);
+
+    // 2. MPI: post all recvs first, then all sends, then waitall
+    std::vector<MPI_Request> reqs;
+    reqs.reserve(2 * numPeers_);
+    for (int i = 0; i < numPeers_; ++i) {
+        int p = peers_[i];
+        size_t recvCount = h_recvOffsets_[i+1] - h_recvOffsets_[i];
+        if (recvCount == 0) continue;
+        cstone::mpiRecvGpuDirect(
+            d_recvBuf_.data() + h_recvOffsets_[i], recvCount,
+            p, tagBase_ + epoch_, reqs);
+    }
+    for (int i = 0; i < numPeers_; ++i) {
+        int p = peers_[i];
+        size_t sendCount = h_sendOffsets_[i+1] - h_sendOffsets_[i];
+        if (sendCount == 0) continue;
+        cstone::mpiSendGpuDirect(
+            d_sendBuf_.data() + h_sendOffsets_[i], sendCount,
+            p, tagBase_ + epoch_, reqs);
+    }
+    MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
+
+    // 3. Unpack: one kernel — index-driven, NO sentinel
+    unpackNodeHaloKernel<<<...>>>(
+        rawPtr(d_recvBuf_),
+        rawPtr(d_recvNodeIds_), rawPtr(d_recvOffsets_),
+        rawPtr(arr), nodeToDof,
+        numPeers_);
+
+    ++epoch_;  // unique MPI tag per exchange (cstone convention)
+}
+```
+
+Notes:
+- `epoch_` is `mutable`; same convention as cstone's `Halos::haloEpoch_`.
+  An MPI collective is required between successive `exchangeNodeHalo()`
+  calls if no other collective happens. CG already has Allreduce per
+  iter, so this is satisfied.
+- `nodeToDof` indirection is preserved exactly as the host version handles
+  it.
+- We start with **hand-rolled pack/unpack kernels** rather than
+  `gatherRanges` because our send is a single index list per peer (not
+  multiple disjoint ranges). If profiling later shows `gatherRanges` is
+  faster (it's coalesced and tuned), we switch — but the simple kernel
+  is correct first.
+
+## 6. Validation Plan (Step-by-Step Gate)
+
+**Rule:** each step must pass before the next is touched. Don't bundle
+multiple changes between checksums — that's exactly what hid the v1 bugs.
+
+### Gate 1 — CSR construction matches host
+Build `d_sendNodeIds_`, `d_recvNodeIds_`, offsets on device. Then on
+cube16, 4 ranks:
+1. Build host version (existing code).
+2. Build v2 device version, copy back to host.
+3. **Per peer**, sort both lists, compare:
+   - per-peer node count: must match exactly
+   - per-peer sorted node-id sequence: must match exactly
+
+If they don't match, the construction in §4 is wrong; fix that before
+touching anything else.
+
+### Gate 2 — pack output matches host
+With CSRs validated, run pack on a known input (e.g. `arr[i] = i*3.14`).
+Copy `d_sendBuf_` back, compare to host pack. Bit-exact for float, exact
+or ULP-1 for double.
+
+### Gate 3 — single MPI exchange round-trip
+Pack on rank A, send to B, B unpacks into a zeroed array. Then B re-packs
+the ghost slots and sends back to A. `arr` on A at the ghost-mirror slots
+should match the original send.
+
+### Gate 4 — one CG iteration matches host
+Run one CG iteration with v2 `exchangeNodeHalo()`. Compare `||p||` and
+`||Ap||` after the iteration. Must match host within solver tolerance.
+
+### Gate 5 — full Poisson solve matches host
+Cube16 + cube64 + cube128. `||u||` and `Max` must match host's working
+output to ~1e-12 (double precision Poisson on small mesh is essentially
+deterministic).
+
+### Gate 6 — tet mesh validation
+Same as Gate 5 but on a tet mesh. This catches NPC=4 vs NPC=8 bugs
+before scale-testing exposes them.
+
+### Gate 7 — scale test
+Only after Gates 1–6 pass: cube256, cube512 on 4/16/64 ranks. Measure:
+- NodeHaloTopology construction time (should be <1 s, not 70 s)
+- per-CG-iter halo exchange time (should be ~1 ms latency-bound)
+- weak-scaling efficiency
+
+## 7. Where Each Piece Lives in the Code
+
+Files to touch:
+
+| File | What changes |
+|------|--------------|
+| [backend/distributed/unstructured/domain.hpp](../../backend/distributed/unstructured/domain.hpp) | Replace `NodeHaloTopology` body. Public surface unchanged. Remove `mutable sendBuf_/recvBuf_` resize on hot path; pre-size in ctor. |
+| [backend/distributed/unstructured/domain.cu](../../backend/distributed/unstructured/domain.cu) | New construction kernels (`buildSendNodeIdsKernel`, `buildRecvNodeIdsKernel`). New hot-path kernels (`packNodeHaloKernel`, `unpackNodeHaloKernel`). |
+
+Files we **do not** touch:
+
+- `HaloData::buildNodeOwnership()` Steps 1+2 — keep as-is, correct.
+- `AdjacencyData` — `d_conn_local_ids_` is already what we need.
+- Public `exchangeNodeHalo<T>(...)` signature — internal body changes only.
+- Cstone — we use existing accessors and primitives, no patches needed
+  beyond the ones we already applied.
+
+## 8. Pitfalls to Avoid (Lessons from v1 + Audit Findings)
+
+1. **Do not change behavior and performance in the same commit.** v1
+   merged "make device-resident" with "remove host bookkeeping" with
+   "change pack semantics" all at once. When NaN appeared we couldn't
+   bisect.
+2. **Do not use a value-based sentinel** (NaN, T(0), INT_MAX in float
+   bits). Always index-driven: pack and unpack iterate over explicit ID
+   lists.
+3. **Do not resize device buffers on the hot path.** Mutable shared state
+   + concurrent calls = race. Pre-size in ctor.
+4. **Do not assume `RecvList` and `SendList` are symmetric.** RecvList
+   per peer is one contiguous range; SendList per peer is multiple
+   disjoint ranges (`SendManifest` with `offsets_[]` and `scan_[]`).
+   Iterate accordingly.
+5. **Do not skip Gate 1.** If the CSRs are wrong, every later gate
+   fails for a misleading reason.
+6. **Do not call `gatherRanges` for our pack step.** Mechanically wrong
+   shape — see §3 "signature & call-site evidence." Hand-roll instead.
+
+### Audit finding — pre-existing bugs in `1d90501`
+
+Reading the committed working version closely revealed the T(0) sentinel
+([domain.hpp:794](../../backend/distributed/unstructured/domain.hpp))
+and `mutable resize` race ([domain.hpp:776–780](../../backend/distributed/unstructured/domain.hpp))
+**already exist in `1d90501`**, not just the broken v1. They're inert
+under current usage because:
+- T(0) is only hit when `nodeToDof[n] < 0` (node is not a DOF),
+  which happens cleanly for pure-Dirichlet H1 problems.
+- The race needs concurrent `exchangeNodeHalo` calls; CG is
+  single-threaded on host, MPI Allreduce serializes between halo
+  exchanges.
+
+v2 §5 fixes both regardless: index-driven unpack means no sentinel; ctor
+pre-sizing means no hot-path resize. Also: hardcoded `tag=777`
+([domain.hpp:813,825](../../backend/distributed/unstructured/domain.hpp))
+gets replaced with an epoch counter (cstone convention) so multi-field
+exchange in one timestep doesn't tag-collide.
+
+## 9. Open Questions
+
+- **Per-peer kernel launch vs single fused kernel?** Two design choices:
+  (a) one launch per peer, simpler but has launch overhead at high peer
+  count; (b) single launch over flat CSRs with peer index from
+  binary-search of offsets. Start with (a); if profiling shows launch
+  overhead matters, switch to (b).
+- **CUDA-aware MPI fallback path.** When `CSTONE_HAVE_GPU_AWARE_MPI=OFF`,
+  cstone's `mpiSendGpuDirect` automatically host-stages. Verify Alps's
+  cray-mpich actually has it on; if not, we eat the staging cost.
+- **AMR rebuild cost.** Every adaptMesh re-runs NodeHaloTopology
+  construction. The new construction is O(local boundary) so should be
+  fast, but verify we're not doing host syncs we missed.
+- **Phase 5 tiebreaker port.** Host version has a tiebreaker exchange
+  ([domain.cu:1374–1476](../../backend/distributed/unstructured/domain.cu)) for the corner-shared bug. Decide after Gate 5
+  whether to port it. If `||u||` matches host on the cube cases, the bug
+  doesn't bite our validation; we'd port it only when scale-testing
+  reveals it.
+
+## 10. Out-of-Scope Improvements (Future)
+
+These are tempting but explicitly **not** in v2. Land v2 working first.
+
+- Async overlap of halo exchange with local SpMV.
+- Persistent MPI requests (`MPI_Send_init` / `MPI_Start`).
+- Combining multiple field exchanges into one MPI message.
+- Replacing thrust sort+unique with a hash-table-based dedup on device.

--- a/docs/design/node_halo_topology_v2_bug_report_2026-05.md
+++ b/docs/design/node_halo_topology_v2_bug_report_2026-05.md
@@ -1,0 +1,130 @@
+# NodeHaloTopology v2 — Bug Report (2026-05)
+
+Source: parallel session by Daniel that ran v2 at scale (cube512/32 ranks
+and cube1024/256 ranks). Current Mac session was about to add the same
+fix from a different angle. Captured here so we don't re-derive it.
+
+## Failure pattern (validated)
+
+Across all mismatching ranks at 32+ ranks, the asymmetry is systematic:
+
+```
+v2 send sizes ≤ host send sizes   (often slightly smaller, sometimes 100+ off)
+v2 recv sizes ≥ host recv sizes   (often larger, sometimes 2-3× larger)
+```
+
+Sample (cube512, 32 ranks, validate mode):
+```
+[Rank 25] send peer  4  size: host=12      v2=10
+[Rank 25] send peer  6  size: host=27758   v2=27711
+[Rank 25] recv peer  9  size: host=840     v2=1422   ← 1.7× larger
+[Rank 25] recv peer 23  size: host=1841    v2=2676
+[Rank 25] recv peer 27  size: host=941     v2=2779   ← 3× larger
+
+[Rank 23] send peer 24  size: host=103962  v2=103744
+[Rank 23] recv peer 17  size: host=60144   v2=61201
+[Rank 23] recv peer 25  size: host=737     v2=2436
+[Rank 23] recv peer 29  size: host=745     v2=2616
+```
+
+Cube16/4 ranks reproduces the same pattern (this session, 2026-05-09):
+```
+[Rank 3] recv peer 1  size: host=61   v2=130   ← 2.1× larger
+[Rank 3] recv peer 2  size: host=404  v2=480
+[Rank 0] recv peer 2  size: host=137  v2=205
+[Rank 0] recv peer 3  size: host=215  v2=266
+```
+
+## Root cause (high confidence)
+
+cstone halo bookkeeping doesn't model node ownership. v2's
+`buildFromCstoneHalos` walks element corners in cstone halo ranges and
+filters by local `d_nodeOwnership_`, but it never exchanges per-key
+ownership claims with peers. So:
+
+- A boundary node N may be touched by element halos from peers P1 and P2.
+- v2 emits (peer=P1, node=N) and (peer=P2, node=N) into recvNodeIds_,
+  because both halo ranges contain elements with N as a corner.
+- After sort+unique on (peer, node), both entries survive — they're
+  distinct (peer, node) pairs.
+- Result: v2 expects to receive N from both P1 and P2.
+- Host path resolves this via global `keyOwner[sfc_key]` map (built from
+  `MPI_Allgatherv`), which says "N is owned by exactly one rank."
+  Host's recv list for N has exactly one entry.
+
+Send side mirror: when this rank's `d_nodeOwnership_` says it owns N
+but the global tiebreaker (host) yields ownership to a lower-rank peer,
+host removes N from send list while v2 keeps it.
+
+## Numeric impact
+
+Drift is small but **scale-dependent and growing** — more ranks → more
+3+-way corners → more wrong-owner decisions → larger drift. CG would
+converge to a wrong fixed point.
+
+| Mesh / Ranks       | Host norm                          | v2 norm                            | Drift             |
+|--------------------|------------------------------------|------------------------------------|-------------------|
+| cube512 / 32       | matrix=1.463879e+01, rhs=2.993200e-03 | matrix=1.463887e+01, rhs=2.995761e-03 | ~5e-6 / ~9e-4 |
+| cube1024 / 256     | matrix=2.071203e+01, rhs=1.555497e-03 | matrix=2.071215e+01, rhs=1.558524e-03 | ~6e-6 / ~2e-3 |
+
+Mesh-load speedup confirmed:
+- cube512/32: 68 s → 24 ms (2800×)
+- cube1024/256: ~27 s → 28 ms (1000×)
+
+Assembly slowdown with v2 halo (suspected: extra atomic contention from
+duplicate contributions):
+- cube1024/256: 9.2 ms (host) → 32.8 ms (v2)
+
+## Fix design
+
+**Add a peer-subgroup all-to-all tiebreaker** before §4.3 of the v2
+build:
+
+1. Each rank emits `(sfc_key, my_rank)` for every node currently flagged
+   `ownership ∈ {1, 2}` (locally owned or shared). This is the rank's
+   *claim*.
+2. Send the claim list to each peer in `findPeersMac` set
+   (point-to-point Isend/Irecv on device pointers via cstone's
+   mpiSendGpuDirect / Recv).
+3. On the receive side, for each incoming `(sfc_key, peer_rank)`:
+   binary-search local `d_localToGlobalSfcMap_` for `sfc_key`. If found
+   and `peer_rank < my_rank`: yield ownership (set
+   `d_nodeOwnership_[local_id] = 0`).
+4. Resync `d_nodeOwnership_` on device.
+5. Then run the existing emit + filter + sort_unique with the now-
+   authoritative ownership.
+
+**Why all-to-all-in-peer-subgroup, not pairwise?** With pairwise
+tiebreakers, A and B each compare against each other but neither knows
+about C's claim on the same key. 3+-way ties resolve incorrectly. The
+all-to-all in the peer subgroup ensures every rank that could touch a
+key sees every other rank's claim, so min-rank-wins is computed
+identically by all participants.
+
+**Cost.** Boundary nodes per rank ≈ √(elem/rank). For 1M elem/rank ≈
+10⁴ keys × 12 bytes × ~30 peers = ~3 MB sent per rank. One round of
+peer p2p. O(boundary), no Allgatherv. Keeps the scaling win.
+
+## Verification gate
+
+```bash
+# Cube16, 4 ranks (smallest reproducer):
+MARS_NODEHALO_VALIDATE=1 srun --account=csstaff --nodes=1 \
+  --ntasks-per-node=4 --time=00:10:00 ~/affinity/bind_numa.sh \
+  daint-gpu/examples/distributed/unstructured/mars_cvfem_graph \
+  --mesh=/capstor/scratch/cscs/gandanie/git/mars/cube16.mesh \
+  --kernel=tensor --iterations=1
+```
+
+Expect: `[Rank N] NodeHaloTopo v2 == host (Gate 1 pass)` on every rank.
+
+Then escalate:
+```bash
+# cube512/32 — the case the other session hit
+srun -l --ntasks-per-node=4 --nodes=8 -A csstaff -t 00:15:00 \
+  --export=ALL,MARS_NODEHALO_VALIDATE=1 \
+  daint-gpu/examples/distributed/unstructured/mars_cvfem_graph \
+  cube512.mesh/ --kernel=tensor --iterations=5
+```
+
+Then cube1024/256 once cube512 is clean.

--- a/docs/design/node_halo_topology_v2_testing.md
+++ b/docs/design/node_halo_topology_v2_testing.md
@@ -1,0 +1,185 @@
+# NodeHaloTopology v2 — Cluster Testing Guide
+
+The v2 device-resident NodeHaloTopology has been implemented but **not
+compiled or run anywhere** (developer machine has no CUDA/MPI). Use this
+guide on Alps/Santis to drive it through Gates 1–7.
+
+## State on disk
+
+- `backend/distributed/unstructured/domain.hpp`
+  - `NodeHaloTopology` struct gained `buildFromCstoneHalos()` and
+    `validateAgainstHost()` declarations (around L439–457)
+  - `exchangeNodeHalo()` hot-path rewritten:
+    - removed T(0) sentinel — now index-driven (L807 area)
+    - removed hot-path resize of `sendBuf_/recvBuf_` (L789–791 area)
+    - epoch-counter MPI tags (L848 area) instead of hardcoded 777
+- `backend/distributed/unstructured/domain.cu`
+  - new free function `buildNodeHaloTopologyHostPath()` wraps the
+    original O(global) host body unchanged
+  - `NodeHaloTopology` ctor now selects path via env vars; pre-sizes
+    `sendBuf_/recvBuf_`
+  - new `emitHaloNodesKernel` + `buildFromCstoneHalos` + `validateAgainstHost`
+    implementations (~300 lines after the ctor)
+- `.attic/nodehalotopo_v1_broken.diff` — earlier abandoned device-resident
+  attempt, archived for reference
+
+## Build
+
+Apply cstone patches (skip if already applied):
+```bash
+bash scripts/patch_cornerstone.sh
+```
+
+Then standard CUDA build:
+```bash
+cd build
+cmake .. \
+  -DMARS_ENABLE_KOKKOS=OFF \
+  -DMARS_ENABLE_CUDA=ON \
+  -DMARS_ENABLE_TESTS=ON \
+  -DMARS_ENABLE_UNSTRUCTURED=ON \
+  -DMARS_ENABLE_FEM_EXAMPLES=ON \
+  -DCMAKE_CUDA_ARCHITECTURES=90
+make -j mars_cvfem_graph
+```
+
+## Runtime selection
+
+Three modes via env vars:
+
+| Env | Behavior |
+|-----|----------|
+| (unset) | Original host O(global) path. Default. Production. |
+| `MARS_NODEHALO_VALIDATE=1` | Build BOTH paths, diff per-peer node-id lists, abort on mismatch. Use for Gate 1. |
+| `MARS_NODEHALO_V2=1` | v2 device-resident path only. Use after Gate 1 passes. |
+
+If `VALIDATE` is set, `V2` is implied (validation builds v2 into the live
+struct after the diff passes).
+
+## Gate 1 — CSR construction matches host
+
+```bash
+MARS_NODEHALO_VALIDATE=1 mpirun -np 4 ./bin/examples/mars_cvfem_graph \
+    --mesh /path/to/cube16.mesh
+```
+
+**Pass criterion**: stdout shows
+```
+[Rank N] NodeHaloTopo v2 == host (Gate 1 pass)
+```
+on every rank, and the program continues past topology construction
+without aborting.
+
+**Failure mode 1**: per-peer node-count mismatch.
+Means v2 is missing or adding node IDs at some peer. Most likely cause:
+ownership filter mismatch with host's tiebreaker. Recovery path: add a
+device-side tiebreaker before §4.3 of the design.
+
+**Failure mode 2**: peer-list mismatch.
+Means the v2 derivation of peers from `incomingHaloIndices`/
+`outgoingHaloIndices` disagrees with the host's `unordered_map` traversal.
+Investigate whether some rank has only outgoing or only incoming halo
+(my filter requires non-empty in either direction; that's correct).
+
+**Try first on cube16, 4 ranks.** Tiny mesh, cheap to iterate.
+Then cube64, then cube128.
+
+## Gate 2 — pack output matches host
+
+This isn't a separate run — Gates 1 and 4 together exercise pack/unpack
+on real data. After Gate 1 passes, run a single-iteration smoke test:
+
+```bash
+MARS_NODEHALO_V2=1 mpirun -np 4 ./bin/examples/mars_cvfem_graph \
+    --mesh /path/to/cube16.mesh --max-iter 1 --tol 1.0
+```
+
+Compare `||u||` after iteration 1 with the same flag set vs unset.
+Should match to ~1e-12 (double).
+
+## Gate 3 — single MPI round-trip
+
+If Gate 2 deviates, isolate by setting array values to a known pattern
+(e.g., `arr[i] = i * 3.14`) before exchangeNodeHalo, then dump the
+post-exchange ghost slot values from each rank and compare. The
+hot-path code is the same in both modes; if Gate 2 fails it's likely
+the v2 CSRs themselves, not the MPI plumbing.
+
+## Gate 4 — one CG iter matches host
+
+```bash
+MARS_NODEHALO_V2=1 mpirun -np 4 ./bin/examples/mars_cvfem_graph \
+    --mesh cube64.mesh --max-iter 1
+```
+vs unset. `||u||` after 1 iter must match.
+
+## Gate 5 — full Poisson solve on cube16/64/128
+
+```bash
+for sz in 16 64 128; do
+  for mode in "" "MARS_NODEHALO_V2=1"; do
+    eval $mode mpirun -np 4 ./bin/examples/mars_cvfem_graph \
+        --mesh cube${sz}.mesh > out_${sz}_${mode:-host}.log
+  done
+done
+diff out_16_host.log out_16_MARS_NODEHALO_V2=1.log
+```
+`||u||` and `Max` must match.
+
+## Gate 6 — tet mesh
+
+```bash
+MARS_NODEHALO_V2=1 mpirun -np 4 ./bin/examples/mars_ex1_poisson \
+    --mesh /path/to/tet_mesh
+```
+Compare against unset. NPC=4 codepath through emitHaloNodesKernel.
+
+## Gate 7 — scale test
+
+Only after Gates 1–6 pass cleanly:
+
+```bash
+for n in 4 16 64; do
+  MARS_NODEHALO_V2=1 srun -N$((n/4)) -n$n \
+      ./bin/examples/mars_cvfem_graph --mesh cube512.mesh
+done
+```
+
+Look for the line `Rank 0: NodeHaloTopo[v2] N peers, M send nodes, K recv nodes`
+in stdout, with the **wallclock for that phase reported by the existing
+PhaseTimer instrumentation** — should be sub-second, not 70 s.
+
+## If validation reveals ownership-tiebreaker is needed
+
+Most likely outcome on real meshes: the host-path tiebreaker via
+`MPI_Allgatherv` of all owned keys + `unordered_map` resolves
+corner-shared duplicates that v2 doesn't. Two paths forward:
+
+**Option A (simpler)**: keep `HaloData::buildNodeOwnership()` Steps 1+2
+as-is, then add a **point-to-point peer-bounded tiebreaker** before
+v2's CSR build:
+- Each rank exchanges (sfc_key, ownership) with peers from
+  `findPeersMac` only
+- Apply lowest-rank-wins
+- Then run v2 builder on the resolved ownership
+
+This is O(boundary), still device-resident with CUDA-aware MPI.
+
+**Option B (cheaper but less general)**: assume cstone's element halo
+already covers all corner-shared neighbors. On cube meshes with
+sufficient halo width this holds. Run with `bucketSize >= 2*NPC` and
+verify Gate 5 numerically. Document the assumption.
+
+Decide after seeing the actual mismatch on cube256 with realistic rank
+counts.
+
+## Rolling back
+
+The host path is unchanged and remains the default. To roll back v2
+entirely:
+```bash
+git checkout backend/distributed/unstructured/domain.cu
+git checkout backend/distributed/unstructured/domain.hpp
+```
+The `.attic/nodehalotopo_v1_broken.diff` is a **separate** abandoned
+attempt and should NOT be reapplied — it's there for reference only.

--- a/docs/reference/01_cstone_overview.md
+++ b/docs/reference/01_cstone_overview.md
@@ -1,0 +1,331 @@
+# Cornerstone-Octree Reference for MARS
+
+Header-only + CUDA library at `/Users/gandanie/scratch/santis/mars/cornerstone-octree/`.
+This document is the API-surface map. For algorithmic depth (Hilbert, focus
+tree, sync data flow), see [04_cstone_focus_tree.md](04_cstone_focus_tree.md).
+
+## 1. Repo Layout
+
+| Directory | Purpose |
+|-----------|---------|
+| `cstone/cuda/` | GPU abstractions: `DeviceVector` (PIMPL), errorcheck, thrust wrappers |
+| `cstone/domain/` | `Domain` class, `GlobalAssignment` SFC splitting, buffer layouts, halo book-keeping |
+| `cstone/fields/` | Particle field utilities |
+| `cstone/focus/` | Focused octree on GPU: construction, convergence, MAC updates |
+| `cstone/halos/` | Halo exchange: `Halos`, CPU `haloexchange`, GPU `haloExchangeGpu` |
+| `cstone/primitives/` | sort, gather/scatter, MPI wrappers, math, CUB integrations |
+| `cstone/sfc/` | Hilbert/Morton encoding (32/64-bit), `Box`, key ops |
+| `cstone/traversal/` | Dual-tree MAC, `findPeersMac`, collision/overlap detection |
+| `cstone/tree/` | `Octree`, `OctreeView`, B-tree leaves, `TreeNodeIndex`, tree construction |
+| `cstone/util/` | Allocators, tuple metaprogramming, strong types, `array` container |
+
+No `src/`; everything is in headers / `.cuh`.
+
+## 2. Core Types
+
+### Index types — `tree/definitions.h`
+| Type | Where | Notes |
+|------|-------|-------|
+| `TreeNodeIndex` | definitions.h:25 | `int`, octree node index |
+| `LocalIndex` | definitions.h:27 | `unsigned`, max ~4B particles per rank |
+| `maxTreeLevel<unsigned>` | definitions.h:51 | 10 levels (32-bit) |
+| `maxTreeLevel<unsigned long long>` | definitions.h:54 | 21 levels (64-bit) |
+
+### SFC keys — `sfc/sfc.hpp:27–112`
+```cpp
+template<class IntegerType> using MortonKey  = StrongType<IntegerType, struct MortonKeyTag>;
+template<class IntegerType> using HilbertKey = StrongType<IntegerType, struct HilbertKeyTag>;
+template<class IntegerType> using SfcKind    = HilbertKey<IntegerType>;  // default
+```
+Instantiations: `HilbertKey<unsigned>`, `HilbertKey<unsigned long long>`,
+`MortonKey<...>`. Encode/decode at `sfc.hpp:142–194`.
+
+### IndexPair / IndexRanges — `domain/index_ranges.hpp:29–107`
+```cpp
+template<class T> struct IndexPair : public std::tuple<T,T> {
+    T start() const; T end() const; T count() const;
+};
+using TreeIndexPair = IndexPair<TreeNodeIndex>;
+
+class IndexRanges<Index> {           // CSR-like: multiple (start,end) ranges
+    void addRange(IndexType lo, IndexType hi);
+    IndexType rangeStart(size_t i) const;
+    IndexType rangeEnd(size_t i) const;
+    std::size_t count(size_t i) const;
+    std::size_t totalCount() const;
+};
+using SendManifest = IndexRanges<LocalIndex>;
+using RecvList     = std::vector<IndexPair<LocalIndex>>;       // 1 contiguous range per rank
+using SendList     = std::vector<SendManifest>;                // multiple ranges per rank
+```
+
+**Critical asymmetry**: `incomingHaloIndices_[peer]` is a **single
+contiguous range** (RecvList element). `outgoingHaloIndices_[peer]` is a
+SendManifest, possibly **multiple disjoint ranges**.
+
+### BufferDescription — `domain/buffer_description.hpp:29–45`
+```cpp
+struct BufferDescription { LocalIndex start; LocalIndex end; LocalIndex size; };
+```
+Layout: `|-- halos --|-- assigned --|-- halos --|`
+                    `0         start           end         size`
+
+### Box — `sfc/box.hpp:94–149`
+Float bounding box with per-axis `BoundaryType { open, periodic, fixed }`
+(`sfc.hpp:80–85`). Accessors: `xmin/xmax/.../lx/ly/lz/ilx/ily/ilz`.
+
+### SfcAssignment — `domain/domaindecomp.hpp:57–110`
+```cpp
+template<class KeyType> class SfcAssignment {
+    KeyType operator[](int rank) const;
+    int findRank(KeyType key) const;            // binary search
+    LocalIndex totalCount(int rank) const;
+    int numRanks() const;
+    std::span<const TreeNodeIndex> numNodesPerRank() const;
+    std::span<const TreeNodeIndex> treeOffsetsConst() const;
+};
+```
+
+### DeviceVector — `cuda/device_vector.h:32–72`
+PIMPL wrapper hiding thrust headers. Explicit instantiations:
+- arithmetic: `char, uint8_t, int, unsigned, uint64_t, float, double`
+- arrays: `util::array<int,2/3>`, `util::array<unsigned,1/2>`,
+  `util::array<float/double,3/4>`
+
+`rawPtr(deviceVector) -> T*`. **`double` is instantiated**, but for
+gatherRanges and exchange paths, support depends on the kernel's own
+instantiations (see Section 4).
+
+## 3. Domain Class — `domain/domain.hpp:38–641`
+
+### Constructor — `domain.hpp:63–81`
+```cpp
+Domain(int rank, int nRanks, unsigned bucketSize, unsigned bucketSizeFocus,
+       float theta, const Box<T>& box = Box<T>{0, 1});
+```
+Asserts `bucketSize >= bucketSizeFocus`.
+
+### Members
+- `BufferDescription prevBufDesc_, bufDesc_;`
+- `FocusedOctree<KeyType, T, Accelerator> focusTree_;`
+- `AccVector<LocalIndex> layoutAcc_;` (GPU/CPU layout)
+- `std::vector<LocalIndex> layout_;` (CPU mirror)
+- `GlobalAssignment<KeyType, T, Accelerator> global_;`
+- `Halos<KeyType, Accelerator> halos_{myRank_};`
+
+### sync() — `domain.hpp:164–206`
+```cpp
+template<class KeyVec, class VectorX, class VectorH, class... Vectors1, class... Vectors2>
+void sync(KeyVec& particleKeys, VectorX& x, VectorX& y, VectorX& z, VectorH& h,
+          std::tuple<Vectors1&...> particleProperties,
+          std::tuple<Vectors2&...> scratchBuffers);
+```
+**Preconditions** (domain.hpp:95–109): array sizes equal `localNParticles_`
+from previous call (any size on first call); ≥3 scratch buffers.
+
+**Postconditions**: arrays resized to `nParticles + nHalos`; `x,y,z,h` at
+`[startIndex():endIndex()]` filled and **SFC-sorted**; halo property values
+**undefined** until `exchangeHalos(property)`.
+
+**Step sequence** (domain.hpp:150–162, 174–206):
+1. Compute global bbox
+2. Build global octree from assigned-range particles
+3. Compute per-node max interaction radius
+4. Assign leaves to ranks via SFC split
+5. Discover halos
+6. Compute layout
+7. Resize arrays to assigned + halo
+8. MPI exchange coords + properties
+9. Sort to SFC order
+10. Halo-exchange remaining properties
+
+### syncGrav() — `domain.hpp:208–282`
+Adds mass `m`; iterates focus-tree refinement using expansion centers
+(center-of-mass) until convergence MPI_Allreduce reports 0.
+
+### Public accessors — `domain.hpp:333–390`
+```cpp
+const auto& incomingHaloIndices() const;   // forward to halos_
+const auto& outgoingHaloIndices() const;
+LocalIndex startIndex() const;
+LocalIndex endIndex() const;
+LocalIndex nParticles() const;
+LocalIndex nParticlesWithHalos() const;
+OctreeView<const KeyType> globalTree() const;
+const FocusedOctree<KeyType, T, Accelerator>& focusTree() const;
+TreeNodeIndex startCell() const;
+TreeNodeIndex endCell() const;
+std::span<const LocalIndex> layout() const;
+const Box<T>& box() const;
+KeyType assignmentStart() const;
+```
+
+### exchangeHalos() / reapplySync() — `domain.hpp:291–331`
+Repeat previous halo pattern for new arrays; uses `mutable haloEpoch_` for
+unique MPI tags.
+
+## 4. Halo Subsystem
+
+### Halos<KeyType, Accelerator> — `halos/halos.hpp:38–125`
+```cpp
+int exchangeRequests(std::span<const KeyType> leaves,
+                     std::span<const TreeIndexPair> assignment,
+                     std::span<const int> peers,
+                     std::span<const LocalIndex> layout);
+
+template<class Scratch1, class Scratch2, class... Vectors>
+void exchangeHalos(std::tuple<Vectors&...> arrays,
+                   Scratch1& sendBuffer, Scratch2& receiveBuffer) const;
+
+const RecvList& incomingHaloIndices() const;   // per-peer single range
+const SendList& outgoingHaloIndices() const;   // per-peer multiple ranges
+
+mutable int haloEpoch_{0};   // <-- requires MPI collective between calls
+```
+
+### CPU path — `halos/exchange_halos.hpp:26–93`
+```cpp
+template<class... Arrays>
+void haloexchange(int epoch, const RecvList&, const SendList&, Arrays...);
+```
+Pack to uint64_t-aligned host buffers, `MPI_Isend` per peer, `MPI_Recv` with
+`MPI_ANY_SOURCE`. Tag = `P2pTags::haloExchange + epoch`.
+
+### GPU path — `halos/exchange_halos_gpu.cuh:34–120`
+```cpp
+template<class DevVec1, class DevVec2, class... Arrays>
+void haloExchangeGpu(int epoch, const RecvList&, const SendList&,
+                     DevVec1& sendScratch, DevVec2& recvScratch, Arrays... arrays);
+```
+- `TransferType = uint64_t` for alignment + 32-bit count workaround
+- `gatherRanges(d_rangeScan, d_rangeOffsets, numRanges, src, buffer, bufferSize)`
+  packs scattered ranges into contiguous device buffer (`halos/gather_halos_gpu.h:22`)
+- `mpiSendGpuDirect` / `mpiRecvGpuDirect` from `primitives/mpi_cuda.cuh:31–74`
+  branch on `CSTONE_HAVE_GPU_AWARE_MPI` at compile time
+
+### Type instantiation gaps
+`gatherRanges` is explicitly instantiated for: `float, double, int,
+unsigned, uint64_t, char, uint8_t`, and small `util::array<...,3>` variants.
+**Custom struct types require an explicit kernel instantiation in a new .cu**
+or byte-level packing.
+
+### haloEpoch_ pitfall
+`mutable int haloEpoch_{0}` is **not thread-safe**. Multiple threads calling
+exchangeHalos concurrently corrupt the counter. Also: between two
+`exchangeHalos()` calls the user **must execute an MPI collective** (e.g.
+`MPI_Barrier`), or tag mismatches deadlock.
+
+## 5. SFC Machinery — `sfc/sfc.hpp`
+
+```cpp
+KeyType sfc3D<KeyType, T>(T x, T y, T z, const Box<T>& box);   // L142–178
+util::tuple<unsigned,unsigned,unsigned> decodeSfc<KeyType>(KeyType k);  // L181–194
+void computeSfcKeys<T,KeyType>(const T* x, const T* y, const T* z,
+                               KeyType* keys, size_t n, const Box<T>& box);  // L268
+```
+`computeSfcKeys` skips entries equal to `removeKey<KeyType>::value`.
+
+## 6. Tree / Octree
+- `TreeNodeIndex` = `int` index into octree node arrays
+- Cornerstone octree = SFC-key array marking leaf starts (3 invariants in `csarray.hpp:19–33`)
+- Full octree (`tree/octree.hpp`) stores internal+leaf with Warren-Salmon
+  placeholder bits encoding level
+- See [04_cstone_focus_tree.md](04_cstone_focus_tree.md) §2–3 for full detail
+
+## 7. MPI Utilities — `primitives/mpi_wrappers.hpp` + `mpi_cuda.cuh`
+- `MpiType<T>` mapping (L25–94) for double, float, char, uchar, short, ushort,
+  int, unsigned, long, ulong, ulonglong
+- `mpiSendAsync<T>(data, count, rank, tag, requests)` — `MPI_Isend`
+- `mpiRecvAsync<T>(...)` — `MPI_Irecv`
+- `mpiAllgatherv` (L202–226) — handles struct/array types via scaled counts
+- GPU variants in `mpi_cuda.cuh`; conditional on
+  `CSTONE_HAVE_GPU_AWARE_MPI` (L24–28)
+
+## 8. Reusable Primitives Table (for MARS)
+
+| Function | File:Line | Purpose |
+|----------|-----------|---------|
+| `sortByKey<useGpu>` | primitives_acc.hpp:101 | Sort + permutation, GPU/CPU dual path |
+| `gatherRanges` | halos/gather_halos_gpu.h:22 | Pack disjoint device ranges to contiguous buffer |
+| `gatherAcc<useGpu>` | primitives_acc.hpp:58 | Gather: `dst[i] = src[ord[i]]` |
+| `scatterAcc<useGpu>` | primitives_acc.hpp:65 | Scatter: `dst[ord[i]] = src[i]` |
+| `sequence<useGpu>` | primitives_acc.hpp:92 | Iota fill |
+| `sfc3D` / `decodeSfc` / `computeSfcKeys` | sfc/sfc.hpp | SFC encode/decode |
+| `findPeersMac<T,KeyType>` | traversal/peers.hpp:46 | Dual-tree MAC peer discovery |
+| `Domain::sync` | domain/domain.hpp:164 | Full sync |
+| `Domain::exchangeHalos` | domain/domain.hpp:327 | Repeat halo for new arrays |
+| `halos_.exchangeRequests` | halos/halos.hpp:60 | Negotiate halo index ranges |
+| `haloExchangeGpu` | halos/exchange_halos_gpu.cuh:34 | GPU-direct MPI halo exchange |
+| `mpiSendGpuDirect` | primitives/mpi_cuda.cuh:31 | GPU-aware send (or staging) |
+| `mpiRecvGpuDirect` | primitives/mpi_cuda.cuh:62 | GPU-aware recv (or staging) |
+| `DeviceVector<T>` | cuda/device_vector.h:32 | PIMPL device buffer |
+
+## 9. Canonical Usage Example — `test/integration_mpi/exchange_halos_gpu.cpp:70–150`
+```cpp
+RecvList incomingHalos(numRanks);
+SendList outgoingHalos(numRanks);
+if (rank == 0) {
+    outgoingHalos[1].addRange(0, 1);
+    outgoingHalos[1].addRange(1, 3);
+    incomingHalos[1] = {3, 10};
+}
+// ... mirror on rank 1 ...
+
+DeviceVector<double> d_x = x;
+DeviceVector<char> sendBuffer(7 * 24);
+DeviceVector<char> receiveBuffer(7 * 24);
+
+haloExchangeGpu(0, incomingHalos, outgoingHalos, sendBuffer, receiveBuffer,
+                rawPtr(d_x), rawPtr(d_y), rawPtr(d_z));
+```
+
+## 10. Limitations / Gotchas
+1. `haloEpoch_` mutable, not thread-safe; needs MPI collective between calls
+2. Halo discovery is **particle-level**, not node-level. MARS builds node
+   halos on top via cstone's element halo bookkeeping.
+3. `DeviceVector` copy = deep copy. Prefer swap.
+4. `gatherRanges` instantiation gaps for custom types
+5. Particle array size invariant across syncs (use `removeKey` sentinel)
+6. SFC functions assume global rectangular `Box`; coords outside clipped
+7. MPI collective required between `exchangeHalos()` calls
+
+## 11. Build / Fetch
+| Flag | Effect |
+|------|--------|
+| `CSTONE_WITH_CUDA` (or USE_CUDA) | Enable CUDA paths |
+| `CSTONE_WITH_GPU_AWARE_MPI` | Direct device-pointer MPI vs host staging |
+| `CSTONE_WITH_HIP` | AMD path; mutually exclusive with CUDA |
+
+MARS pulls cstone via `FetchContent_Declare`. Output at
+`_deps/cornerstone_fetch-src/include/cstone/`. **Patches we apply** (sed-based,
+preserving everything else): added accessors in `halos.hpp:111–112` and
+forwarders in `domain.hpp` for `incomingHaloIndices()` /
+`outgoingHaloIndices()`. Headers only — no link library.
+
+C++ standards: host C++20, CUDA C++17, HIP C++20.
+
+## 12. Key File Index
+```
+include/cstone/
+  domain/domain.hpp                 L38–641     Domain orchestration
+  domain/assignment.hpp             L36–210     GlobalAssignment
+  domain/index_ranges.hpp           L28–107     IndexPair, SendList, RecvList
+  domain/buffer_description.hpp     L29–45      BufferDescription
+  domain/domaindecomp.hpp           L57–281     SfcAssignment, makeSfcAssignment
+  halos/halos.hpp                   L38–125     Halos class (+ our patch L111–112)
+  halos/exchange_halos.hpp          L26–93      CPU haloexchange
+  halos/exchange_halos_gpu.cuh      L34–120     GPU-direct haloExchangeGpu
+  halos/gather_halos_gpu.h          L21–28      gatherRanges signature
+  sfc/sfc.hpp                       L27–277     sfc3D, decodeSfc, key types
+  sfc/box.hpp                       L94–149     Box<T>
+  tree/definitions.h                L19–116     index types, removeKey
+  tree/octree.hpp                   L38–196     full octree
+  primitives/gather.hpp             L29–148     CPU gather/scatter, SfcSorter
+  primitives/primitives_acc.hpp     L27–109     unified GPU/CPU wrappers
+  primitives/mpi_wrappers.hpp       L24–226     MPI type maps, Isend/Irecv
+  primitives/mpi_cuda.cuh           L15–141     GPU-aware MPI
+  cuda/device_vector.h              L26–102     PIMPL DeviceVector
+  traversal/peers.hpp               L21–161     findPeersMac
+test/integration_mpi/
+  exchange_halos_gpu.cpp            L1–150      canonical usage
+```

--- a/docs/reference/02_mars_overview.md
+++ b/docs/reference/02_mars_overview.md
@@ -1,0 +1,323 @@
+# MARS Unstructured Backend Reference
+
+This is the API-surface map of `backend/distributed/unstructured/`. For
+deep dives see:
+- [03_mars_cvfem_kernels.md](03_mars_cvfem_kernels.md) — CVFEM kernels
+- [05_mars_amr_module.md](05_mars_amr_module.md) — AMR
+- [06_mars_solvers.md](06_mars_solvers.md) — solvers + sparse matrix
+
+## 1. Architecture
+
+| Subdir | Purpose |
+|--------|---------|
+| `.` | `domain.hpp` / `domain.cu` — `ElementDomain<Tag,Real,Key,Acc>` wrapping cstone |
+| `fem/` | CVFEM kernels (12 variants), tensor ops, coloring, sparsity, H1 FE space |
+| `solvers/` | CG, BiCGSTAB, GMRES, Hypre PCG, AMG preconditioner |
+| `amr/` | Octree-driven hex/tet refinement, transfer, error indicators |
+| `utils/` | Mesh I/O (binary, MFEM, Exodus), reference elements, BC handling |
+
+cstone integration: `domain.hpp:490`
+`using DomainType = cstone::Domain<KeyType, RealType, AcceleratorTag>`.
+`incomingHaloIndices()` / `outgoingHaloIndices()` accessed at `domain.cu:1244–1245`.
+
+## 2. ElementDomain — `domain.hpp:485–1091`
+
+### Member layout
+| Member | Type | Lazy? | Purpose |
+|--------|------|-------|---------|
+| `d_elemSfcCodes_` | `DeviceVector<KeyType>` | no | element SFC codes |
+| `d_conn_keys_` | `Tuple(NPC × DV<KeyType>)` | no | element→node connectivity in **SFC keys** (NPC=4 tet, 8 hex) |
+| `d_props_` | `DeviceVector<RealType>` | no | per-node characteristic size `h` |
+| `d_boundary_` | `DeviceVector<uint8_t>` | no | per-node boundary flag |
+| `box_` | `cstone::Box<RealType>` | no | bounding box |
+| `d_elemToNodeMap_` | `DeviceVector<KeyType>` | no | representative node (min SFC) per elem |
+| `d_localToGlobalSfcMap_` | `DeviceVector<KeyType>` | yes | local-id → global SFC (sorted) |
+| `d_localToGlobalNodeMap_` | `DeviceVector<KeyType>` | yes | local-id → global node idx |
+| `adjacency_` | `unique_ptr<AdjacencyData>` | yes | local-id connectivity + node→elem CSR |
+| `halo_` | `unique_ptr<HaloData>` | yes | node ownership + halo elem indices |
+| `nodeHaloTopo_` | `unique_ptr<NodeHaloTopology>` | yes | per-peer node send/recv lists |
+| `coordCache_` | `unique_ptr<CoordinateCache>` | yes | decoded (x,y,z) from SFC |
+| `originalCoords_` | `unique_ptr<OriginalCoordinates>` | yes | exact mesh-file coords |
+
+### Element index model
+SFC keys are globally unique scalars. cstone partitions SFC space:
+```
+[0, startIndex())              low-rank halos
+[startIndex(), endIndex())     owned elements (this rank assembles)
+[endIndex(), getElementCount())  high-rank halos
+```
+Local node IDs `[0, nodeCount)` are dense and contiguous per rank, built
+during `sync()`. `d_localToGlobalSfcMap_` is sorted ascending → binary
+searchable on device. Built by sort+unique on element connectivity SFC keys
+(`domain.cu:2346–2380`).
+
+### Constructor flow
+File constructor (`domain.hpp:513`):
+1. Read mesh (binary `.float32/.double`, MFEM `.mesh`, Exodus `.exo`)
+2. MPI_Allreduce global bbox (`domain.hpp:1266–1276`)
+3. Move to GPU; call device constructor
+
+Device constructor (`domain.hpp:540`):
+1. Move device coords + connectivity in
+2. Call `sync()`
+
+`sync()`:
+1. Compute element SFC keys from centroids
+2. cstone::Domain::sync → SFC sort + MPI redistribute + element halo
+3. Extract unique node SFC keys
+4. Sort, assign dense local IDs
+5. Allocate per-rank node arrays, scatter coords/boundary by local ID
+
+### Public accessors (selected)
+```cpp
+size_t getNodeCount() const;           // not lazy
+size_t getElementCount() const;        // not lazy
+auto getConnectivity<I>() const;       // d_conn_keys_[I]
+auto getElementToNodeConnectivity();   // LAZY: tuple of local-id arrays
+auto getLocalToGlobalSfcMap();         // LAZY
+auto getNodeOwnershipMap();            // LAZY
+auto getNodeX/Y/Z();                   // LAZY
+auto getNodeToElementOffsets/List();   // LAZY (CSR)
+pair<size_t,size_t> localElementRange();   // [startIdx, endIdx)
+vector<pair> haloElementRanges();          // [0,startIdx) ∪ [endIdx,N)
+bool isLocalElement(idx);
+```
+
+### Template instantiations (8)
+`{TetTag, HexTag} × {float, double} × {unsigned, uint64_t} × {cstone::GpuTag}`
+
+## 3. AdjacencyData — CSR connectivity
+
+Triggered via `buildAdjacency()` or lazily via `ensureAdjacency()`
+(`domain.cu:2345, 2380`).
+
+### Build flow
+1. **buildNodeToElementMap()** — for each element, iterate corner local IDs,
+   accumulate per-node element list, dedup via `thrust::sort_by_key + unique`
+2. **createElementToNodeLocalIdMap()** — for each element corner, look up
+   SFC key → binary search `d_localToGlobalSfcMap_` → store local id
+
+### Storage
+| Field | Type | Size |
+|-------|------|------|
+| `d_nodeToElementOffsets_` | `DV<KeyType>` | nodeCount + 1 |
+| `d_nodeToElementList_` | `DV<KeyType>` | sum of element degrees |
+| `d_conn_local_ids_` | `Tuple(NPC × DV<KeyType>)` | elementCount × NPC |
+
+Consumed by FEM assembly (gather), coloring (conflict detection), AMR error
+indicators.
+
+## 4. HaloData / NodeHaloTopology
+
+### HaloData::buildNodeOwnership() — `domain.cu:939–1011`
+
+**Step 1** (`domain.cu:979–987`): Mark nodes in `[startIdx, endIdx)` as
+owned (=1) via `markElementNodesOwnership<KeyType, NPC>` kernel.
+
+**Step 2** (`domain.cu:989–1000`): For elements in `[0, startIdx)` (halos
+from lower-ranked partitions), mark their corner nodes as not-owned (=0).
+Implements "lowest-SFC-key rank wins" tiebreaker.
+
+**Known limitation** (`domain.cu:1002–1008`): ~9 corner-shared nodes on
+4-rank cube remain doubly-owned because cstone's halo width misses
+opposite-rank elements that touch corner-only nodes. NodeHaloTopology Phase 5
+fixes this with a tiebreaker exchange.
+
+`buildHaloElementIndices()` caches halo elem indices for fast iteration.
+
+### NodeHaloTopology — `domain.cu:1214–1725` (~500 lines)
+
+Replaces O(global) `MPI_Allgatherv` with O(boundary) using cstone's
+`incomingHaloIndices()` / `outgoingHaloIndices()`.
+
+**Six phases**:
+1. **Per-element source-rank array** (L1254–1278): `d_elemOwnerRank[e]` =
+   peer rank or INT_MAX, filled from `incomingHaloIndices` ranges
+2. **`atomicMin` lowest peer touching each node** (L1305–1329): walk halo
+   element corners, atomicMin into `d_lowestPeerTouching[nodeId]`
+3. **Recompute ownership** (L1331–1341): node owned ⇔ locally-touched AND
+   `rank ≤ lowestPeerTouching`. Fixes corner-shared bug.
+4. **Boundary mask** (L1343–1372): mark nodes appearing in any halo elem
+5. **Tiebreaker exchange via CUDA-aware MPI** (L1374–1476): publish
+   boundary node SFC keys + ownership claims among peers; merge claims;
+   apply lowest-rank tiebreaker. Point-to-point `Isend/Irecv` on device
+   pointers, 3-tag pattern (count, keys, claims)
+6. **Build send/recv lists** (L1500+): per-peer
+   `recvNodeIds_[p]` (ghost nodes owned by p) and `sendNodeIds_[p]`
+   (owned nodes sent to p). Stored as CSR.
+
+### exchangeNodeHalo() — `domain.hpp:765`
+```cpp
+template<class VectorType>
+void exchangeNodeHalo(VectorType& nodeArray, const int* nodeToDof = nullptr) const;
+```
+1. **Pack** (L786–797): gather `arr[nodeToDof?nodeToDof[n]:n]` into `sendBuf_`
+2. **MPI** (L800–829): post all `MPI_Irecv` on `recvBuf_` device ptrs, all
+   `MPI_Isend` on `sendBuf_` device ptrs, `MPI_Waitall`
+3. **Scatter** (L831–844): write `recvBuf_` back into `arr` at ghost nodes
+
+**Invariant**: For every ghost node N, cstone's element halo must include
+≥1 element owned by N's owner rank. Holds for typical FEM partitions with
+halo width ≥ full-element-layer.
+
+## 5. CVFEM Assembly — `fem/`
+
+See [03_mars_cvfem_kernels.md](03_mars_cvfem_kernels.md) for kernel-level
+detail. Files:
+- `mars_cvfem_assembler.hpp` — dispatch enum + launcher
+- `mars_cvfem_hex_kernel*.hpp` — 12 variants
+- `mars_cvfem_coloring.hpp` — graph coloring
+- `mars_sparse_matrix.hpp` + `mars_sparsity_builder.hpp`
+- `mars_h1_fe_space.hpp`
+- `mars_cvfem_node_data.hpp` — AoS struct (72 B aligned)
+
+Halo exchange in solve: `exchangeNodeHalo(Ap)` before each SpMV in CG loop.
+
+## 6. Solvers — `solvers/`
+
+See [06_mars_solvers.md](06_mars_solvers.md). Available:
+- CG (single-rank, distributed via `setHaloExchangeCallback`)
+- BiCGSTAB (non-symmetric)
+- GMRES(restart)
+- Hypre PCG + BoomerAMG
+
+CG uses cuSPARSE SpMV + cuBLAS dot + `MPI_Allreduce` (when
+`ownedSize_ > 0`). **Watch**: `CUSPARSE_INDEX_32I` limits to ~2.1B
+nonzeros (fix when scaling beyond).
+
+## 7. AMR — `amr/`
+
+See [05_mars_amr_module.md](05_mars_amr_module.md).
+- `mars_amr_manager.hpp` — orchestration, InitTimings, AmrStats
+- `mars_amr_octree.hpp` — Doerfler marking + 1-irregular
+- `mars_amr_octree_native.hpp` — cstone-driven (recommended at scale)
+- `mars_amr_hex_refine.hpp` — 1→8 hex with 19 new nodes
+- `mars_amr_tet_refine.hpp` — Bey's red 1→8 tet
+- `mars_amr_solution_transfer.hpp` — P0 trilinear by parentage
+- `mars_amr_error_indicator.hpp` — gradient-based + Doerfler
+
+## 8. Examples
+
+| File | Element | Status |
+|------|---------|--------|
+| `mars_ex1_poisson.cu` | tet | working |
+| `mars_cvfem_full.cu` | hex | working (Hypre AMG) |
+| `mars_cvfem_graph.cu` | hex | working |
+| `mars_amr_cvfem_graph.cu` | hex | working |
+| `mars_amr_poisson.cu` | hex/tet | working |
+| `mars_cvfem_poisson.cu` | hex | **⚠ segfault** — TODO #7 |
+| `mars_ex_beam_tet.cu` | tet | working |
+
+`PhaseTimer` pattern (RAII): cudaDeviceSynchronize on dtor + duration print.
+
+## 9. Helpers
+
+### extractConnPtrs — `domain.cu:932–936`
+```cpp
+template <typename KeyType, typename Tuple, std::size_t... Is>
+void extractConnPtrs(const Tuple& t, const KeyType* ptrs[], std::index_sequence<Is...>) {
+    ((ptrs[Is] = thrust::raw_pointer_cast(std::get<Is>(t).data())), ...);
+}
+```
+Used at `domain.cu:973`.
+
+### cudaCheckError
+Wraps every kernel launch in domain.cu (lines 995, 1007, 1028, 1045, 1059,
+1077, 1088, 1326, 1370, 1405, ...).
+
+### Mesh I/O
+- `read_mesh_binary` — `.float32/.double` SoA with separate connectivity
+- `read_mfem_mesh` — MFEM `.mesh` ASCII
+- `read_exodus_mesh` — Exodus II (if `MARS_HAVE_NETCDF`)
+
+## 10. Connectivity Conventions
+| Space | Type | Range | Sparse? |
+|-------|------|-------|---------|
+| Global SFC key | KeyType | [0, 2^32) or [0, 2^64) | yes |
+| Dense local ID | KeyType | [0, nodeCount) | no |
+
+Conversion via `mapSfcToLocalIdKernel` (`domain.cu:829–848`):
+```cpp
+KeyType local_id = cub::LowerBound(sorted_sfc, num_nodes, sfc_key);
+assert(sorted_sfc[local_id] == sfc_key);
+```
+
+Naming: `d_*` device, `h_*` host, `*Sfc / *_keys` global SFC, `*_local_ids`
+dense local, `nodeToDof` indirection map.
+
+## 11. Identified Bugs (current state)
+
+### Bug 1: NaN sentinel changed to T(0) — `domain.hpp:794`
+```cpp
+sbuf[i] = (idx >= 0) ? arr[idx] : T(0);
+```
+Comments at L754–757 state pack should use NaN for nodes this rank doesn't
+own. Changing to `T(0)` corrupts ghost values that should remain owned-rank
+data — zero is indistinguishable from real zero.
+**Action**: revert to NaN sentinel with NaN-aware unpack, OR redesign so
+unpack is index-driven (only writes nodes the recv list says belong to peer).
+
+### Bug 2: Race on mutable buffer resize — `domain.hpp:776–780`
+```cpp
+mutable DeviceVector<RealType> sendBuf_, recvBuf_;
+...
+if (topo.sendBuf_.size() != sendTotal) topo.sendBuf_.resize(sendTotal);
+if (topo.recvBuf_.size() != recvTotal) topo.recvBuf_.resize(recvTotal);
+```
+Concurrent calls to `exchangeNodeHalo()` race the resize. No mutex.
+**Action**: pre-size during NodeHaloTopology construction OR add mutex.
+
+### Bug 3: Broken device-resident NodeHaloTopology rewrite (current state)
+Mentioned in compact summary. Current code at `domain.cu:1214–1725` is the
+host-driven version. An earlier device-resident attempt was abandoned due
+to NaN/non-deterministic results.
+
+### Bug 4: Corner-shared double ownership (minor)
+~9 nodes on 4-rank cube remain doubly-owned. NodeHaloTopology Phase 5
+tiebreaker handles this in working version.
+
+### Bug 5: Lazy field initialization order
+`getNodeX/Y/Z` checks `if (originalCoords_) return ... else
+ensureCoordinateCache()`. If `box_` is mutated post-construction, cached
+coords go stale. Rare but possible.
+
+### Bug 6: mars_cvfem_poisson.cu segfault — TODO #7
+Likely uninitialized adjacency access or coordinate caching path. Needs
+investigation; deferred.
+
+## 12. Build System
+
+CMake target: `mars_unstructured` (STATIC). Sources: `domain.cu` + `domain_cuda_impl.cpp`.
+
+Options:
+- `MARS_ENABLE_CUDA` — gates nvcc compilation
+- `MARS_ENABLE_HIP` — AMD path; mutually exclusive with CUDA
+- `MARS_ENABLE_UNSTRUCTURED` — this backend
+- `MARS_ENABLE_FEM_EXAMPLES` — examples
+- `MARS_ENABLE_TESTS` — test harness
+- `MARS_ENABLE_MPI` — required for distributed
+- `MARS_ENABLE_DISTRIBUTED_BACKEND` — distributed (Kokkos SFC) backend
+
+cstone fetched via `FetchContent`; available at
+`_deps/cornerstone_fetch-src/include/cstone/`. Patches applied via sed
+(see [01_cstone_overview.md](01_cstone_overview.md) §11).
+
+CUDA flags: `--diag-suppress=20281`, `CUDA_SEPARABLE_COMPILATION ON`,
+`-Xnvlink=--suppress-stack-size-warning`. Architectures `80;90` typical.
+
+ctest: `ctest -R marsReadMeshBinary` and similar filters.
+
+## 13. Scaling Notes (10^9 elements target)
+
+Per-rank at 10^9 / 1024 ranks = ~10^6 elements:
+- Connectivity: 8 × 8B = 64 B/elem → 64 MB
+- Coordinates: ~192 B/elem → 192 MB
+- CSR adjacency: ~192 MB
+- **Total ~500 MB/rank** (fits H100 80 GB easily)
+
+MPI:
+- Halo exchange: O(√(elem/rank)) boundary nodes → ~10k floats/iter, 40 KB
+- Dominant: assembly (~4.6 ms for 10^6 hex with tensor kernel on GH200)
+
+cstone partitioning: SFC sort gives spatial locality → bounded peer count
+and halo size → linear scaling.

--- a/docs/reference/03_mars_cvfem_kernels.md
+++ b/docs/reference/03_mars_cvfem_kernels.md
@@ -1,0 +1,428 @@
+# MARS CVFEM Kernel Family — Deep Reference
+
+Citation-heavy reference for `backend/distributed/unstructured/fem/`. For
+the dispatcher and how it plugs into ElementDomain see
+[02_mars_overview.md](02_mars_overview.md).
+
+## 1. Mathematical Foundation
+
+**Control-Volume Finite-Element Method (CVFEM)** — conservative
+unstructured discretization combining FE shape functions with flux-based
+control volumes (Patankar 1980, Shashkov–Steinberg).
+
+### Sub-Control-Surface (SCS) integration
+
+A hex8 element is split into **12 SCS** — faces connecting element center
+to edge midpoints:
+- 4 bottom (SCS 0–3, z=−0.5): edges 0-1, 1-2, 2-3, 3-0
+- 4 top (SCS 4–7, z=+0.5): edges 4-5, 5-6, 6-7, 7-4
+- 4 vertical (SCS 8–11, z=0): edges 0-4, 1-5, 2-6, 3-7
+
+Each SCS = quad with 4 nodes from the 27-point hex subdivision (8 corners
++ 12 edge mids + 6 face centers + 1 center). Integration points are at
+face locations (±0.5), aligning element-center flux surfaces to hex faces.
+
+**LRSCV array** — `mars_cvfem_hex_kernel.hpp:88–92`:
+```c
+__device__ __constant__ int hexLRSCV[24] = {
+    0,1, 1,2, 2,3, 0,3,        // bottom 4
+    4,5, 5,6, 6,7, 4,7,        // top 4
+    0,4, 1,5, 2,6, 3,7         // vertical 4
+};
+```
+nodeL, nodeR define opposing control volumes separated by each SCS face.
+
+### Shape functions
+
+`hexShapeFcn[12][8]` — `mars_cvfem_hex_kernel.hpp:60–85`. At each SCS,
+**only 2 of 8 nodes** have non-zero shape functions (0.5 each). Parametric
+derivatives at IPs in `hexDerivConst[12][8][3]` (L96–121).
+
+### Flux formulation
+
+Per SCS integration point `ip`:
+
+**Advection:**
+```
+phi_upwind = upwind(mdot, phi[nodeL], phi[nodeR])
+dcorr      = beta_upwind * grad_phi · (coords_ip - coords_upwind)
+adv_flux   = mdot * (phi_upwind + dcorr)
+```
+
+**Diffusion:**
+```
+diff_coeff[n] = -gamma_ip * (dndx[n] · areaVec)    ∀ n ∈ [0,8]
+```
+
+### Sparsity patterns
+- **Full** (27 NNZ/row): all 8×8 element-local pairs → 64 entries/element
+- **Graph** (7 NNZ/row, diagonal lumping): only 12 SCS edges (nodeL,
+  nodeR) contribute. Missing 45 entries lumped to diagonal — preserves row
+  sums (conservation). See `mars_sparsity_builder.hpp:104–127`.
+
+## 2. Reference Element & Shape Functions
+
+### Jacobian — `mars_cvfem_hex_kernel.hpp:124–138`
+```cuda
+__device__ inline void invert3x3(double J[3][3], double invJ[3][3]) {
+    double det = J[0][0]*(J[1][1]*J[2][2] - J[1][2]*J[2][1])
+               - J[0][1]*(J[1][0]*J[2][2] - J[1][2]*J[2][0])
+               + J[0][2]*(J[1][0]*J[2][1] - J[1][1]*J[2][0]);
+    double invDet = 1.0 / det;
+    invJ[0][0] = (J[1][1]*J[2][2] - J[1][2]*J[2][1]) * invDet;
+    // ... 8 more lines
+}
+```
+
+### Physical shape derivatives — `mars_cvfem_hex_kernel.hpp:141–170`
+```cuda
+__device__ inline void computeShapeDerivatives(
+    int ip, const double coords[8][3], double dndx[8][3])
+{
+    double J[3][3] = {{0,0,0},{0,0,0},{0,0,0}};
+    for (int node = 0; node < 8; ++node)
+        for (int i = 0; i < 3; ++i)
+            for (int j = 0; j < 3; ++j)
+                J[i][j] += hexDerivConst[ip][node][j] * coords[node][i];
+    double invJ[3][3];
+    invert3x3(J, invJ);
+    for (int node = 0; node < 8; ++node)
+        for (int i = 0; i < 3; ++i) {
+            dndx[node][i] = 0.0;
+            for (int j = 0; j < 3; ++j)
+                dndx[node][i] += invJ[i][j] * hexDerivConst[ip][node][j];
+        }
+}
+```
+Implements ∇_x N = J^{-T} · ∇_ξ N.
+
+### Area vectors — `mars_cvfem_hex_kernel.hpp:265–286`
+27-point hex subdivision (L173–212). Each SCS quad's area computed via
+**triangulation from quad centroid** (L215–256):
+```cuda
+__device__ inline void quad_area_by_triangulation(
+    const double areacoords[4][3], double areaVec[3])
+{
+    double xmid[3] = { 0.25*sum_x, 0.25*sum_y, 0.25*sum_z };
+    for (int itri = 0; itri < 4; ++itri) {
+        int t = (itri + 1) % 4;
+        double r2[3] = areacoords[t] - xmid;
+        areaVec += 0.5 * cross(r1, r2);
+        r1 = r2;
+    }
+}
+```
+
+## 3. NodeData Layout (AoS)
+
+`mars_cvfem_node_data.hpp:14–24`
+```cuda
+struct alignas(32) NodeData {
+    double x, y, z;           // 24 B
+    double phi, gamma, beta;  // 24 B
+    double gx, gy, gz;        // 24 B
+};  // 72 B = 3 L1 sectors (32 B each)
+```
+Rationale: 32 threads × scattered nodes hit
+- SoA (9 arrays): 9 × 32 = 288 sectors
+- AoS (1 struct): ~96 sectors
+**3× L2 traffic reduction**.
+
+Packing kernel (L39–63): one thread per node, copies 9 SoA arrays into AoS.
+
+## 4. Sparse Matrix CSR
+
+`mars_cvfem_hex_kernel.hpp:9–38`
+```cuda
+template<typename RealType>
+struct CSRMatrix {
+    int* rowPtr;          // [numRows+1]
+    int* colInd;          // [nnz], sorted within row
+    RealType* values;     // [nnz]
+    int* diagPtr;         // [numRows] direct diagonal index
+    int numRows, nnz;
+
+    __device__ void addValue(int row, int col, RealType val) {
+        // Linear search (baseline only) — slow
+        for (int i = rowPtr[row]; i < rowPtr[row+1]; ++i)
+            if (colInd[i] == col) { atomicAdd(&values[i], val); return; }
+    }
+    __device__ __forceinline__ RealType* diag(int row) {
+        return &values[diagPtr[row]];
+    }
+};
+```
+Columns sorted within each row → binary search (`tensor.hpp:231–240`).
+
+## 5. Sparsity Builder — `mars_sparsity_builder.hpp`
+
+### Graph sparsity — L130–273
+1. **Edge-list kernel** (L77–127): each thread emits 12×2=24 edge tuples per
+   element, plus invalid for ghosts
+2. **Thrust pipeline** (L149–213):
+   - Allocate edge row/col vectors
+   - Append diag entries (`thrust::sequence`)
+   - Remove `row < 0` (ghosts)
+   - `thrust::sort` by (row, col)
+   - `thrust::unique` → dedup
+   - atomicAdd per row → counts
+   - `thrust::exclusive_scan` → rowPtr
+   - Copy colInd
+3. **Diagonal lookup** (L247–270): per row, binary search colInd for
+   `colInd[k] == row`
+
+Complexity: O(E log E), E = numElements × 24. At 10^9 elements,
+E ≈ 2.4×10^10. Thrust GPU sort ~10× faster than CPU.
+
+## 6. Twelve Kernel Variants — Cross-Comparison
+
+| Variant | File | Block | Threads/Elem | Reg | Best When |
+|---------|------|-------|--------------|-----|-----------|
+| Original (Graph) | mars_cvfem_hex_kernel_graph.hpp | 256 | 1 | ~255 | never |
+| Optimized | mars_cvfem_hex_kernel_optimized.hpp | 256 | 1 | ~240 | baseline+10% |
+| Shmem | mars_cvfem_hex_kernel_shmem.hpp | 256 | 1 | ~80 | memory-bound |
+| Team | mars_cvfem_hex_kernel_optimized.hpp:268 | 256 (8 warps) | 32 | ~160 | extreme contention |
+| **Tensor** | mars_cvfem_hex_kernel_tensor.hpp | 256 | 1 | ~210–230 | **CURRENT BEST: 4.60 ms / 10^8 hex on GH200** |
+| TensorColored | mars_cvfem_hex_kernel_tensor_colored.hpp | 256 | 1 | ~210–230 | atomics costly |
+| TensorAoS | mars_cvfem_hex_kernel_tensor_aos.hpp | 256 | 1 | ~210–230 | nodes dominate |
+| TensorPerip | mars_cvfem_hex_kernel_tensor_perip.hpp | 256 | 1 | ~170–200 | regs constrained |
+| TensorPeripLb2 | mars_cvfem_hex_kernel_tensor_perip.hpp:277 | 128 | 1 | ~140–170 | NOT GH200 |
+| SmemCache | mars_cvfem_hex_kernel_smem_cache.hpp | 256 | 1 | ~180–210 | L2 latency dominates |
+| WmmaTensor | mars_cvfem_hex_kernel_tensor_wmma.hpp | 256 (1 warp/elem) | 32 | ~120 | SM80+ FP64 WMMA |
+| WgmmaTensor | (incomplete) | 128 | 16 (2 elem/warp) | ~100–130 | SM90+ Hopper async |
+
+### 6.1 Tensor Kernel (current best) — `mars_cvfem_hex_kernel_tensor.hpp:30–291`
+
+**Why it wins**:
+1. Full local matrix `lhs[8×8]` in registers
+2. Optimized loads (L87–136): unroll-by-4 for ILP and load reordering
+3. Direct scatter via atomic; sorted CSR cols → binary search (L271–288)
+4. Minimal spilling (~210–230 regs; GH200 has 256 KB/SM regs)
+
+**Launch**:
+```cuda
+numBlocks = (numElements + 255) / 256;
+cvfem_hex_assembly_kernel_tensor<..., 256><<<numBlocks, 256, 0, stream>>>(...);
+```
+Thread-per-element model. No intra-block sync.
+
+**Measured**: 4.60 ms for 10^8 hex on GH200.
+
+**Roofline**:
+- ~3000 FLOPs/elem (12 SCS × shape evals + Jacobian + advection + diffusion)
+- ~500 B/elem mem (with AoS nodes)
+- 6 FLOP/byte; memory roof = 3.9 TB/s × 6 = 23 TFLOPS
+- Actual = 10^8 × 3000 / 4.6 ms ≈ 65 TFLOPS → **21% of FP64 peak**
+- Latency- and atomic-bound, not memory-bound
+
+### 6.2 TensorColored — `mars_cvfem_hex_kernel_tensor_colored.hpp:25–225`
+
+Eliminates atomics. Same as tensor but `+=` direct writes (lines 195, 209,
+217). Driven by per-color element list:
+```cuda
+const int linearIdx = blockIdx.x * blockDim.x + threadIdx.x;
+const int elemIdx = d_elemList[linearIdx];
+```
+
+Dispatch loop (`mars_cvfem_assembler.hpp:165–188`):
+```cuda
+for (int c = 0; c < col->numColors; ++c) {
+    int cBlocks = (col->colorSize(c) + blockSize - 1) / blockSize;
+    cvfem_hex_assembly_kernel_tensor_colored<256>
+        <<<cBlocks, blockSize, 0, stream>>>(col->colorStart(c), ...);
+}
+```
+**Speedup**: 10–15% on contended assembly.
+
+### 6.3 TensorAoS — `mars_cvfem_hex_kernel_tensor_aos.hpp:26–216`
+
+One 72-byte AoS read per node vs 9 separate loads. **3× L2 utilization**
+improvement with same runtime (gather-bound case).
+
+### 6.4 TensorPerip — `mars_cvfem_hex_kernel_tensor_perip.hpp:33–225`
+
+Pre-compute all 64 CSR positions before SCS loop:
+```cuda
+int pos[64];   // L98
+for (int i = 0; i < 8; ++i) {
+    int row_start = matrix->rowPtr[dofs[i]];
+    for (int j = 0; j < 8; ++j) {
+        pos[i*8 + j] = binary_search(...);
+    }
+}
+```
+Then in 12-iter SCS loop:
+```cuda
+int pL = pos[nodeL*8 + n];
+if (pL >= 0) atomicAdd(&matrix->values[pL], diff_coeff);
+```
+Saves 128 regs (lhs[64] doubles → 64 ints), occupancy +10%, ~5% slower
+overall.
+
+**__launch_bounds__(256, 2) variant** (L277–319): forces 2 CTAs/SM. Worse
+on GH200 (prefers wide occupancy).
+
+### 6.5 SmemCache — `mars_cvfem_hex_kernel_smem_cache.hpp:96–349`
+
+Block hash-table dedupes ~400 unique nodes across 256 elements, caches in
+shared memory:
+
+**Phase 1–2** (L134–165): hash-table insert per node ID via `atomicCAS`:
+```cuda
+int h = smem_hash(nid, HT_MASK);
+while (true) {
+    int prev = atomicCAS(&s.hash_keys[h], -1, nid);
+    if (prev == -1 || prev == nid) break;
+    h = (h + 1) & HT_MASK;
+}
+```
+
+**Phase 3–4** (L169–206): sequential slots, cooperative load of node data:
+```cuda
+double* base = s.node_data + sl * 9;
+base[0] = d_x[nid]; base[1] = d_y[nid]; ...
+s.row_start[sl] = matrix->rowPtr[dof];
+```
+
+**Phase 5–6** (L212–349): SCS loop reads from smem (~5 cyc) instead of L2
+(~30 cyc).
+
+Smem footprint: ~53 KB; with `__launch_bounds__(256, 2)`: 106 KB << 228 KB
+GH200 limit.
+
+### 6.6 WmmaTensor — `mars_cvfem_hex_kernel_tensor_wmma.hpp:64–387`
+
+Diffusion = matrix product S^T × D:
+- S[12×8]: per-SCS, nodeL ↔ +1, nodeR ↔ −1
+- D[12×8]: per (SCS, node) diff_coeff
+- C = S^T[8×12] × D[12×8] = lhs_diff[8×8]
+
+Uses FP64 WMMA 8×8×4 (SM80+). 1 warp / element, 8 elements / block.
+
+Three 8×8×4 mma_sync calls = 1536 FLOPs in ~30 cycles.
+
+**Reality**: FP64 WMMA = 67 TFLOPS on GH200 vs 312 TFLOPS scalar peak.
+Matmul too small (1536 FLOP) → latency-dominated. **2–3× slower than
+scalar tensor.** Not a win at this size.
+
+### 6.7 WgmmaTensor — Hopper-only
+
+Async WGMMA m64n8k4. 2 elements/warp, 75% util. Incomplete; experimental.
+
+## 7. Coloring — `mars_cvfem_coloring.hpp:48–157`
+
+Greedy (Jones-Plassmann variant on CPU pre-pass).
+
+1. **Build node→elements CSR** (L64–81): count, scan, fill
+2. **Greedy color** (L88–122):
+```cpp
+std::vector<int> elemColor(numElements, -1);
+std::vector<int> usedBuf(32, 0);
+int tick = 1;
+for (size_t e = 0; e < numElements; ++e) {
+    for (int n = 0; n < 8; ++n) {
+        size_t v = conn[n][e];
+        for (int k = nodeElemOff[v]; k < nodeElemOff[v+1]; ++k) {
+            int nb = nodeElem[k];
+            if (nb != e && elemColor[nb] >= 0)
+                usedBuf[elemColor[nb]] = tick;
+        }
+    }
+    int c = 0;
+    while (usedBuf[c] == tick) ++c;
+    elemColor[e] = c;
+    if (c >= numColors) numColors = c + 1;
+    ++tick;
+}
+```
+**Tick trick**: avoid resetting usedBuf each iteration → O(numElements)
+total instead of O(numElements × maxColor).
+
+3. **Permutation** (L124–140), **upload to device** (L142–156).
+
+Result: typically 8–12 colors unstructured; exactly 8 for structured hex
+(parity i+j+k).
+
+## 8. Dispatch & Config — `mars_cvfem_assembler.hpp`
+
+### Enum (L21–34)
+```cpp
+enum class CvfemKernelVariant {
+    Original, Optimized, Shmem, Team, Tensor, TensorColored, TensorAoS,
+    TensorPerip, TensorPeripLb2, SmemCache, WmmaTensor, WgmmaTensor
+};
+```
+
+### Config (L41–47)
+```cpp
+struct Config {
+    int blockSize = 256;
+    CvfemKernelVariant variant = CvfemKernelVariant::Original;
+    cudaStream_t stream = 0;
+    const CvfemColoringData* coloring = nullptr;   // required for TensorColored
+    const NodeData* nodeData = nullptr;             // required for TensorAoS
+};
+```
+
+### Dispatch (L49–309): `assembleGraphLump()` parses variant, computes
+grid, launches kernel.
+
+**SmemCache special case** — needs explicit cudaFuncSetAttribute:
+```cuda
+cudaFuncSetAttribute(scPtr, cudaFuncAttributeMaxDynamicSharedMemorySize, smemSz);
+cudaFuncSetAttribute(scPtr, cudaFuncAttributePreferredSharedMemoryCarveout, 100);
+scPtr<<<numBlocks, blockSize, smemSz, stream>>>(...);
+```
+
+## 9. Bottleneck Analysis (Tensor on GH200, 10^8 hex)
+
+Estimated breakdown of 4.60 ms:
+
+| Phase | Time | % | Notes |
+|-------|------|---|-------|
+| Gather (nodes + connectivity) | 0.8 ms | 17% | scattered L2 reads |
+| Jacobian + dndx | 1.2 ms | 26% | det+invert latency-bound, no ILP |
+| SCS loop (adv + diff) | 1.5 ms | 33% | atomicAdd contention |
+| CSR scatter | 1.1 ms | 24% | binary search + atomic |
+
+**Optimization targets**:
+1. TensorColored — drop atomics → ~10% faster
+2. TensorAoS — reduce gather L2 traffic → ~5% faster
+3. SmemCache — gather → smem reads → ~5% faster
+4. **Async MPI overlap** — overlap halo with compute → bigger win at scale
+
+Not worth pursuing: WmmaTensor (matmul too small), WgmmaTensor (only Hopper
+async, marginal at best).
+
+## 10. Variant Selection Quickref
+
+| Scenario | Best Variant |
+|----------|--------------|
+| Standard 10^9 hex | Tensor |
+| Atomic contention | TensorColored |
+| Gather-bound | TensorAoS |
+| Reg-pressure | TensorPerip |
+| L2-bound nodes | SmemCache |
+| FP64 tensor cores | not recommended (WmmaTensor too small) |
+| Hopper async | WgmmaTensor (experimental) |
+
+## 11. File Index
+```
+fem/
+  mars_cvfem_assembler.hpp                       L17–502
+  mars_cvfem_hex_kernel.hpp                      L9–481  (constants + baseline)
+  mars_cvfem_hex_kernel_graph.hpp                graph variant
+  mars_cvfem_hex_kernel_optimized.hpp            L56–476 (incl team L268)
+  mars_cvfem_hex_kernel_shmem.hpp                L20–266
+  mars_cvfem_hex_kernel_tensor.hpp               L29–294 (current best)
+  mars_cvfem_hex_kernel_tensor_colored.hpp       L24–228
+  mars_cvfem_hex_kernel_tensor_aos.hpp           L25–219
+  mars_cvfem_hex_kernel_tensor_perip.hpp         L30–322
+  mars_cvfem_hex_kernel_tensor_wmma.hpp          L64–387
+  mars_cvfem_hex_kernel_smem_cache.hpp           L37–352
+  mars_cvfem_coloring.hpp                        L44–157
+  mars_cvfem_node_data.hpp                       L25–86
+  mars_sparse_matrix.hpp
+  mars_sparsity_builder.hpp                      L30–273
+  mars_h1_fe_space.hpp
+```

--- a/docs/reference/04_cstone_focus_tree.md
+++ b/docs/reference/04_cstone_focus_tree.md
@@ -1,0 +1,383 @@
+# Cornerstone Focus Tree, Global Assignment & Tree Subsystems — Deep Reference
+
+Algorithmic depth on cstone internals load-bearing for MARS. For the API
+surface map, see [01_cstone_overview.md](01_cstone_overview.md).
+
+## 1. Hilbert vs Morton Encoding
+
+`include/cstone/sfc/hilbert.hpp`, `include/cstone/sfc/morton.hpp`
+
+Both map 3D coords to 1D SFC keys via bit interleaving. **21 levels for
+uint64_t**, **10 levels for uint32_t** (3 bits per level = octree subdivision).
+
+### Morton (magic-number method)
+`iMorton<KeyType>(ix, iy, iz)`:
+- Expand each coord to 30/63 bits by inserting 2 zero bits between each bit
+  via multiply-and-mask (`expandBits`)
+- Interleave: `key = xx*4 + yy*2 + zz` (Z-order curve)
+- Decode: `compactBits` inverts via shift-XOR parallel prefix
+
+### Hilbert
+`iHilbert<KeyType>(px, py, pz)`:
+- Per level coarse-to-fine, extract 3-bit octant
+- Apply 3D rotation matrix lookup `mortonToHilbert[8] = {0,1,3,2,7,6,4,5}`
+- Apply in-place rotations/reflections (L71–82) to maintain continuity
+
+Default is Hilbert because it preserves locality better (fewer jumps
+between adjacent cells).
+
+**Invariant**: `keyEnd - keyStart` is always a power of 8. `treeLevel(range)
+= log_8(range)`.
+
+Decoding inverts level-by-level (`decodeHilbert` L130–172).
+
+## 2. Cornerstone Tree (csarray)
+
+`include/cstone/tree/csarray.hpp`
+
+**Three invariants** (L19–33):
+1. Vector contains keys 0 and max (2^30 or 2^61)
+2. Sorted ascending
+3. Difference between consecutive keys is a power of 8
+
+Length-N array → N−1 leaf nodes. Leaf `i` spans `[tree[i], tree[i+1])`.
+
+Data: `leaves_: std::vector<KeyType>` of length numNodes+1. **No internal
+nodes stored** — only leaves.
+
+### Rebalance — `csarray.hpp:375–389`
+1. For each node, compute op: merge (0), keep (1), or split (8/64/512/4096)
+2. Exclusive scan `nodeOps` → output indices
+3. For each input node, `processNode()` emits 1, 8, or N new leaves
+4. Last element always copy of original max
+
+### Search
+- `findNodeAbove(tree, n, key)` — lower_bound, first node ≥ key
+- `findNodeBelow(tree, n, key)` — upper_bound − 1, last node ≤ key
+
+## 3. Full Octree
+
+`include/cstone/tree/octree.hpp`
+
+Stores both **internal and leaf nodes** in one linear array (no recursion).
+
+### Members of `OctreeData` (L337–355)
+- `prefixes` — SFC keys with **Warren-Salmon placeholder bits** encoding
+  level (L341, L89). `encodePlaceholderBit(key, 3*level)` packs level
+  into high bits.
+- `childOffsets` — first-child index (0 for leaves)
+- `parents` — parent index, one per group of 8 siblings
+- `levelRange` — first node index per level (level-order access)
+- `leafToInternal` / `internalToLeaf` — between cornerstone (SFC-sorted)
+  and internal (level-order) layouts
+
+### Construction `buildOctreeCpu` — L168–196
+1. `createUnsortedLayoutCpu` — emit leaves and internals; for each leaf
+   pair, compute common prefix at multiples of 3 bits, emit internal at
+   that level (L87–100)
+2. `sort_by_key` reorder by prefix (level-order then SFC)
+3. `linkTreeCpu` — for each internal, find first child via binary search
+   in prefixes one level down; set `childOffsets[i]`, record parent
+   (L115–148)
+
+### Navigation
+- `child(node, octant)` = `childOffsets[node] + octant`
+- `parent(node)` = `parents[(node-1)/8]`
+- `isLeaf(node)` = `childOffsets[node] == 0`
+
+## 4. GlobalAssignment
+
+`include/cstone/domain/assignment.hpp`
+
+### Members (L54–300)
+- `myRank_, numRanks_, bucketSize_, box_`
+- `leaves_` — global tree leaves replicated across all ranks
+- `nodeCounts_` — particles per global leaf
+- `tree_` — full octree on host; `d_csTree_, d_nodeCounts_` on GPU
+- `assignment_: SfcAssignment<KeyType>` — rank → SFC-key boundary
+- `exchanges_: SendRanges` — initial particle distribution
+
+### `assign()` — L93–146
+1. Compute SFC keys for assigned particles, sort
+2. Update global tree via `updateOctreeGlobal` (uses `MPI_Allreduce` MAX
+   per node — `tree/update_mpi.hpp:33–52`)
+3. Recompute rank boundaries via `makeSfcAssignment`
+4. Return required buffer size for next exchange
+
+### Accessors
+- `treeLeaves()` L219 — GPU/CPU view
+- `nodeCounts()` L226
+- `octreeHost()` L243 — always CPU-resident
+- `assignment()` L257
+- `postExchangeStart(bufDesc)` L262 — first locally-assigned particle index
+
+## 5. SfcAssignment
+
+`include/cstone/domain/domaindecomp.hpp:58–127`
+
+### Members
+- `rankBoundaries_` — SFC key per rank boundary (numRanks+1)
+- `counts_` — particles per rank
+- `numNodesPerRank_` — global leaves per rank
+- `treeOffsets_` — cumulative scan of `numNodesPerRank_`
+
+### `findRank(key)` — L96–100
+```cpp
+auto it = std::upper_bound(begin(rankBoundaries_), end(rankBoundaries_), key);
+return int(it - begin(rankBoundaries_)) - 1;
+```
+O(log numRanks).
+
+### `treeOffsets()` L83
+Maps rank `r` → leaf index range `[treeOffsets[r], treeOffsets[r+1])`.
+
+## 6. makeSfcAssignment — Load-Balanced Bucket Split
+
+`domaindecomp.hpp:112–127`
+
+1. `uniformBins(counts, bins, binCounts)` (L34–55):
+   - Inclusive scan `counts` → cumulative distribution
+   - Bin target = total / numRanks
+   - Per rank boundary, binary search in scan for leaf closest to target
+   - Residuals: last bin gets fewer particles
+2. Gather SFC keys at bin boundaries
+3. `numNodesPerRank[i] = treeOffsets[i+1] - treeOffsets[i]`
+
+**Invariant**: each rank gets approx equal counts **respecting tree node
+boundaries** (no splitting).
+
+## 7. FocusedOctree Lifecycle
+
+`include/cstone/focus/octree_focus_mpi.hpp`
+
+### Constructor (L55–79)
+Single-node tree, octree on host or GPU.
+
+### `converge()` — L599–617
+```cpp
+while (converged != numRanks_) {
+    updateMinMac(assignment, invThetaEff, false);
+    converged = updateTree(peers, assignment, globalTreeLeaves, box, scratch);
+    updateCounts(particleKeys, globalTreeLeaves, globalCounts, scratch);
+    updateGeoCenters();
+    MPI_Allreduce(...converged...);
+}
+```
+Per iteration:
+- Recompute MAC acceptance radii from geometric centers
+- Rebalance based on counts and MACs
+- Update leaf counts
+- Update geometric centers
+
+### `updateTree()` — L93–193
+- Transfer leaves from other ranks via `focusTransfer`
+- Enforce mandatory keys (rank/peer boundaries)
+- `CombinedUpdate<KeyType>::updateFocus` (`octree_focus.hpp:65–118`):
+  rebalance loop with MAC refinement
+- Translate global assignment to focus-tree node indices via
+  `translateAssignment` (`domaindecomp.hpp:197–220`)
+- Sync treelets (peer-owned portions) via `syncTreelets`
+
+### `discoverHalos()` — L530–586
+For each assigned focus leaf in `[firstNode, lastNode)`:
+1. Compute bounding box from particle positions+h × searchExt × 2
+2. Walk octree from root; at each node: if its geometric box overlaps
+   bbox AND node is unassigned leaf → mark `macsAcc_[nodeIdx] = 1`
+
+### `computeLayout()` — L588–595
+For each leaf: if assigned or halo → include cumulative range, else zero.
+Returns nonzero error if any halo not matched to a peer.
+
+### `updateCounts()` — L210–269
+1. Local leaf counts via `computeNodeCounts`
+2. Global gather for halo counts via `rangeCount`
+3. Upsweep (sum-of-children) for internal nodes
+4. Exchange counts with peers (MPI p2p)
+5. Second upsweep with peer data
+
+## 8. exchangeRequestKeys — Halo Negotiation
+
+`include/cstone/domain/exchange_keys.hpp:44–99`
+
+1. Each rank extracts SFC key ranges of halo nodes via
+   `extractMarkedElements` (`layout.hpp:111–141`):
+   - Scan layout array; where `layout[i] != layout[i+1]`, add pair
+     `(treeLeaves[i], treeLeaves[i+1])`
+2. Send to each peer via `mpiSendAsync` (tag `haloRequestKeys`)
+3. Receive from peers in any order (`MPI_ANY_SOURCE`)
+4. For each `(lowerKey, upperKey)`:
+   - Binary search in own tree → `lowerIdx, upperIdx`
+   - Add range `[layout[lowerIdx], layout[upperIdx])` to peer's `SendList`
+5. `MPI_Waitall` on sends
+
+**Invariant**: peer A's outgoing halos to B = B's incoming halos from A.
+
+## 9. findPeersMac — Dual-Tree Traversal
+
+`include/cstone/traversal/peers.hpp:47–104`
+
+Inputs: `myRank`, `assignment`, `domainTree`, `box`, `invThetaEff` (1/θ + margin).
+
+Algorithm:
+1. Span assigned SFC range with intermediate keys (L85–87)
+2. Parallel loop over spanning nodes:
+   - `locateNode(key, domainTree)` → containing internal node
+   - `dualTraversal(...)` recurses on (focus_node, global_node) pairs:
+     - `crossFocusPairs(a, b)`: a intersects focus range, b lies outside,
+       MAC fails (geometric boxes too close)
+     - `p2p(a, b)`: extract rank of b from assignment, mark as peer
+3. Return sorted, deduplicated peer list
+
+**MAC test** (L73): `!minMacMutualInt(aBox, bBox, ellipse, pbc)` where
+`ellipse = Vec3<T>{box.ilx(), box.ily(), box.ilz()} * box.maxExtent() *
+invThetaEff * roundOff` (L58).
+
+## 10. discoverHalos Kernel Logic
+
+`include/cstone/focus/octree_focus_mpi.hpp:530–586`
+
+Per assigned focus leaf:
+1. **Bounding box** (L560–578):
+   - `inclusive_scan(leafCountsAcc_)` → cumulative counts
+   - `computeBoundingBox(x, y, z, h, layout[i], layout[i+1], 2*searchExt, ...)`
+2. **Tree traversal** via `findHalos()` CPU or `findHalosGpu`:
+   - Start at root
+   - Per node: if geom box overlaps bbox AND node is halo (not in
+     assigned range) → set `macsAcc_[nodeIdx] = 1`; else if internal →
+     recurse
+
+If `accumulate==true`, OR with existing flags.
+
+## 11. Layout Array
+
+`include/cstone/domain/layout.hpp:143–182`
+
+For focus tree of N leaves, `layout[0..N]` is cumulative particle count:
+- `layout[i]` = buffer index where leaf i's particles start
+- `layout[i+1] - layout[i]` = particles in leaf i (assigned + halos)
+- `layout[N]` = total particles present
+
+Per leaf i: assigned → contiguous start; halo → particles present too;
+neither → zero-width.
+
+`computeNodeLayout` (L152–182):
+```cpp
+for (i = 0; i < numLeaves; ++i) {
+    bool present = (assignedRange covers i) || flags[leafToInternal[i]];
+    layout[i] = present ? leafCounts[i] : 0;
+}
+exclusive_scan(layout);
+```
+
+## 12. Full sync() Data Flow
+
+`include/cstone/domain/domain.hpp:164–206`
+
+1. `distribute()` (`assignment.hpp`): SFC encode → sort → MPI exchange to
+   assigned ranks. Returns `keyView` (SFC-sorted assigned keys), `exchangeStart`
+2. **Reorder to SFC post-exchange** (L182): `gatherArrays` reorders x,y,z,h
+3. `findPeersMac` (L185)
+4. `focusTree.converge()` (L189) — first call only
+5. `focusTree.updateMinMac()` (L193)
+6. `focusTree.updateTree()` (L194)
+7. `focusTree.updateCounts()` (L195)
+8. `focusTree.discoverHalos()` (L198)
+9. `focusTree.computeLayout()` (L200)
+10. `halos_.exchangeRequests()` (L201)
+11. `updateLayout()` (L203) — reorder to final positions
+12. `setupHalos()` (L204) — exchange particle data
+
+Output: x,y,z,h,keys SFC-sorted; assigned `[startIndex, endIndex)`; halos
+beyond. Properties at assigned filled; halo property values undefined
+until next `exchangeHalos()`.
+
+## 13. Reusable Primitives for MARS NodeHaloTopology v2
+
+| Primitive | File:Line | Use |
+|-----------|-----------|-----|
+| `findPeersMac` | peers.hpp:47 | Peer list (already exposed via `domain.peers()` if accessor exists) |
+| `incomingHaloIndices()` | halos.hpp:111 | per-peer single contiguous element range |
+| `outgoingHaloIndices()` | halos.hpp:112 | per-peer multiple ranges (SendManifest) |
+| `gatherRanges` | halos/gather_halos_gpu.h:22 | pack scattered device ranges |
+| `mpiSendGpuDirect` | primitives/mpi_cuda.cuh:31 | GPU-aware send (or staging) |
+| `mpiRecvGpuDirect` | primitives/mpi_cuda.cuh:62 | GPU-aware recv (or staging) |
+| `haloexchange` / `haloExchangeGpu` | exchange_halos.hpp / exchange_halos_gpu.cuh | full pack/MPI/unpack pipeline |
+| `exchangeRequestKeys` | exchange_keys.hpp:44 | negotiate halo ranges via MPI |
+| `computeNodeLayout` | layout.hpp:151 | cumulative offsets from halo flags |
+| `extractMarkedElements` | layout.hpp:111 | extract SFC key pairs for flagged elements |
+
+**No primitive for** "send arbitrary keyed data to peers and merge by key"
+— MARS would need to implement that for node-level halos. Composition idea
+for v2:
+
+```
+1. Have peer list (findPeersMac) and focus tree
+2. Per iteration:
+   a. discoverHalos → mark macsAcc_
+   b. exchangeRequests → incomingHaloIndices, outgoingHaloIndices
+   c. For each peer:
+      - outgoingHaloIndices[peer].scan() → element-buffer offsets
+      - element_id = leaves[offsets[range]]
+      - Launch GPU kernel: gather scattered element data → contiguous peer buffer
+   d. mpiSendGpuDirect (with CUDA-aware MPI)
+   e. mpiRecvGpuDirect for incoming
+   f. Apply received halos to device particle/node buffers
+```
+
+For node halos specifically: derive node sets from element halo ranges,
+then build per-peer (sendNodeIds_, recvNodeIds_) CSRs once at sync, reuse
+each iteration with a thin pack/MPI/unpack wrapper.
+
+## 14. Gordon-Bell Limitations
+
+| Issue | Where | Impact |
+|-------|-------|--------|
+| `MPI_Allgather` of tree | update_mpi.hpp:43, assignment.hpp:117 | full tree replicated; scales to ~1000 ranks; latency dominates beyond |
+| `MPI_Allreduce` in converge | octree_focus_mpi.hpp:615 | global barrier per iter |
+| Host-side rebalancing | csarray.hpp:375 | CPU exclusive_scan + processNode loop; no GPU path for cornerstone rebalance |
+| `computeNodeCounts` per rank | csarray.hpp:182 | O(numLeaves) binary searches in particle keys; OMP-parallel but host |
+| `extractMarkedElements` | layout.hpp:111 | linear scan, no SIMD/GPU |
+| Global octree replicated | assignment.hpp:62 | O(numRanks × bucketSize) memory per rank |
+| SPH bbox loop in discoverHalos | octree_focus_mpi.hpp:530 | kernel per pair, batching limited |
+
+Mitigations:
+- GPU acceleration for tree rebalance (some functions in
+  `cstone/tree/octree_gpu.h` already)
+- Distributed global tree (only own subtree + peer portions)
+- Async MPI collectives (defer Allreduce to compute phases)
+
+## 15. Algorithmic Citations
+
+- **Cornerstone**: Keller et al., SIAM J. Sci. Comput. 2016
+- **Hilbert**: Miki & Umemura, New Astron. 2016 (cited in cstone)
+- **Warren-Salmon placeholder bits**: Warren & Salmon SC93 — internal
+  tree linking (L115–148)
+- **Dual-tree traversal**: standard for FMM/SPH; cstone uses it for peer
+  discovery to avoid O(N²) pair evaluations
+
+## 16. Data Structure Diagram
+
+```
+Global Tree (all ranks have copy)
+├─ leaves[]              cornerstone array (SFC-sorted, invariants 1-3)
+├─ nodeCounts[]          particles per leaf
+└─ octree                Warren-Salmon prefixes, internal+leaf
+
+Focus Tree (per-rank, distributed)
+├─ leaves[]              cornerstone subset (assigned + mandatory)
+├─ octree                full internal+leaf
+├─ leafCountsAcc[]       local + peer particle counts
+├─ centersAcc[] / geoCentersAcc[]    com / geometric centers
+├─ macsAcc[]             MAC pass/fail per node (also halo flags)
+└─ assignment_           peer rank → leaf index ranges
+
+Halo Bookkeeping (Halos<>)
+├─ incomingHaloIndices[rank] = {start, end}    single contiguous range
+├─ outgoingHaloIndices[rank] = SendManifest    multiple ranges
+└─ layout[0..numLeaves]                         cumulative particle offsets
+
+Per-iteration exchange:
+1. discoverHalos → set macsAcc_
+2. exchangeRequests → MPI p2p negotiation
+3. haloexchange → send/recv data (CPU or GPU-direct)
+```

--- a/docs/reference/05_mars_amr_module.md
+++ b/docs/reference/05_mars_amr_module.md
@@ -1,0 +1,490 @@
+# MARS AMR Module — Deep Reference
+
+`backend/distributed/unstructured/amr/`. For ElementDomain/cstone integration
+see [02_mars_overview.md](02_mars_overview.md).
+
+## 1. Directory Contents
+
+| File | Purpose |
+|------|---------|
+| `mars_amr.hpp` | Top-level include |
+| `mars_amr_manager.hpp` | `AmrManager<ElementTag, KeyType, RealType>` orchestrator |
+| `mars_amr_octree.hpp` | Doerfler marking + 1-irregular enforcement |
+| `mars_amr_octree_native.hpp` | cstone-driven AMR (unified DD + AMR) — recommended |
+| `mars_amr_octree_refine.hpp` | `OctreeAlignedRefine` — emits 8 children per marked parent (no dedup) |
+| `mars_amr_hex_refine.hpp` | `HexRefiner` — GPU-native isotropic hex with edge/face dedup |
+| `mars_amr_tet_refine.hpp` | `TetRefiner` — Bey's red 1→8 |
+| `mars_amr_solution_transfer.hpp` | P0 trilinear transfer by parentage |
+| `mars_amr_error_indicator.hpp` | Hex/Tet gradient-based error + Doerfler marking |
+
+## 2. AmrManager — `mars_amr_manager.hpp:190–649`
+
+### Config (struct)
+```cpp
+struct Config {
+    int maxLevels             = 5;
+    RealType refineFraction   = 0.3;
+    RealType coarsenFraction  = 0.03;
+    RealType errorTolerance   = 1e-6;
+    int bucketSize            = 64;
+    int blockSize             = 256;
+    int irregularityIters     = 3;
+    MarkingStrategy strategy  = MarkingStrategy::OctreeNative;  // or Doerfler
+};
+```
+
+### Constructor
+```cpp
+AmrManager(const Config& config = Config{}) : config_(config), currentLevel_(0) {
+    typename AmrOctree<KeyType, RealType>::Config oct;
+    oct.refineFraction  = config_.refineFraction;
+    oct.coarsenFraction = config_.coarsenFraction;
+    oct.maxLevel        = config_.maxLevels;
+    amrOctree_.config() = oct;
+}
+```
+
+### Members
+```cpp
+Config config_;
+int currentLevel_;
+int rank_, numRanks_;
+InitTimings initTimings_;
+DomainPtr domain_;            // ElementDomain<...>
+AmrOctree<KeyType, RealType> amrOctree_;
+OctreeNativeAmr<KeyType, RealType> octreeNativeAmr_;
+```
+
+### initialize() — L248–306
+Two overloads:
+- `initialize(meshFile, rank, numRanks)` (L248–287) — load mesh, build cstone domain, cache coords, init octrees
+- `initialize(domain, rank, numRanks)` (L289–306) — accept pre-built domain
+
+Lap timing (L252–260):
+```cpp
+auto lap = [&t0]() -> float {
+    cudaDeviceSynchronize();
+    MPI_Barrier(MPI_COMM_WORLD);
+    auto t1 = std::chrono::high_resolution_clock::now();
+    float ms = std::chrono::duration<float, std::milli>(t1 - t0).count();
+    t0 = t1;
+    return ms;
+};
+```
+
+### adaptMesh() — L312–570
+
+```cpp
+AmrStats adaptMesh(const RealType* d_errorPerElement,
+                   const RealType* d_nodeSolution,
+                   DeviceVector& d_newNodeSolution);
+```
+
+**Six phases** (each timed with cudaSync + MPI_Barrier):
+
+#### Phase 1: Marking (L356–411, `markTimeMs`)
+
+**OctreeNative path** (L357–367):
+```cpp
+octreeNativeAmr_.markFromOctree(d_errorPerElement, *domain_);
+// no halo exchange, no 1-irregular (octree guarantees conformity)
+```
+
+**Doerfler path** (L369–411):
+```cpp
+amrOctree_.markForRefinement();   // per-element uint8_t marks
+exchangeMarks();                  // promote to int, exchangeHalos, convert back
+amrOctree_.enforce1Irregular();   // iterative propagation
+exchangeMarks();
+```
+
+#### Phase 2: Refinement (L449–456, `refineTimeMs`)
+```cpp
+auto refined = OctreeAlignedRefine::refineLocal(
+    coords, conn, d_marks, startIdx, endIdx);
+// 8 children per marked, 19 new nodes per child for hex
+// numElements_after = 8*numMarked + numUnmarked
+// numNodes_after = oldNumNodes + 19*numMarked
+```
+
+#### Phase 3: Solution Transfer (L465–486, `transferTimeMs`)
+Loop over fields:
+```cpp
+transferred[f] = SolutionTransfer<...>::transferByParentage(
+    refined, oldFields[f], ...);
+```
+**Pre-sync coord save** (L481–485) — to re-encode SFC keys after cstone redistributes.
+
+#### Phase 4: Rebuild (L488–490, `rebuildTimeMs`)
+```cpp
+rebuildDomainFromDevice(refined);    // L607–637
+amrOctree_.reset(*domain_);
+```
+
+#### Phase 5: Reorder/SFC lookup (L492–551, `reorderTimeMs`)
+1. Encode pre-sync coords in NEW box → `d_preKeys` (L496–499)
+2. `thrust::sort_by_key((preKey, value))` per field (L504–514)
+3. For each new local node, binary-search its key in pre-sync sorted table
+   (L534–550)
+
+#### Phase 6: Halo Fill (L553–559, `haloFillTimeMs`)
+```cpp
+for (auto& field : newFields) domain_->exchangeNodeHalo(*field);
+```
+Fills ghosts not reached by binary search (owner on different rank).
+
+### AmrStats — L22–43
+
+```cpp
+struct AmrStats {
+    size_t elementsBeforeLocal, elementsAfterLocal;
+    size_t elementsBeforeGlobal, elementsAfterGlobal;     // via MPI_Allreduce
+    size_t nodesBeforeGlobal, nodesAfterGlobal;
+    size_t elementsRefined;
+    int level;
+    double errorNorm;                                      // globalErrorNorm
+    float totalTimeMs, markTimeMs, refineTimeMs,
+          transferTimeMs, rebuildTimeMs, reorderTimeMs, haloFillTimeMs;
+};
+```
+
+### InitTimings — L238–244
+```cpp
+struct InitTimings {
+    float domainSyncTimeMs;   // file read + bbox + cstone sync
+    float haloTopoTimeMs;     // HaloData + NodeHaloTopology
+    float adjacencyTimeMs;
+    float coordCacheTimeMs;
+    float octreeTimeMs;
+    float totalMs;
+};
+```
+
+### shouldContinue()
+```cpp
+bool shouldContinue(const AmrStats& stats) const {
+    return currentLevel_ < config_.maxLevels &&
+           stats.errorNorm > config_.errorTolerance &&
+           stats.elementsRefined > 0;
+}
+```
+
+## 3. Refinement Strategies
+
+### Doerfler Marking — `mars_amr_octree.hpp:168–223`
+
+```cpp
+RealType maxError = thrust::reduce(d_error, +, thrust::maximum());
+RealType refineThresh  = refineFraction  * maxError;
+RealType coarsenThresh = coarsenFraction * maxError;
+// per-element kernel: mark = (error > refineThresh && level < maxLevel) ? 1 :
+//                            (error < coarsenThresh && level > 0) ? 2 : 0
+```
+
+**1-irregular enforcement** (L189–223): iterate
+```cpp
+for (int it = 0; it < irregularityIters; ++it) {
+    propagateMarksKernel<<<...>>>();   // node-adjacency neighbor check
+    if (thrust::equal(marks_old, marks_new)) break;
+}
+```
+
+### OctreeNative Marking — `mars_amr_octree_native.hpp:156–295`
+
+1. **Scatter errors to leaves** (L210–230): per element, atomically max
+   error into leaf indexed by representative SFC key. atomicCAS-emulated
+   `atomicMax<double>` (L70–80).
+2. **MPI_Allreduce per-leaf errors** (L237–250): copy d_leafError H→ →
+   `MPI_Allreduce(MAX)` → copy back. (Could be GPU-direct.)
+3. **Convert to weighted counts** (L265–269):
+   ```cuda
+   leafCount_weighted = count * (1 + error/maxError * bucketSize);
+   ```
+4. **cstone rebalance decision** (L272–276):
+   ```cpp
+   cstone::computeNodeOpsGpu(treeLeaves, numLeaves, d_weightedCounts,
+                             bucketSize, d_nodeOps);
+   ```
+   Output `nodeOps[]`: 0/1/8/64/... per leaf
+5. **Map leaf decisions to element marks** (L278–291): per local element,
+   look up its leaf, check `nodeOps`. ≥8 → mark=1, ==0 → mark=2, else 0
+
+**No mark exchange** — each rank independently applies leaf ops to its
+elements (cstone determinism).
+
+## 4. Hex Refinement (1 → 8)
+
+### Node numbering — `mars_amr_hex_refine.hpp:26–41`
+
+```
+        7--------6
+       /|       /|       Edges:    0-1, 0-2, 0-3, 0-4 (4×)
+      / |      / |                 1-2, 1-5         (2×)
+     4--------5  |                 2-3, 2-6         (2×)
+     |  3-----|--2                 3-7              (1×)
+     | /      | /                 4-5, 4-7         (2×)
+     |/       |/                  5-6, 6-7         (2×) → 12 total
+     0--------1
+```
+
+**Per marked element, 19 new nodes** (8 corners reused):
+- 12 edge midpoints
+- 6 face centers (bot, top, front, back, left, right)
+- 1 body center
+
+### HexRefiner::refine() — L411–600
+
+1. **Count children** (L427–464):
+   `childCounts[e] = (marks[e] > 0) ? 8 : 1`
+   Exclusive scan → `elemPrefix`. Count marked → `markedPrefix`.
+
+2. **Edge keys + dedup** (L497–508):
+   - `emitEdgeKeysKernel`: 12 edge keys per marked
+   - `EdgeKey::encode(lo, hi) = (hi << 32) | lo`
+   - `thrust::sort + unique` → `numUniqueEdges` (typically 6–7× compression)
+
+3. **Face keys + dedup** (L510–532):
+   - 6 face keys per marked, sorted 4 nodes packed into Lo/Hi pair
+   - `thrust::sort` on `zip(Lo, Hi)` + unique → `numUniqueFaces`
+   (10–12× compression typical)
+
+4. **Allocate + compute coords** (L534–566):
+   - `numNewNodes = oldNumNodes + numUniqueEdges + numUniqueFaces + numMarked`
+   - Edge: midpoint of two corner coords
+   - Face: 0.25× sum of 4 corners
+   - Body: 0.125× sum of 8 corners
+
+5. **Build child connectivity** (L568–583): `buildChildConnectivityKernel`
+   per marked element, 8 children each with connectivity into the 27-point
+   subdivision (corners + edge mids + face centers + body)
+
+### Result struct
+```cpp
+struct Result {
+    DeviceVector d_conn0..7, d_x, d_y, d_z;
+    DeviceVector d_edgeKeys, d_faceKeysLo, d_faceKeysHi, d_markedPrefix, d_marks;
+    size_t numNodes, numElements, numUniqueEdges, numUniqueFaces, numMarked, oldNumNodes;
+    KeyType edgeBaseNode() { return oldNumNodes; }
+    KeyType faceBaseNode() { return oldNumNodes + numUniqueEdges; }
+    KeyType bodyBaseNode() { return oldNumNodes + numUniqueEdges + numUniqueFaces; }
+};
+```
+
+### OctreeAlignedRefine::refineLocal() — `mars_amr_octree_refine.hpp:240–306`
+
+GPU-native, no edge/face dedup. Emits 19 nodes per child directly:
+- Output node IDs: `oldNumNodes + 19*markedPrefix[e] + {0..18}`
+- cstone sync handles dedup via SFC ordering (coincident coords → same key → dedup)
+- **Pro**: no GPU dedup overhead
+- **Con**: 19×numMarked nodes pre-dedup; cstone reduces post-sync
+
+## 5. Tet Refinement (Bey's Red 1 → 8)
+
+`mars_amr_tet_refine.hpp:95–171`
+
+- 4 **corner tets** keep one original vertex + 3 adjacent edge midpoints
+- 4 **octahedron tets** triangulate 6 edge midpoints with consistent
+  diagonal (m01-m23) for quality preservation
+
+`TetRefiner::refine()` (L198–322) is hex-pattern but only edges (no
+face/body). `numNewNodes = oldNumNodes + numUniqueEdges`.
+
+## 6. Solution Transfer
+
+`mars_amr_solution_transfer.hpp`
+
+### Hex `transferByParentage()` — L354–395
+
+Layout post-refinement:
+```
+[0, oldNumNodes)                                              old nodes
+[oldNumNodes, +numUniqueEdges)                                edge mids
+[+numUniqueEdges, +numUniqueFaces)                            face centers
+[+numUniqueFaces, +numMarked)                                 body centers
+```
+
+Two-phase:
+1. `copyOldNodeSolutionsKernel` (L247–255): copy `[0, oldNumNodes)`
+2. `transferByParentageKernel` (L107–196): for each marked element,
+   compute new node values from corners:
+   ```cuda
+   newSol[findEdge(a,b)]   = 0.5  * (u[a] + u[b])
+   newSol[findFace(a,b,c,d)] = 0.25 * (u[a]+u[b]+u[c]+u[d])
+   newSol[bodyNode]        = 0.125 * sum_8(u)
+   ```
+   `findEdge/findFace` = binary search in sorted key arrays.
+
+Multi-field: loop calling per field.
+
+### Tet `transferByParentageTet()` — L397–420
+6 edge midpoints only. No face/body.
+
+## 7. Error Indicators
+
+`mars_amr_error_indicator.hpp`
+
+### Hex (least-squares, L19–102)
+Per element:
+- Build 3×3 Gram `A = Σ(dx_i dx_i^T)`, RHS `b = Σ(dx_i du_i)`
+- Cramer's rule for `grad = A^{-1} b`
+- Det singularity guard: `det threshold = h^4 * 1e-12`
+- `error[e] = h^2 * ||grad||`, h = ³√volume
+- isfinite check
+
+### Tet (exact, L105–161)
+- `J = [dx1 dx2 dx3]^T` (edges from node 0)
+- `grad = J^{-T} [du1 du2 du3]^T` via Cramer
+- `error[e] = h^2 * ||grad||`, h = (6V)^{1/3}, V = det(J)/6
+
+### Doerfler marking — L242–261
+```cpp
+RealType maxError = thrust::reduce(d_error, max);
+RealType thresh = refineFraction * maxError;
+markElementsKernel: mark[e] = (error[e] > thresh) ? 1 : 0
+```
+
+### globalErrorNorm — L263–301
+```cpp
+RealType localSum = thrust::transform_reduce(
+    d_error, d_error+n,
+    [] __device__(RealType e) { return e*e; },
+    RealType(0), thrust::plus<RealType>());
+MPI_Allreduce(&localSum, &globalSum, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+return std::sqrt(globalSum);
+```
+
+`globalErrorNormOwned()` — sums only `[startIdx, endIdx)` to avoid
+double-counting halos.
+
+## 8. Rebuild Flow — `rebuildDomainFromDevice` (L607–637)
+
+```cpp
+template<typename ResultType>
+void rebuildDomainFromDevice(ResultType& refined) {
+    // 1. Wrap refined coords + conn
+    auto coords = std::make_tuple(std::move(refined.d_x), ..., std::move(refined.d_z));
+    auto conn   = std::make_tuple(std::move(refined.d_conn0), ..., std::move(refined.d_conn7));
+
+    // 2. ElementDomain device-data ctor:
+    //    cstone ingests coords + conn → SFC keys → SFC sort → MPI redistribute → element halos
+    domain_ = std::make_unique<Domain>(
+        std::move(coords), std::move(conn), rank_, numRanks_, config_.bucketSize);
+
+    // 3. Lazy init in the order the solver wants
+    (void)domain_->getNodeOwnershipMap();
+    cudaDeviceSynchronize();
+    (void)domain_->getElementToNodeConnectivity();
+    domain_->cacheNodeCoordinates();
+}
+```
+
+**No host round-trip**: coords + conn move directly device → cstone.
+
+**Node dedup**: multiple ranks may emit same (x,y,z). SFC ordering +
+distribution naturally dedup.
+
+## 9. MPI Patterns
+
+| Phase | Pattern | Frequency |
+|-------|---------|-----------|
+| Doerfler mark exchange | Alltoallv (cstone halo) | 2× per level (before + after 1-irregular) |
+| 1-irregular iter | Alltoallv per iter | up to `irregularityIters` |
+| OctreeNative leaf errors | Allreduce(MAX) | 1× per level |
+| Rebuild (cstone sync) | Allgather + Alltoallv | 1× per level |
+| Halo fill | Alltoallv | 1× per field |
+
+**Big win**: OctreeNative eliminates Doerfler's 2–3× Alltoallv on marks.
+
+## 10. Octree Integration with cstone
+
+cstone's octree **is** the AMR data structure. Leaf split/merge directly
+controls element refinement.
+
+`markFromOctree` accesses cstone's global tree (L195–202):
+```cpp
+const auto& globalTree = domain.getDomain().globalTree();
+```
+
+Element keys = min of 8 corner-node SFC keys (representative node
+convention). After refineLocal, new child coords emitted; cstone re-derives
+SFC keys with new bbox during sync. Children's keys fall into parent's
+octree range by construction → SFC sort respects hierarchy.
+
+**Unified DD + AMR**: domain decomposition and refinement use the same
+tree → automatic load balancing, no asynchrony.
+
+## 11. Gordon-Bell Scaling Gotchas
+
+| Concern | Fix / Recommendation |
+|---------|----------------------|
+| Doerfler 2× Alltoallv on marks | Use OctreeNative (zero mark exchange) |
+| O(N) host loops in 1-irregular | OctreeNative skips this entirely |
+| Reorder binary search per node | typically 5–10% of adapt time; linear in `newNumNodes` |
+| Solution transfer per-field serialization | batch transfers if multifield |
+| Hex dedup `thrust::sort/unique` overhead | use `OctreeAlignedRefine` (cstone deduplicates via SFC) |
+| Element halo rebuild via Alltoallv | unavoidable; ~30–40% of adapt time |
+| Memory blowup during transfer | limit refineFraction to <10% if memory-constrained |
+| Error indicator compute (gradient LSQ) | ~2 ms / 10^6 elem on H100; coarsen if hot path |
+
+## 12. Canonical AMR Loop — `mars_amr_poisson.cu:407–450`
+
+```cpp
+using KeyType  = uint64_t;
+using RealType = double;
+
+AmrManager<HexTag, KeyType, RealType>::Config cfg;
+cfg.maxLevels = 3; cfg.refineFraction = 0.3; cfg.bucketSize = 64;
+AmrManager<HexTag, KeyType, RealType> amr(cfg);
+amr.initialize(meshFile, rank, numRanks);
+
+cstone::DeviceVector<RealType> d_nodeSolution;
+AmrStats stats; stats.elementsRefined = 1;
+
+for (int level = 0; level <= amrLevels; ++level) {
+    // 1. SOLVE
+    solvePoisson<KeyType, RealType>(amr.domain(), sourceTerm, kernelVariant,
+                                    blockSize, maxIter, tolerance, rank,
+                                    d_nodeSolution, d_nodeToDof, numOwnedDofs);
+    if (level >= amrLevels) break;
+
+    // 2. ERROR INDICATOR
+    auto d_error = HexErrorIndicator<KeyType, RealType>::computeError(
+        std::get<0>(d_conn).data(), ..., std::get<7>(d_conn).data(),
+        d_nodeSolution.data(), d_x.data(), d_y.data(), d_z.data(),
+        d_nodeToDof.data(), numElements, blockSize);
+
+    // 3. ADAPT
+    cstone::DeviceVector<RealType> d_newSolution;
+    stats = amr.adaptMesh(d_error.data(), d_nodeSolution.data(), d_newSolution);
+    AmrManager<HexTag, KeyType, RealType>::printStats(stats, rank);
+    d_nodeSolution = std::move(d_newSolution);
+
+    // 4. CONVERGENCE
+    if (!amr.shouldContinue(stats)) break;
+}
+```
+
+## 13. Roadmap to 10^9 hex
+
+| Concern | Recommendation |
+|---------|----------------|
+| Marking | OctreeNative (no mark exchange) |
+| Element type | HexTag (19 new nodes per child = smooth interp) |
+| Error indicator | coarse approximation (jumps or residual) for hot loops |
+| Transfer | parentage-based trilinear |
+| Refine fraction | <10% to bound memory peak |
+| MPI scaling | OctreeNative + cstone halo rebuild ~100–200 ms / level at 1000 ranks |
+
+## 14. File Index
+```
+amr/
+  mars_amr.hpp                              top-level include
+  mars_amr_manager.hpp                      L22–649    AmrManager + Stats + InitTimings
+  mars_amr_octree.hpp                       L168–223   Doerfler + 1-irregular
+  mars_amr_octree_native.hpp                L70–295    OctreeNative (cstone-driven)
+  mars_amr_octree_refine.hpp                L240–306   OctreeAlignedRefine::refineLocal
+  mars_amr_hex_refine.hpp                   L26–600    HexRefiner (with edge/face dedup)
+  mars_amr_tet_refine.hpp                   L95–322    TetRefiner (Bey's red)
+  mars_amr_solution_transfer.hpp            L107–420   transferByParentage(Hex/Tet)
+  mars_amr_error_indicator.hpp              L19–301    Hex/Tet gradient + Doerfler + globalErrorNorm
+```

--- a/docs/reference/06_mars_solvers.md
+++ b/docs/reference/06_mars_solvers.md
@@ -1,0 +1,519 @@
+# MARS Solvers & Sparse Matrix Infrastructure — Deep Reference
+
+`backend/distributed/unstructured/solvers/` + `fem/mars_sparse_matrix.hpp`,
+`fem/mars_sparsity_builder.hpp`, `fem/mars_h1_fe_space.hpp`. For dispatcher
+and ElementDomain context see [02_mars_overview.md](02_mars_overview.md).
+
+## 1. Solver Inventory
+
+| File | Type | Key Capability |
+|------|------|----------------|
+| `mars_cg_solver.hpp` | CG | cuSPARSE SpMV, cuBLAS dot, halo callback hook |
+| `mars_cg_solver_with_preconditioner.hpp` | PCG | abstract `Preconditioner` interface |
+| `mars_distributed_cg_solver.hpp` | distrib CG | MPI-aware wrapper over CG |
+| `mars_bicgstab_solver.hpp` | BiCGSTAB | non-symmetric, 6 work vecs, breakdown detection |
+| `mars_gmres_solver.hpp` | GMRES(restart) | Krylov basis, Givens, Hessenberg QR |
+| `mars_hypre_pcg_solver.hpp` | Hypre PCG | IJMatrix/IJVector + BoomerAMG |
+| `mars_hypre_amg_preconditioner.hpp` | precond | standalone BoomerAMG wrapper |
+| `mars_hypre_pcg_eliminated_solver.hpp` | Hypre + elim | DOF elimination strategy |
+| `mars_hypre_pcg_simple_solver.hpp` | Hypre baseline | comparison vs eliminated |
+| `mars_distributed_hypre_pcg_solver.hpp` | distrib Hypre | ParCSR partitioning |
+
+## 2. CG Solver — `mars_cg_solver.hpp`
+
+### Members
+```cpp
+int maxIter_;                              // default 1000
+RealType tolerance_;                       // default 1e-10
+bool verbose_;
+std::function<void(Vector&)> haloExchangeCallback_;
+int ownedSize_;                            // > 0 → MPI_Allreduce on dot products
+cublasHandle_t cublasHandle_;
+cusparseHandle_t cusparseHandle_;
+```
+
+### Constructor (L25–34)
+```cpp
+ConjugateGradientSolver(int maxIter = 1000, RealType tolerance = 1e-10)
+    : maxIter_(maxIter), tolerance_(tolerance), verbose_(true),
+      haloExchangeCallback_(nullptr) {
+    cublasCreate(&cublasHandle_);
+    cusparseCreate(&cusparseHandle_);
+}
+```
+
+### Setup
+- No matrix factorization (Krylov)
+- Diagonal extracted lazily for Jacobi (L203–222 `extractDiagonalKernel`)
+- Diag safety: `diag[i] = 1.0 if |diag[i]| < 1e-14 else diag[i]` (L58–65)
+
+### Solve loop — L129–192
+
+```cpp
+for (int iter = 0; iter < maxIter_; ++iter) {
+    if (haloExchangeCallback_) haloExchangeCallback_(p);   // 1. halo
+    spmv(A, p, Ap);                                         // 2. SpMV
+    RealType pAp = dot(p, Ap);                              // 3. dot (Allreduce if ownedSize_>0)
+    RealType alpha = rho / pAp;
+    axpy(alpha,  p,  x, x);                                 // 4. AXPY
+    axpy(-alpha, Ap, r, r);
+    jacobiPrecondition(diag, r, z);                         // 5. precond
+    RealType r_norm = std::sqrt(dot(r, r));                 // 6. converge check
+    if (r_norm / b_norm < tolerance_) return true;
+    RealType beta = rho_new / rho;
+    axpbyPartial(1.0, z, beta, p, m);                       // 7. update p
+    rho = rho_new;
+}
+```
+
+### Halo exchange — L132–134, L202–205
+```cpp
+void setHaloExchangeCallback(std::function<void(Vector&)> cb) { haloExchangeCallback_ = cb; }
+```
+For rectangular matrices (m owned rows, n total cols), `p` sized to `n`.
+Callback fills `p[m:n]` with neighbor values before SpMV.
+
+### SpMV (cuSPARSE) — L215–271
+```cpp
+cusparseCreateCsr(&matA, A.numRows(), A.numCols(), A.nnz(),
+                  A.rowOffsetsPtr(), A.colIndicesPtr(), A.valuesPtr(),
+                  CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
+                  CUSPARSE_INDEX_BASE_ZERO, CUDA_R_64F);
+cusparseCreateDnVec(&vecX, x.size(), x.data(), CUDA_R_64F);
+cusparseCreateDnVec(&vecY, y.size(), y.data(), CUDA_R_64F);
+
+size_t bufferSize = 0;
+cusparseSpMV_bufferSize(handle, NON_TRANSPOSE, &alpha, matA, vecX,
+                        &beta, vecY, CUDA_R_64F, ALG_DEFAULT, &bufferSize);
+void* buffer; cudaMalloc(&buffer, bufferSize);
+cusparseSpMV(handle, NON_TRANSPOSE, &alpha, matA, vecX, &beta, vecY,
+             CUDA_R_64F, ALG_DEFAULT, buffer);
+cudaFree(buffer);
+```
+
+**⚠ Bug 1**: `CUSPARSE_INDEX_32I` limits to ~2.1B nonzeros. At 10^9
+elements on 1000 ranks this is fine per-rank, but watch for
+single-rank matrix indexing.
+
+**⚠ Bug 2**: alloc/free of `buffer` per call. Cache it.
+
+### Dot product — L279–307
+```cpp
+size_t n = (ownedSize_ > 0) ? size_t(ownedSize_) : std::min(x.size(), y.size());
+RealType local = 0;
+cublasDdot(cublasHandle_, n, x.data(), 1, y.data(), 1, &local);
+if (ownedSize_ > 0) {
+    int initialized = 0; MPI_Initialized(&initialized);
+    if (initialized) {
+        RealType global = 0;
+        auto type = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+        MPI_Allreduce(&local, &global, 1, type, MPI_SUM, MPI_COMM_WORLD);
+        return global;
+    }
+}
+return local;
+```
+
+### Convergence — L163–182
+Relative tolerance: `||r||_2 / ||b||_2 < tol`.
+
+## 3. BiCGSTAB — `mars_bicgstab_solver.hpp:92–208`
+
+For non-symmetric / saddle-point / convection-dominated.
+
+```cpp
+Vector r, r0, p, v, s, t;   // 6 work vecs
+for (int iter = 0; iter < maxIter_; ++iter) {
+    spmv(A, p, v);
+    RealType alpha = rho / dot(r0, v);
+    s = r - alpha*v;
+    if (||s|| / ||b|| < tol) { x += alpha*p; return true; }
+    spmv(A, s, t);
+    RealType omega = dot(t, s) / dot(t, t);
+    x += alpha*p + omega*s;
+    r = s - omega*t;
+    if (|r0^T r| < 1e-30) return false;            // breakdown (L102, 137, 178)
+    rho_new = dot(r0, r);
+    beta = (rho_new / rho) * (alpha / omega);
+    p = r + beta*(p - omega*v);
+    rho = rho_new;
+}
+```
+
+vs CG:
+- 2 SpMV/iter
+- No symmetry needed
+- Breakdown possible
+- Memory: 6 vecs vs 4
+
+## 4. GMRES(restart) — `mars_gmres_solver.hpp:39–231`
+
+For ill-conditioned, singular, or when CG stalls.
+
+```cpp
+std::vector<Vector> V(restart_ + 1);   // (m+1) × n basis
+
+for (int outer = 0; outer < maxIter_ / restart_; ++outer) {
+    r = b - A*x;
+    if (usePreconditioner) r = M^{-1} r;
+    beta = ||r||;
+    V[0] = r / beta;
+    s[0] = beta;
+
+    for (j = 0; j < restart_; ++j) {                 // Arnoldi
+        w = A * V[j];
+        if (usePreconditioner) w = M^{-1} w;
+        for (i = 0; i <= j; ++i) {                   // mod Gram-Schmidt
+            H[i][j] = w^T V[i];
+            w -= H[i][j] * V[i];
+        }
+        H[j+1][j] = ||w||;
+        V[j+1] = w / H[j+1][j];
+        // Givens rotations on H[i:i+1, j], i = 0..j-1
+        // New rotation
+        cs[j] = H[j][j] / h_norm; sn[j] = H[j+1][j] / h_norm;
+        s[j+1] = -sn[j]*s[j]; s[j] = cs[j]*s[j];
+    }
+    // Back-solve H y = s; x += V*y
+}
+```
+
+Memory: (m+1) × n. Typical m=30. Per-iter: 1 SpMV + O(j²) inner products.
+
+## 5. Preconditioners
+
+### Jacobi (diagonal) — embedded in CG files
+
+```cpp
+class JacobiPreconditioner : public Preconditioner<...> {
+    void setup(const Matrix& A) override {
+        diag_ = A.getDiagonal();
+        thrust::transform(diag_.begin(), diag_.end(), diag_.begin(),
+                         [] __device__(RealType d) {
+                             return std::abs(d) > 1e-14 ? d : RealType(1.0);
+                         });
+    }
+    void apply(const Vector& r, Vector& z) override {
+        thrust::transform(r.begin(), r.end(), diag_.begin(), z.begin(),
+                         thrust::divides<RealType>());
+    }
+};
+```
+
+Build O(nnz). Apply O(numRows). Excellent for diagonally dominant.
+
+### AMG (Hypre BoomerAMG) — `mars_hypre_amg_preconditioner.hpp`
+
+```cpp
+void setup(const Matrix& A) override {
+    HYPRE_IJMatrixCreate(comm_, ilower_, iupper_, ilower_, iupper_, &A_hypre_);
+    HYPRE_IJMatrixSetObjectType(A_hypre_, HYPRE_PARCSR);
+    HYPRE_IJMatrixInitialize(A_hypre_);
+    for (int i = 0; i < m_; ++i) {
+        // ... HYPRE_IJMatrixSetValues row-by-row
+    }
+    HYPRE_IJMatrixAssemble(A_hypre_);
+    HYPRE_IJMatrixGetObject(A_hypre_, (void**)&parcsr_A_);
+
+    HYPRE_BoomerAMGCreate(&precond_);
+    HYPRE_BoomerAMGSetCoarsenType(precond_, 6);     // Falgout
+    HYPRE_BoomerAMGSetRelaxType(precond_, 6);       // SymGS / hybrid
+    HYPRE_BoomerAMGSetNumSweeps(precond_, 1);
+    HYPRE_BoomerAMGSetMaxLevels(precond_, 20);
+    HYPRE_BoomerAMGSetup(precond_, parcsr_A_, NULL, NULL);
+}
+```
+
+Build O(nnz × log L). Apply O(L × nnz_coarse), 5–15 FLOPs/nnz typical.
+Robust for SPD elliptic.
+
+## 6. Hypre Integration — `mars_hypre_pcg_solver.hpp:46–78`
+
+```cpp
+template<typename KeyType>
+bool solve(const Matrix& A, const Vector& b, Vector& x,
+           IndexType globalDofStart, IndexType globalDofEnd,
+           IndexType globalColStart, IndexType globalColEnd,
+           const std::vector<KeyType>& localToGlobalDof);
+```
+
+- Row partition: `[globalDofStart, globalDofEnd)` — owned rows
+- Col partition: `[globalColStart, globalColEnd)` — ghost cols, monotonic across ranks
+- For rectangular matrices: row indices in owned range, column indices in
+  global DOF space, off-diagonal remote entries properly indexed
+
+## 7. Sparse Matrix CSR — `mars_sparse_matrix.hpp`
+
+```cpp
+template<typename IndexType, typename RealType, typename AcceleratorTag>
+class SparseMatrix {
+    using DeviceVectorIndex = typename mars::VectorSelector<IndexType, AcceleratorTag>::type;
+    using DeviceVectorReal  = typename mars::VectorSelector<RealType,  AcceleratorTag>::type;
+private:
+    IndexType numRows_;        // m (owned DOFs in distrib)
+    IndexType numCols_;        // n (owned + ghost)
+    IndexType nnz_;
+    DeviceVectorIndex d_rowOffsets_;   // [m+1]
+    DeviceVectorIndex d_colIndices_;   // [nnz]
+    DeviceVectorReal  d_values_;       // [nnz]
+};
+```
+
+`IndexType` typically `int32_t`. **Limit at ~2.1B nonzeros** (cuSPARSE
+INDEX_32I). int64 path needs CUSPARSE_INDEX_64I and `IndexType=int64_t`.
+
+### Atomic add — L239–250
+```cpp
+template<typename RealType, typename IndexType>
+__device__ inline void atomicAddSparseEntry(
+    RealType* values, const IndexType* colIndices,
+    IndexType rowStart, IndexType rowEnd,
+    IndexType col, RealType value)
+{
+    int idx = findColumnIndex(colIndices, rowStart, rowEnd, col);
+    if (idx >= 0) atomicAdd(&values[idx], value);
+    // silent drop if column not in pattern
+}
+```
+Column must exist in sparsity. `buildGraphSparsity` from connectivity
+guarantees all (i,j) pairs within element nodes exist.
+
+### Distributed off-diagonal layout
+```
+A = [ A_own  A_ghost ]
+    [m × m  m × n_ghost]
+```
+Halo exchange fills `x[m:n]` before SpMV; `y[0:m]` accumulates contributions
+from all columns.
+
+## 8. Sparsity Builder — `mars_sparsity_builder.hpp`
+
+### Graph (7 NNZ/row) — `buildGraphSparsity`
+```cpp
+size_t numEdges = numElements * 12 * 2;
+buildSparsityEdgeListKernel<<<...>>>(
+    d_conn0..7, d_nodeToDof, numElements,
+    d_edgeRow.data(), d_edgeCol.data());
+
+// Diag entries
+thrust::sequence(d_diagRow.begin(), d_diagRow.end());
+thrust::sequence(d_diagCol.begin(), d_diagCol.end());
+
+// Merge edges + diag
+// Remove invalid (-1)
+// thrust::sort by (row, col)
+// thrust::unique → nnz
+
+// Histogram + scan → rowPtr
+thrust::device_vector<int> d_rowCounts(numDofs, 0);
+thrust::for_each(d_allRow.begin(), d_allRow.end(),
+    [counts] __device__ (int row) { atomicAdd(&counts[row], 1); });
+thrust::exclusive_scan(d_rowCounts.begin(), d_rowCounts.end(), d_rowPtr.begin());
+```
+
+### Full (27 NNZ/row)
+```cpp
+// emit all 8×8 = 64 pairs per element
+for (int i = 0; i < 8; ++i)
+    for (int j = 0; j < 8; ++j) {
+        edgeListRow[base + i*8 + j] = dofs[i];
+        edgeListCol[base + i*8 + j] = dofs[j];
+    }
+```
+
+| Metric | Graph (7 NNZ) | Full (27 NNZ) |
+|--------|---------------|---------------|
+| Assembly | edge flux only | full element stiffness |
+| SpMV | sparser (faster) | denser |
+| Use case | Poisson, advection-diffusion | elasticity, coupled |
+
+## 9. DOF Mapping — `mars_h1_fe_space.hpp`
+
+```cpp
+H1FESpace(Domain& domain, int order = 1)
+    : domain_(domain), order_(order)
+{
+    const auto& ownership = domain_.getNodeOwnershipMap();
+    size_t numNodes = domain_.getNodeCount();
+    thrust::host_vector<uint8_t> h_ownership(numNodes);
+    thrust::copy(/* D2H copy */);
+    numDofs_ = 0;
+    for (size_t i = 0; i < numNodes; ++i) {
+        if (h_ownership[i] == 1 || h_ownership[i] == 2) numDofs_++;
+        // ghost (==0) NOT counted
+    }
+}
+```
+
+Ownership semantics:
+- `1`: owned (contributes to RHS)
+- `2`: shared (on partition boundary; needed for assembly, dual-owned)
+- `0`: ghost (read-only copy)
+
+## 10. Boundary Conditions — `mars_boundary_conditions.hpp`
+
+### Dirichlet by row replacement — L57–92
+```cuda
+__global__ void applyDirichletKernel(
+    const IndexType* boundaryDofs, IndexType numBoundaryDofs, RealType bcValue,
+    const IndexType* rowOffsets, const IndexType* colIndices,
+    RealType* values, RealType* rhs, IndexType numRows)
+{
+    IndexType idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= numBoundaryDofs) return;
+    IndexType row = boundaryDofs[idx];
+    rhs[row] = bcValue;
+    for (IndexType i = rowOffsets[row]; i < rowOffsets[row+1]; ++i) {
+        values[i] = (colIndices[i] == row) ? RealType(1.0) : RealType(0.0);
+    }
+}
+```
+
+**⚠ Symmetry concern**: Row replacement preserves A[i, :] for interior
+rows but A[j, i] for boundary col j is non-zero, so matrix becomes
+non-symmetric. Two-step elimination (kernels at L95–225) restores symmetry.
+
+### Two-step elimination — L95–225
+```cuda
+// Step 1: subtract boundary contributions from interior RHS
+__global__ void eliminateBCStep1Kernel(...) {
+    if (!isBoundaryRow(row, boundaryDofs)) {
+        for (each entry in row) {
+            if (isBoundaryDof(col, boundaryDofs))
+                rhs[row] -= values[i] * bcValue;
+        }
+    }
+}
+
+// Step 2: zero boundary rows/cols
+__global__ void eliminateBCStep2Kernel(...) {
+    // boundary rows → identity
+    // interior rows → zero columns at boundary DOFs
+}
+```
+Result: block-diagonal with boundary DOFs decoupled.
+
+## 11. Per-Iteration Cost (10^6 elem/rank, 7-NNZ, 4 ranks)
+
+| Op | Cost | Notes |
+|----|------|-------|
+| Halo exchange | 1–2 ms | latency-bound, ~100 KB ghost @ 50 GB/s |
+| SpMV (cuSPARSE) | 2–3 ms | 7M nonzeros, memory-bound, ~16 GB/s utilization |
+| Dot product | 0.1 ms local + 0.5 ms Allreduce | latency-bound |
+| Precond apply (Jacobi) | 0.2 ms | thrust::transform |
+| AXPY ×3 | 0.3 ms | cuBLAS small-vec, latency-bound |
+| **Total** | **4–7 ms** | dominated by SpMV + halo |
+
+Convergence: CG SPD elliptic ~√κ iters. κ=100–1000 → 10–30 iters typical.
+Total solve: 40–210 ms.
+
+Weak scaling p=4: SpMV flat, halo +1 ms, Allreduce +0.3 ms (log p),
+~30% MPI overhead per iter.
+
+## 12. Identified Bugs
+
+1. **CUSPARSE_INDEX_32I** (L227 `mars_cg_solver.hpp`) limits to 2.1B nnz.
+   Fix: parameterize, use INDEX_64I when `IndexType=int64_t`.
+2. **SpMV buffer alloc/free per call** (L233–241). Fix: cache descriptor +
+   buffer per solver instance.
+3. **BC row replacement breaks symmetry**. Fix: use elimination Step1+Step2
+   when symmetry critical.
+4. **Halo column off-diagonal**: cstone halo exchange must run before SpMV
+   (driven by `setHaloExchangeCallback`). If not set, off-rank columns
+   read stale data. Sparsity builder uses `numTotalDofs` (owned + ghost)
+   to ensure cols exist locally.
+
+## 13. Solver Selection Quickref
+
+| Problem | Best |
+|---------|------|
+| SPD elliptic, well-conditioned | CG |
+| Non-symmetric, steady | BiCGSTAB |
+| Ill-conditioned, singular | GMRES(30) |
+| Large distributed elliptic | Hypre PCG + BoomerAMG |
+
+## 14. Canonical Solve — `mars_cvfem_graph.cu`
+
+### Domain setup (L119–132)
+```cpp
+ElementDomain<ElemTag, RealType, KeyType, cstone::GpuTag> domain(
+    meshFile, rank, numRanks, true, bucketSize);
+size_t nodeCount = domain.getNodeCount();
+size_t elementCount = domain.getElementCount();
+```
+
+### DOF map (L138–144)
+```cpp
+cstone::DeviceVector<int> d_nodeToDof(nodeCount);
+int numDofs = buildDofMappingGpu<KeyType>(
+    d_nodeOwnership.data(), d_nodeToDof.data(), nodeCount);
+int numTotalDofs = static_cast<int>(nodeCount);
+```
+
+### Sparsity (L149–189)
+```cpp
+const auto& d_conn = domain.getElementToNodeConnectivity();
+cstone::DeviceVector<int> d_rowPtr(numTotalDofs + 1);
+cstone::DeviceVector<int> d_colInd, d_diagPtr(numTotalDofs);
+int nnz = CvfemSparsityBuilder<KeyType>::buildGraphSparsity(
+    std::get<0>(d_conn).data(), ..., std::get<7>(d_conn).data(),
+    elementCount, d_nodeToDof.data(), numTotalDofs,
+    d_rowPtr.data(), nullptr, nullptr, 0);
+d_colInd.resize(nnz);
+CvfemSparsityBuilder<KeyType>::buildGraphSparsity(
+    ..., d_colInd.data(), d_diagPtr.data(), 0);
+```
+
+### Assembly (L199–240+)
+```cpp
+domain.cacheNodeCoordinates();
+const auto& d_x = domain.getNodeX();
+// ... allocate d_rhs, d_values, build CSR matrix wrapper ...
+// dispatch: CvfemHexAssembler::assemble(d_matrix, d_x, ..., kernelVariant);
+```
+
+### BC (from `mars_ex1_poisson.cu`, L223–250)
+```cpp
+std::vector<bool> isBoundaryDOF(totalLocalDofs, false);
+for (size_t i = 0; i < h_x.size(); ++i)
+    if (std::abs(h_x[i] - 0.0) < 1e-6 || std::abs(h_x[i] - 8.0) < 1e-6)
+        isBoundaryDOF[i] = true;
+std::vector<KeyType> boundaryDofs;
+for (size_t i = 0; i < isBoundaryDOF.size(); ++i)
+    if (isBoundaryDOF[i]) boundaryDofs.push_back(i);
+BoundaryConditionHandler<...> bc;
+bc.applyDirichlet(fes, K, b, boundaryDofs, 0.0);
+```
+
+### Solve (from `mars_ex1_poisson.cu`, L280–310)
+```cpp
+ConjugateGradientSolver<RealType, IndexType, AcceleratorTag> solver(maxIter, tolerance);
+solver.setVerbose(true);
+solver.setOwnedSize(numDofs);
+// solver.setHaloExchangeCallback([&](Vector& p) { dofHandler.updateGhostDofValues(p); });
+cstone::DeviceVector<RealType> x(numTotalDofs, 0.0);
+bool converged = solver.solve(K, b, x);
+```
+
+## 15. File Index
+```
+solvers/
+  mars_cg_solver.hpp                       L25–307 (single + distrib base)
+  mars_cg_solver_with_preconditioner.hpp   PCG abstraction
+  mars_distributed_cg_solver.hpp           MPI wrapper
+  mars_bicgstab_solver.hpp                 L92–208
+  mars_gmres_solver.hpp                    L39–231
+  mars_hypre_pcg_solver.hpp                L46–78
+  mars_hypre_amg_preconditioner.hpp        BoomerAMG wrapper
+  mars_hypre_pcg_eliminated_solver.hpp     DOF elim variant
+  mars_hypre_pcg_simple_solver.hpp         baseline
+  mars_distributed_hypre_pcg_solver.hpp    distrib Hypre
+
+fem/
+  mars_sparse_matrix.hpp                   CSRMatrix struct, atomicAdd helpers
+  mars_sparsity_builder.hpp                L30–273 graph + full
+  mars_h1_fe_space.hpp                     H1FESpace, DOF mapping
+
+utils/
+  mars_boundary_conditions.hpp             L57–225 row replacement + elimination
+```

--- a/docs/reference/07_mfem_node_ownership.md
+++ b/docs/reference/07_mfem_node_ownership.md
@@ -1,0 +1,183 @@
+# MFEM's Node-Ownership and Halo Exchange — Reference for MARS
+
+Sourced from a parallel deep-read of MFEM source by an Explore agent
+(2026-05). Saved here as durable context. Citations are to MFEM source
+files; verify against current github HEAD before treating as gospel.
+
+## TL;DR
+
+MFEM avoids the runtime claim/merge protocol entirely. **Node ownership
+is deterministic and pre-computed at mesh construction**:
+
+1. For each shared vertex, MFEM builds an `IntegerSet` containing the
+   ranks of all elements touching it.
+2. `IntegerSet::Recreate()` (`general/sets.cpp`) sorts the ranks
+   ascending and removes duplicates.
+3. `GroupTopology::Create()` (`general/communication.cpp`) calls
+   `PickElementInSet(group_id)`, which returns `data[0]` — the **lowest
+   rank in the sorted set**.
+4. That lowest rank is the master for the entire simulation. No
+   per-iteration negotiation, no claim merge, no min-rank-wins recompute.
+
+The **3+-way corner problem doesn't arise** because every rank that
+touches the same vertex computes the same sorted IntegerSet → the same
+lowest-rank master.
+
+## Key data structures
+
+| Structure | File | Purpose |
+|-----------|------|---------|
+| `IntegerSet` | `general/sets.cpp` | Sorted, deduped rank list per shared entity |
+| `ListOfIntegerSets` | `general/sets.cpp` | One IntegerSet per group |
+| `GroupTopology` | `general/communication.cpp` | Master per group, group ⇄ ranks topology |
+| `ldof_group[ldof]` | `fem/pfespace.cpp` | Group ID this DOF belongs to (0 = local-only) |
+| `ldof_ltdof[ldof]` | `fem/pfespace.cpp` | True-DOF index if I'm master, -2 if not |
+| `svert_lvert` | `mesh/pmesh.hpp` | shared-vertex → local-vertex map |
+| `group_svert` | `mesh/pmesh.hpp` | group → shared-vertex Table |
+
+## Construction flow (per rank)
+
+```
+1. Mesh partitioner assigns rank to each element (input).
+2. ParMesh builds vertex→element adjacency (Table).
+3. For each vertex, replace element indices with their partition ranks.
+4. If this rank's MyRank appears AND others appear → vertex is shared.
+5. Build IntegerSet from those ranks; sort ascending, dedupe.
+6. GroupTopology stores all distinct IntegerSets.
+7. For each group: master rank = IntegerSet[0] (lowest).
+8. ParFiniteElementSpace marks each DOF as -1 (mine) or -2 (someone else's).
+9. Master ranks number their owned DOFs; broadcast counts so slaves can
+   compute global true-DOF numbering.
+```
+
+This is O(local boundary), runs once.
+
+## Per-iteration halo exchange
+
+`GroupCommunicator` provides `Bcast()` (master → slaves) and `Reduce()`
+(slaves → master, with reduction op).
+
+**Two modes:**
+- `byGroup`: per-group point-to-point. One Isend per (group, slave).
+- `byNeighbor` (default): aggregate all DOFs destined for neighbor N
+  into one buffer, one Isend per neighbor. Minimizes message count.
+
+**Not persistent** (fresh Isend/Irecv per call), **not Alltoallv**. All
+MPI is point-to-point organized by neighbor rank.
+
+## How a 3-way corner resolves
+
+Vertex shared by ranks {1, 3, 7}:
+- Each rank independently builds `IntegerSet = {1, 3, 7}` (sorted).
+- All three call `PickElementInSet → 1`.
+- Rank 1 marks DOF as owned (-1 → ltdof = N).
+- Ranks 3 and 7 mark DOF as -2.
+- Per-iteration: rank 1 broadcasts to ranks 3 and 7. Ranks 3 and 7
+  receive from rank 1.
+
+Zero ambiguity. Zero per-iteration logic to determine who sends to whom.
+
+## What MFEM doesn't do (and why it matters)
+
+- **No "I might own it / they might own it" runtime resolution.**
+  Ownership is set in stone at mesh construction.
+- **No SFC-key key/value claim list exchange.** MFEM uses local element
+  adjacency; the rank-set comes from the partitioner output.
+- **No yielding of duplicate ownership during runtime.** If a corner is
+  shared, the sorted rank list answers "who owns it" deterministically.
+
+## How this differs from our v2
+
+| Aspect | MARS v2 | MFEM |
+|--------|---------|------|
+| When ownership is set | At first NodeHaloTopology build (per-iteration if rebuilt) | Once at mesh construction |
+| Claim mechanism | (sfc_key, my_rank) sent to peers, min-rank-wins on receive | Sorted IntegerSet of ranks touching the entity |
+| 3+-way correctness | Requires every rank in the corner-set to be in the peer subgroup | Automatic — every rank touching the vertex sees the same rank set |
+| Per-iter cost | Pack/MPI/Unpack (correct shape) | Same: pack/MPI/Unpack |
+| Initialization cost | One subgroup p2p exchange + sort_unique merge | Local table build + small Allgatherv on shared-DOF counts |
+
+## Recommendations distilled
+
+The agent gave 10 recommendations; the load-bearing ones for us:
+
+**R1. Replace claim-merge with sorted-rank-set determinism.** Don't ask
+"who claims it" — ask "what's the sorted set of ranks that touch it?"
+Lowest is master. Same answer on every rank because the set is the same.
+
+**R2. Build ownership once.** GroupTopology in MFEM lives for the
+simulation. Our `NodeHaloTopology` already does this — but our v2 attempt
+re-derives ownership each construction; it should be cached and reused.
+
+**R3. byNeighbor aggregation.** Already what `exchangeNodeHalo()` does
+post-construction. ✓
+
+**R5. Validate consensus with Allreduce(MAX) of owner per key.** Cheap
+debug check we should add to `validateAgainstHost`.
+
+**R6. Use SFC key as the unique node identifier.** Already what we do
+via `d_localToGlobalSfcMap_`. ✓
+
+**R8. Test 3-way and 8-way corners explicitly.** We're hitting this
+on cube16/4 (8-way center), cube256/16 (multiple 8-way corners), etc.
+
+## What this means for our in-flight v2 fix
+
+The bug we hit (rank 0 receiving zero recvs) is not a fundamental
+architectural problem. Our approach **is** sorted-rank-set determinism,
+just expressed differently:
+
+- MFEM: every rank builds `IntegerSet{ranks_touching_corner}` from local
+  element adjacency, then takes lowest.
+- MARS v2: every rank publishes its claim, every other rank merges all
+  peers' claims, takes lowest.
+
+Mathematically equivalent **if the published claim set on every rank
+exactly equals the rank's true element-touching set**. The bug we found
+(`d_nodeOwnership` was Step-2-biased, so we under-claimed) is exactly
+the failure mode of "claim set ≠ touching set." The fix already in
+flight (`markLocallyClaimedKernel` rebuilding "I claim from local
+elements") closes that gap.
+
+So the MFEM read is **validating, not redirecting**. Our trajectory is
+correct; we just had a subtle bug in *how* we computed "I touch this
+corner via a local element."
+
+## Two specific changes to consider after Gate 1 passes
+
+Both are post-correctness optimizations, not blockers:
+
+1. **Cache ownership across NodeHaloTopology rebuilds.** AMR triggers
+   a rebuild via `domain_ = make_unique<Domain>(...)`. If the partition
+   doesn't change, ownership doesn't change either. Skip the tiebreaker
+   exchange.
+
+2. **Add the Allreduce-MAX consensus check (R5) to `validateAgainstHost`.**
+   Currently we only diff against the host path's output. Adding "every
+   rank's owner array is consistent with every other rank's" catches
+   bugs the host comparison can't (e.g., if the host path itself has a
+   determinism issue at scale that we've never noticed).
+
+## File index (MFEM source)
+
+```
+mfem/general/
+  sets.cpp             IntegerSet::Recreate (sort + dedupe)
+                       IntegerSet::PickElement (returns data[0])
+  communication.hpp    GroupTopology, GroupCommunicator, Mode enum
+  communication.cpp    GroupTopology::Create
+                       GroupCommunicator::Bcast / Reduce
+                       byGroup vs byNeighbor MPI patterns
+mfem/mesh/
+  pmesh.hpp            ParMesh public surface (svert_lvert, group_svert)
+  pmesh.cpp            FindSharedVertices, FindSharedFaces, etc.
+mfem/fem/
+  pfespace.hpp         ParFiniteElementSpace
+  pfespace.cpp         ConstructTrueDofs (-1/-2 marker logic)
+                       True DOF numbering broadcast
+```
+
+## Cite-with-care note
+
+Agent didn't paste exact line numbers because it browsed via web
+fetches; treat the file paths as authoritative but verify line numbers
+against current MFEM HEAD if you need to cite them in a paper.

--- a/docs/reference/INDEX.md
+++ b/docs/reference/INDEX.md
@@ -1,0 +1,57 @@
+# MARS + Cornerstone Reference Library
+
+Durable, citation-heavy reference docs gathered from deep reads of both repos.
+Use these as the source of truth for API surfaces, algorithms, and gotchas.
+Each doc was written from a full-source read by an exploration agent and saved
+here so we can re-consult across sessions.
+
+Generated 2026-04-30 on branch `cstone`.
+
+## Cornerstone-Octree (the dependency)
+
+- [01_cstone_overview.md](01_cstone_overview.md) — repo layout, core types, Domain
+  class, halo subsystem, SFC machinery, MPI utilities, reusable primitives
+  table, build flags. The "what is in cstone and how do I call it" doc.
+- [04_cstone_focus_tree.md](04_cstone_focus_tree.md) — algorithmic depth on
+  Hilbert/Morton encoding, cornerstone tree, full octree linking, GlobalAssignment,
+  SfcAssignment, makeSfcAssignment, FocusedOctree lifecycle (converge,
+  discoverHalos, computeLayout), exchangeRequestKeys, findPeersMac dual-tree
+  traversal, full sync() data flow, primitives reusable for MARS NodeHaloTopology v2.
+
+## MARS (this repo)
+
+- [02_mars_overview.md](02_mars_overview.md) — top-level architecture,
+  ElementDomain layout, AdjacencyData CSR, HaloData / NodeHaloTopology, CVFEM
+  assembly path, solver flow, AMR pipeline, examples, helpers, connectivity
+  conventions, **identified bugs in current state**, build system.
+- [03_mars_cvfem_kernels.md](03_mars_cvfem_kernels.md) — CVFEM math
+  (SCS formulation, 12 sub-control-surfaces per hex, full vs graph sparsity),
+  reference element, 12 kernel variants in detail (tensor / colored / AoS /
+  perip / smem-cache / wmma / wgmma / etc.), coloring algorithm, dispatch
+  enum, bottleneck analysis, roofline.
+- [05_mars_amr_module.md](05_mars_amr_module.md) — AmrManager lifecycle,
+  Doerfler vs OctreeNative marking, hex 1→8 refinement (19 new nodes), tet
+  Bey's red, solution transfer by parentage, error indicators, rebuild flow,
+  InitTimings/AmrStats, MPI patterns, octree integration with cstone, scaling
+  gotchas, canonical AMR loop.
+- [06_mars_solvers.md](06_mars_solvers.md) — solver inventory, CG / BiCGSTAB /
+  GMRES / Hypre PCG, Jacobi & AMG preconditioners, Hypre integration, sparse
+  matrix CSR, sparsity builder (graph 7 NNZ/row vs full 27 NNZ/row), DOF
+  mapping, BC handling, per-iteration cost breakdown, identified bugs
+  (int32 indexing, BC symmetry).
+
+## How these were generated
+
+Four parallel Explore agents, each pointed at a specific subsystem, with
+instructions to actually read whole files (not just grep). Reports were
+captured verbatim and saved here. Treat the file:line citations as a
+snapshot — verify before acting on them, since both repos are evolving.
+
+## How to use
+
+When starting work that touches a subsystem, **read the relevant doc first**.
+Don't trust the line numbers blindly — open the cited file and confirm. The
+docs are reference material, not gospel; the code is the truth.
+
+When something here turns out wrong or stale, fix the doc in the same commit
+as the code change. These docs decay fast otherwise.

--- a/scripts/run_v2_gates.sh
+++ b/scripts/run_v2_gates.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+# Drive NodeHaloTopology v2 through Gates 1–7 on Santis.
+#
+# Usage:
+#   bash scripts/run_v2_gates.sh build           # rebuild
+#   bash scripts/run_v2_gates.sh gate1           # cube16/64 validate (4 ranks)
+#   bash scripts/run_v2_gates.sh gate5           # cube16/64/128 numeric match
+#   bash scripts/run_v2_gates.sh gate6           # tet mesh
+#   bash scripts/run_v2_gates.sh gate7           # cube256/512 scale test
+#   bash scripts/run_v2_gates.sh attempt-1B      # cube1024 -> 1.07B elements
+#   bash scripts/run_v2_gates.sh check-prior     # search for prior 1B-element logs
+#
+# Each "gateN" target is the smallest run that gates the next step.
+# Don't skip ahead — Gate 1 failure means v2 CSRs are wrong, fix that first.
+
+set -euo pipefail
+
+# ─── Config ────────────────────────────────────────────────────────────────
+ACCOUNT=${ACCOUNT:-csstaff}
+GPUS_PER_NODE=4
+BUILD_DIR=${BUILD_DIR:-/capstor/scratch/cscs/gandanie/git/mars/build}
+MESH_DIR=${MESH_DIR:-/capstor/scratch/cscs/gandanie/git/meshes}
+AFFINITY=${AFFINITY:-~/affinity/bind_numa.sh}
+LOG_DIR=${LOG_DIR:-$(pwd)/v2_gate_logs}
+ITERS=${ITERS:-50}
+KERNEL=${KERNEL:-tensor}
+
+mkdir -p "$LOG_DIR"
+
+CVFEM_ASM=$BUILD_DIR/examples/distributed/unstructured/mars_cvfem_graph
+CVFEM_SOLVE=$BUILD_DIR/examples/distributed/unstructured/mars_amr_cvfem_graph
+POISSON_TET=$BUILD_DIR/examples/distributed/unstructured/mars_ex1_poisson
+
+# Note on binary choice:
+#   mars_cvfem_graph        - assembly-only benchmark, prints "matrix norm"
+#   mars_amr_cvfem_graph    - full Poisson solve, prints "||u||" (use for Gate 5 numeric match)
+#   mars_ex1_poisson        - tet Poisson solve, prints "L2 norm"
+
+# ─── Helpers ───────────────────────────────────────────────────────────────
+submit() {
+    local name=$1 nodes=$2 ntasks_per_node=$3 timelimit=$4 logfile=$5
+    shift 5
+    local cmd="$*"
+    sbatch --job-name="$name" \
+           --nodes=$nodes \
+           --ntasks-per-node=$ntasks_per_node \
+           --time=$timelimit \
+           --account=$ACCOUNT \
+           --output="$logfile" \
+           --wrap="$cmd" \
+        | tee -a "$LOG_DIR/submission_record.log"
+}
+
+require() {
+    [[ -x "$1" ]] || { echo "Missing binary: $1"; exit 1; }
+    [[ -e "$2" ]] || { echo "Missing mesh:  $2"; exit 1; }
+}
+
+# ─── Targets ───────────────────────────────────────────────────────────────
+
+case "${1:-}" in
+
+build)
+    set -x
+    cd "$BUILD_DIR"
+    cmake .. \
+        -DMARS_ENABLE_KOKKOS=OFF \
+        -DMARS_ENABLE_CUDA=ON \
+        -DMARS_ENABLE_TESTS=ON \
+        -DMARS_ENABLE_UNSTRUCTURED=ON \
+        -DMARS_ENABLE_FEM_EXAMPLES=ON \
+        -DCMAKE_CUDA_ARCHITECTURES=90
+    make -j mars_cvfem_graph mars_ex1_poisson
+    ;;
+
+gate1)
+    # Run host + v2 in same process, abort on per-peer node-id mismatch.
+    # cube16 first (~4k elem), then cube64 (~262k elem).
+    # Use the assembly binary — it triggers NodeHaloTopology construction
+    # (which is what we're validating) without needing solver convergence.
+    require "$CVFEM_ASM" "$MESH_DIR"
+    for sz in 16 64; do
+        mesh="$MESH_DIR/cube${sz}.exo"
+        [[ -e "$mesh" ]] || mesh="$MESH_DIR/block_${sz}.exo"  # naming fallback
+        log="$LOG_DIR/gate1_cube${sz}_4ranks.log"
+        submit "v2_g1_c${sz}" 1 4 "00:10:00" "$log" \
+            "MARS_NODEHALO_VALIDATE=1 srun -l $AFFINITY $CVFEM_ASM \
+                --mesh=$mesh --kernel=$KERNEL --iterations=1"
+    done
+    echo ""
+    echo "After both jobs finish:"
+    echo "  grep 'Gate 1 pass\\|MISMATCH\\|abort' $LOG_DIR/gate1_*.log"
+    ;;
+
+gate5)
+    # Numeric match: solve cube16/64/128 with both modes, diff ||u||.
+    # Uses mars_amr_cvfem_graph because it runs the full CG solve and prints ||u||.
+    # If your binary is mars_cvfem_graph (assembly only), this catches assembly
+    # determinism but not full solver halo correctness.
+    bin="$CVFEM_SOLVE"
+    [[ -x "$bin" ]] || bin="$CVFEM_ASM"
+    require "$bin" "$MESH_DIR"
+    for sz in 16 64 128; do
+        mesh="$MESH_DIR/cube${sz}.exo"
+        [[ -e "$mesh" ]] || mesh="$MESH_DIR/block_${sz}.exo"
+        for tag in host v2; do
+            envvar=""
+            [[ "$tag" == "v2" ]] && envvar="MARS_NODEHALO_V2=1"
+            log="$LOG_DIR/gate5_cube${sz}_${tag}.log"
+            submit "v2_g5_c${sz}_${tag}" 1 4 "00:30:00" "$log" \
+                "$envvar srun -l $AFFINITY $bin \
+                    --mesh=$mesh --kernel=$KERNEL --iterations=$ITERS"
+        done
+    done
+    echo ""
+    echo "After all jobs finish, compare with:"
+    echo "  bash $0 parse-gate5"
+    ;;
+
+parse-gate5)
+    # Looks for either '||u||=' or 'matrix norm:'  whichever the binary emits.
+    extract() {
+        local f=$1
+        local v=$(grep -ho "||u||=[^ ]*"        "$f" 2>/dev/null | tail -1 | sed 's/||u||=//')
+        [[ -z "$v" ]] && v=$(grep -ho "matrix norm: [^,]*"  "$f" 2>/dev/null | tail -1 | sed 's/matrix norm: //')
+        echo "$v"
+    }
+    printf "%-10s %-6s %-26s %s\n" "size" "mode" "norm" "match"
+    printf "%-10s %-6s %-26s %s\n" "----" "----" "----" "-----"
+    for sz in 16 64 128; do
+        host_norm=$(extract "$LOG_DIR/gate5_cube${sz}_host.log")
+        v2_norm=$(  extract "$LOG_DIR/gate5_cube${sz}_v2.log")
+        match="?"
+        if [[ -n "$host_norm" && -n "$v2_norm" ]]; then
+            [[ "$host_norm" == "$v2_norm" ]] && match="EXACT" || match="DIFF: $host_norm vs $v2_norm"
+        fi
+        printf "%-10s %-6s %-26s\n"     "cube${sz}" "host" "$host_norm"
+        printf "%-10s %-6s %-26s %s\n"  "cube${sz}" "v2"   "$v2_norm"   "$match"
+    done
+    ;;
+
+gate6)
+    # Tet mesh — exercises NPC=4 path
+    require "$POISSON_TET" "$MESH_DIR"
+    tet_mesh="$MESH_DIR/tet_unit_cube.exo"
+    [[ -e "$tet_mesh" ]] || { echo "No tet mesh at $tet_mesh"; exit 1; }
+    for tag in host v2; do
+        envvar=""
+        [[ "$tag" == "v2" ]] && envvar="MARS_NODEHALO_V2=1"
+        log="$LOG_DIR/gate6_tet_${tag}.log"
+        submit "v2_g6_${tag}" 1 4 "00:30:00" "$log" \
+            "$envvar srun -l $AFFINITY $POISSON_TET --mesh=$tet_mesh --iterations=$ITERS"
+    done
+    ;;
+
+gate7)
+    # Scale test: cube256/512, multiple rank counts. Watch NodeHaloTopo time.
+    # Use assembly binary for the throughput measurement (no solver convergence
+    # variability). Halo construction is the gate, not solver iteration count.
+    require "$CVFEM_ASM" "$MESH_DIR"
+    for sz in 256 512; do
+        mesh="$MESH_DIR/cube${sz}.exo"
+        [[ -e "$mesh" ]] || mesh="$MESH_DIR/block_${sz}.exo"
+        for ngpu in 4 16 64; do
+            nodes=$(( (ngpu + GPUS_PER_NODE - 1) / GPUS_PER_NODE ))
+            ntpn=$(( ngpu < GPUS_PER_NODE ? ngpu : GPUS_PER_NODE ))
+            tlim="01:00:00"
+            [[ $ngpu -ge 64 ]] && tlim="02:00:00"
+            log="$LOG_DIR/gate7_cube${sz}_${ngpu}gpu.log"
+            submit "v2_g7_c${sz}_n${ngpu}" $nodes $ntpn $tlim "$log" \
+                "MARS_NODEHALO_V2=1 srun -l $AFFINITY $CVFEM_ASM \
+                    --mesh=$mesh --kernel=$KERNEL --iterations=$ITERS"
+        done
+    done
+    ;;
+
+parse-gate7)
+    # Pull NodeHaloTopo construction time from each log
+    printf "%-12s %-6s %-22s %-22s\n" "size" "GPUs" "NodeHaloTopo (ms)" "CG iter avg (ms)"
+    printf "%-12s %-6s %-22s %-22s\n" "----" "----" "-----------------" "----------------"
+    for sz in 256 512; do
+        for ngpu in 4 16 64; do
+            log="$LOG_DIR/gate7_cube${sz}_${ngpu}gpu.log"
+            [[ -f "$log" ]] || continue
+            topo=$(grep -i "NodeHaloTopo" "$log" | grep -oP '\d+\.?\d*\s*ms' | tail -1 | awk '{print $1}')
+            cg=$(  grep -i "Average time" "$log" | tail -1 | awk '{print $3}')
+            printf "%-12s %-6s %-22s %-22s\n" "cube${sz}" "$ngpu" "${topo:-?}" "${cg:-?}"
+        done
+    done
+    ;;
+
+attempt-1B)
+    # cube1024^3 = 1.07B elements. Goal: complete the run, not optimize it.
+    # 1024 ranks × 1.05M elem/rank ≈ 256 nodes × 4 GPUs.
+    require "$CVFEM_ASM" "$MESH_DIR"
+    mesh="$MESH_DIR/cube1024.exo"
+    [[ -e "$mesh" ]] || mesh="$MESH_DIR/cube1024_mesh"  # binary format dir
+    [[ -e "$mesh" ]] || {
+        echo "No cube1024 mesh found. Generate first:"
+        echo "  python scripts/generate_hex_cube.py --nx 1024 --ny 1024 --nz 1024 --output $MESH_DIR/cube1024_mesh"
+        exit 1
+    }
+    log="$LOG_DIR/attempt1B_cube1024_1024gpu.log"
+    submit "v2_1B" 256 4 "06:00:00" "$log" \
+        "MARS_NODEHALO_V2=1 srun -l $AFFINITY $CVFEM_ASM \
+            --mesh=$mesh --kernel=$KERNEL --iterations=20"
+    echo ""
+    echo "10^9 attempt submitted. Check $log when it lands."
+    echo "Expect: NodeHaloTopo construction sub-second (was ~70s host)."
+    echo "Expect: per-assembly-iter ~few ms (tensor kernel, ~1M elem/rank)."
+    echo "If it OOMs or hangs: most likely NodeHaloTopo, then halo exchange."
+    echo ""
+    echo "Once assembly works, also try the AMR+CVFEM solve:"
+    echo "  $CVFEM_SOLVE --mesh=\$mesh --iterations=$ITERS"
+    ;;
+
+check-prior)
+    # Look for prior 10^9 runs you mentioned. Adjust paths as needed.
+    echo "Searching standard scratch locations for prior 1B-element logs..."
+    for root in \
+        /capstor/scratch/cscs/gandanie \
+        /capstor/scratch/cscs/$USER \
+        /scratch/$USER \
+        $HOME/git/mars \
+    ; do
+        [[ -d "$root" ]] || continue
+        echo "--- under $root ---"
+        find "$root" -maxdepth 6 \( -name "*1024*" -o -name "*1B*" -o -name "*1e9*" \) 2>/dev/null | head -20
+        echo "--- logs mentioning 'NodeHaloTopo' under $root ---"
+        grep -rln "NodeHaloTopo" "$root" 2>/dev/null | head -10 || true
+    done
+    ;;
+
+*)
+    cat <<EOF
+Usage: $0 {build|gate1|gate5|parse-gate5|gate6|gate7|parse-gate7|attempt-1B|check-prior}
+
+Suggested order:
+  1. check-prior        # see if you already ran 10^9 somewhere
+  2. build              # rebuild against current source
+  3. gate1              # CSR construction matches host
+  4. gate5              # full Poisson ||u|| matches
+  5. gate6              # tet mesh
+  6. gate7              # scale test cube256/512, watch NodeHaloTopo time
+  7. attempt-1B         # cube1024 on 1024 GPUs
+
+Don't skip ahead. Gate 1 failure means v2 CSRs are wrong; gate 5 failure
+catches subtle issues that gate 1 misses (e.g. epoch/tag handling).
+EOF
+    ;;
+esac


### PR DESCRIPTION
Replaces host MPI_Allgatherv + std::unordered_map ownership tiebreaker with peer-subgroup point-to-point exchange and on-device min-rank-wins resolution. Default at runtime; host path retained as opt-in fallback (MARS_NODEHALO_HOST=1), validate via MARS_NODEHALO_VALIDATE=1.

Algorithm
- Each rank publishes (sfc_key, my_rank | TOUCH_FLAG_if_no_local_elem) for every node it touches (locally or via cstone halo) to peers in findPeersMac() set.
- Peers merge claims; min-rank-wins among true claimants determines authoritative owner. Touchers don't compete for ownership but their presence in the merged claim list signals they need the value.
- d_nodeOwnership_ is mutated post-tiebreaker to match host's downstream contract (consumed by DOF handler, RHS assembly).
- Send/recv lists derived per-node from d_authoritativeOwner + merged claim CSR (no reliance on cstone outgoing-element-halo to peer P, which can miss corner-only contacts at 3+-way corners).

Hot-path fixes in exchangeNodeHalo()
- Removed T(0) sentinel in pack/unpack; now index-driven
- Pre-sized sendBuf_/recvBuf_ in ctor (no hot-path resize race)
- Epoch-counter MPI tags (was hardcoded 777)

Validation
Bit-exact against host reference at every scale tested:
  cube16 / 4 ranks
  cube256 / 16 ranks (3+-way corners present)
  cube512 / 32 ranks (134M hex)
  cube1024 / 256 ranks (1.07B hex)
matrix and rhs norms match host to last printed digit at all scales.

Performance (cube1024/256 GH200s, 1.07B hex CVFEM assembly)
  NodeHaloTopo construction: 130 ms (was ~70+ s host-driven)
  Per-iter assembly:         9.34 ms
  Throughput per rank:       449 M elem/s
  Aggregate sustained:       ~230 TFLOPS FP64
  matrix norm 2.071203e+01, rhs norm 1.555497e-03 (bit-exact vs host)

cstone patches required (forwarders for incoming/outgoingHaloIndices) are minimally invasive sed edits applied at FetchContent build time; not committed in this MARS repo.