### PR TITLE
cstone

### DIFF
--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -1665,35 +1665,6 @@ __global__ void computeDivergencePerNodeKernel(const KeyType* c0, const KeyType*
 }
 
 // =============================================================================
-// Inlet boundary-flux source (GUARDED, opt-in). The interior SCS divergence
-// scatter integrates only the INTERIOR sub-control-surfaces of each element; the
-// EXTERIOR inlet-face portion of a boundary node's control volume has no interior
-// SCS face, so the mass actually crossing the inlet opening is never registered.
-// This adds it: per inlet node, += (uTarget . areaVecOutward), where areaVec is
-// the node's outward inlet area-vector. A prescribed inflow makes uTarget oppose
-// the outward normal, so the term is NEGATIVE -- net inflow shows up as negative
-// divergence, which is exactly the sign the projection needs to pull mass in.
-// Only inlet nodes carry a nonzero areaVec; every other node adds 0.
-// =============================================================================
-
-template<typename RealType>
-__global__ void addInletFluxSourceKernel(const RealType* uTgt,
-                                         const RealType* vTgt,
-                                         const RealType* wTgt,
-                                         const RealType* areaVecX,
-                                         const RealType* areaVecY,
-                                         const RealType* areaVecZ,
-                                         RealType* divAccNode,
-                                         size_t numNodes)
-{
-    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i >= numNodes) return;
-    RealType ax = areaVecX[i], ay = areaVecY[i], az = areaVecZ[i];
-    // Off-inlet nodes have a zero area-vector -> no-op.
-    divAccNode[i] += uTgt[i] * ax + vTgt[i] * ay + wTgt[i] * az;
-}
-
-// =============================================================================
 // Rhie-Chow corrected divergence kernel for periodic Q1-Q1 CVFEM. Same as
 // computeDivergencePerNodeKernel but adds the Rhie-Chow pressure-velocity
 // coupling correction at each SCS face:
@@ -2328,17 +2299,6 @@ struct NSStepper
     RealType outletDirX = 1, outletDirY = 0, outletDirZ = 0;
     bool outletDoNothing = true;  // do-nothing outlet (free velocity + p=0 face); false = mass-conserving velocity outlet
 
-    // GUARDED inlet boundary-flux source (off by default). The interior SCS
-    // divergence scatter never integrates the EXTERIOR inlet-face flux (that part
-    // of a boundary node's control volume has no interior sub-control-surface), so
-    // a velocity-inlet + free-pressure outlet under-counts the mass actually
-    // entering. When enabled, runPressureSolveStep adds the prescribed inflow
-    // (uTarget . n)*A per inlet node into the divergence accumulator before the
-    // RHS build. d_inletAreaVec{X,Y,Z} are the per-node OUTWARD inlet area-vectors
-    // (un-normalized, nodeCount-sized, zero off the inlet); the source is the dot
-    // of the prescribed inlet velocity with this vector. Filled by the driver.
-    bool addInletFluxSource = false;
-    cstone::DeviceVector<RealType> d_inletAreaVecX, d_inletAreaVecY, d_inletAreaVecZ;
     // Per-node OUTWARD outlet area-vectors (un-normalized, nodeCount-sized, zero
     // off the outlet). Used only by the through-flow diagnostic to measure
     // Q_out = sum_owned( u . outletAreaVec ). Filled by the driver.
@@ -6573,23 +6533,6 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
     }
     s.domain.reverseExchangeNodeHaloAdd(d_divAccNode);
     maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_divAccNode);
-
-    // GUARDED inlet boundary-flux source. Add the prescribed inlet-face inflow
-    // that the interior SCS scatter cannot see. Applied AFTER the reverse-halo
-    // fold so each OWNED inlet node receives its complete source exactly once (the
-    // per-node area-vectors were already owner-summed + halo-published in the
-    // driver). Off by default -> the do-nothing path stays byte-identical.
-    if (s.addInletFluxSource
-        && s.d_inletAreaVecX.size() == s.nodeCount
-        && s.d_inletAreaVecY.size() == s.nodeCount
-        && s.d_inletAreaVecZ.size() == s.nodeCount)
-    {
-        addInletFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
-            s.d_uTarget.data(), s.d_vTarget.data(), s.d_wTarget.data(),
-            s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
-            d_divAccNode.data(), s.nodeCount);
-        cudaDeviceSynchronize();
-    }
 
     // Source-of-NaN trace: count non-finite divAccNode over ALL owned nodes and
     // over the owned-BOUNDARY subset separately. The interior diagnostic below

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -1665,6 +1665,35 @@ __global__ void computeDivergencePerNodeKernel(const KeyType* c0, const KeyType*
 }
 
 // =============================================================================
+// Inlet boundary-flux source (GUARDED, opt-in). The interior SCS divergence
+// scatter integrates only the INTERIOR sub-control-surfaces of each element; the
+// EXTERIOR inlet-face portion of a boundary node's control volume has no interior
+// SCS face, so the mass actually crossing the inlet opening is never registered.
+// This adds it: per inlet node, += (uTarget . areaVecOutward), where areaVec is
+// the node's outward inlet area-vector. A prescribed inflow makes uTarget oppose
+// the outward normal, so the term is NEGATIVE -- net inflow shows up as negative
+// divergence, which is exactly the sign the projection needs to pull mass in.
+// Only inlet nodes carry a nonzero areaVec; every other node adds 0.
+// =============================================================================
+
+template<typename RealType>
+__global__ void addInletFluxSourceKernel(const RealType* uTgt,
+                                         const RealType* vTgt,
+                                         const RealType* wTgt,
+                                         const RealType* areaVecX,
+                                         const RealType* areaVecY,
+                                         const RealType* areaVecZ,
+                                         RealType* divAccNode,
+                                         size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    RealType ax = areaVecX[i], ay = areaVecY[i], az = areaVecZ[i];
+    // Off-inlet nodes have a zero area-vector -> no-op.
+    divAccNode[i] += uTgt[i] * ax + vTgt[i] * ay + wTgt[i] * az;
+}
+
+// =============================================================================
 // Rhie-Chow corrected divergence kernel for periodic Q1-Q1 CVFEM. Same as
 // computeDivergencePerNodeKernel but adds the Rhie-Chow pressure-velocity
 // coupling correction at each SCS face:
@@ -2298,6 +2327,22 @@ struct NSStepper
     RealType outletU = -1;
     RealType outletDirX = 1, outletDirY = 0, outletDirZ = 0;
     bool outletDoNothing = true;  // do-nothing outlet (free velocity + p=0 face); false = mass-conserving velocity outlet
+
+    // GUARDED inlet boundary-flux source (off by default). The interior SCS
+    // divergence scatter never integrates the EXTERIOR inlet-face flux (that part
+    // of a boundary node's control volume has no interior sub-control-surface), so
+    // a velocity-inlet + free-pressure outlet under-counts the mass actually
+    // entering. When enabled, runPressureSolveStep adds the prescribed inflow
+    // (uTarget . n)*A per inlet node into the divergence accumulator before the
+    // RHS build. d_inletAreaVec{X,Y,Z} are the per-node OUTWARD inlet area-vectors
+    // (un-normalized, nodeCount-sized, zero off the inlet); the source is the dot
+    // of the prescribed inlet velocity with this vector. Filled by the driver.
+    bool addInletFluxSource = false;
+    cstone::DeviceVector<RealType> d_inletAreaVecX, d_inletAreaVecY, d_inletAreaVecZ;
+    // Per-node OUTWARD outlet area-vectors (un-normalized, nodeCount-sized, zero
+    // off the outlet). Used only by the through-flow diagnostic to measure
+    // Q_out = sum_owned( u . outletAreaVec ). Filled by the driver.
+    cstone::DeviceVector<RealType> d_outletAreaVecX, d_outletAreaVecY, d_outletAreaVecZ;
 
     // Constant streamwise (and orthogonal) momentum body force, added in the
     // predictor as +dt*f/rho (BDF1) and +(2dt/3)*f/rho (BDF2). Defaults to 0
@@ -6529,6 +6574,23 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
     s.domain.reverseExchangeNodeHaloAdd(d_divAccNode);
     maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_divAccNode);
 
+    // GUARDED inlet boundary-flux source. Add the prescribed inlet-face inflow
+    // that the interior SCS scatter cannot see. Applied AFTER the reverse-halo
+    // fold so each OWNED inlet node receives its complete source exactly once (the
+    // per-node area-vectors were already owner-summed + halo-published in the
+    // driver). Off by default -> the do-nothing path stays byte-identical.
+    if (s.addInletFluxSource
+        && s.d_inletAreaVecX.size() == s.nodeCount
+        && s.d_inletAreaVecY.size() == s.nodeCount
+        && s.d_inletAreaVecZ.size() == s.nodeCount)
+    {
+        addInletFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            s.d_uTarget.data(), s.d_vTarget.data(), s.d_wTarget.data(),
+            s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
+            d_divAccNode.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+    }
+
     // Source-of-NaN trace: count non-finite divAccNode over ALL owned nodes and
     // over the owned-BOUNDARY subset separately. The interior diagnostic below
     // (maxOwnedInteriorAbs) excludes boundary DOFs, so a boundary NaN is
@@ -7237,6 +7299,43 @@ inline RealType keOwned(NSStepper<KeyType, RealType, ElementTag>& s,
             RealType uu = u[i], vv = v[i], ww = w[i];
             return RealType(0.5) * mass[dof] * (uu * uu + vv * vv + ww * ww);
         }, RealType(0), thrust::plus<RealType>());
+    RealType global = 0;
+    MPI_Datatype mpi_r = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
+    MPI_Allreduce(&local, &global, 1, mpi_r, MPI_SUM, MPI_COMM_WORLD);
+    return global;
+}
+
+// Net flux of a velocity field through a side-set: sum over OWNED nodes of
+// (u . areaVecOutward), with areaVec the per-node outward area-vector (zero off
+// the set). Partition-independent (owned-only) and globally reduced. Used by the
+// pump through-flow diagnostic to measure Q_out against the known Q_in. A
+// positive value means net OUTFLOW through the set.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+inline RealType fluxThroughOwned(NSStepper<KeyType, RealType, ElementTag>& s,
+                                 const cstone::DeviceVector<RealType>& du,
+                                 const cstone::DeviceVector<RealType>& dv,
+                                 const cstone::DeviceVector<RealType>& dw,
+                                 const cstone::DeviceVector<RealType>& aX,
+                                 const cstone::DeviceVector<RealType>& aY,
+                                 const cstone::DeviceVector<RealType>& aZ)
+{
+    const auto& d_own = s.domain.getNodeOwnershipMap();
+    size_t n = s.nodeCount;
+    RealType local = RealType(0);
+    if (aX.size() == n && aY.size() == n && aZ.size() == n)
+    {
+        local = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0),
+            thrust::counting_iterator<size_t>(n),
+            [own = d_own.data(), n2d = s.d_node_to_dof.data(), nOwn = s.numOwnedDofs,
+             u = du.data(), v = dv.data(), w = dw.data(),
+             ax = aX.data(), ay = aY.data(), az = aZ.data()] __device__ (size_t i) -> RealType {
+                if (own[i] != 1) return RealType(0);
+                int dof = n2d[i];
+                if (dof < 0 || dof >= nOwn) return RealType(0);
+                return u[i]*ax[i] + v[i]*ay[i] + w[i]*az[i];
+            }, RealType(0), thrust::plus<RealType>());
+    }
     RealType global = 0;
     MPI_Datatype mpi_r = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
     MPI_Allreduce(&local, &global, 1, mpi_r, MPI_SUM, MPI_COMM_WORLD);

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -489,6 +489,46 @@ __global__ void enforceBcColMatrixKernelByNode(const uint8_t* isPressureBdryNode
     }
 }
 
+// FIX 2: compute the Dirichlet lift for the velocity RHS, reading the INTACT
+// matrix (call this BEFORE the col-zero so the K[row,col] entries are still
+// present). For each non-Dirichlet owned row:
+//   lift[row] = sum_col K[row,col] * qTarget[colNode]   over boundary cols
+// The per-step velocity RHS then subtracts lift[row], which is the standard
+// Dirichlet lift-off that preserves the boundary target's momentum on interior
+// neighbors after those columns are zeroed. qTarget is per-NODE (nodeCount-sized);
+// colNode = dofToNode[c]. Pure accumulator -- does NOT modify values -- so it can
+// run once per component (u,v,w) over the same intact matrix before a single
+// plain col-zero pass. Wall targets are 0 (no lift); only the inlet target lifts.
+template<typename RealType>
+__global__ void computeBcColLiftKernelByNode(const uint8_t* isPressureBdryNode,
+                                            const int* dofToNode,
+                                            int numTotalDofs,
+                                            const int* rowPtr,
+                                            const int* colInd,
+                                            const RealType* values,
+                                            const RealType* qTarget,
+                                            RealType* liftOut,
+                                            int numOwnedRows)
+{
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= numOwnedRows) return;
+    liftOut[row] = RealType(0);
+    int rowNode = dofToNode[row];
+    if (rowNode >= 0 && isPressureBdryNode[rowNode]) return;
+    int rs = rowPtr[row];
+    int re = rowPtr[row + 1];
+    RealType lift = RealType(0);
+    for (int j = rs; j < re; ++j)
+    {
+        int c = colInd[j];
+        if (c < 0 || c >= numTotalDofs) continue;
+        int cnode = dofToNode[c];
+        if (cnode >= 0 && isPressureBdryNode[cnode])
+            lift += values[j] * qTarget[cnode];
+    }
+    liftOut[row] = lift;
+}
+
 // Build the inverse map: dofToNode[d] = local node that has nodeToDof[node] = d.
 // One thread per node. Multiple nodes can never share a DOF (in non-periodic
 // modes), so this is a simple scatter.
@@ -1978,6 +2018,37 @@ __global__ void buildPressureRhsKernel(const RealType* divAccNode,
     rhs[dof] = -coef * divAccNode[i];
 }
 
+// FIX 1: add the opening (inlet/outlet) boundary surface flux to divAccNode.
+// The interior SCS scatter integrates only the INTERIOR median-dual faces, so the
+// exterior opening face of a boundary node's dual cell is missing from divAccNode.
+// Here we add the missing Gauss boundary term: divAccNode[i] += u[i] . areaVec[i],
+// where areaVec is the per-node OUTWARD opening area-vector (zero off the set, its
+// magnitude = the node's share of the opening area). u . areaVec_outward is the
+// outward volumetric flux through that share -- negative for the inward inlet jet
+// (a source into the dual cell), positive for the outlet (a sink) -- which is the
+// SAME sign convention as the interior scatter (positive divAccNode = net outflow)
+// and the SAME raw volumetric-flux units (NOT pre-multiplied by rho/dt; the RHS
+// coef does that). Adding it is not a double-count: no scsLR pair covers the
+// exterior face. One thread per node; only owned nodes contribute (off-set nodes
+// have a zero area-vector so they add nothing even if visited).
+template<typename RealType>
+__global__ void addOpeningFluxSourceKernel(const RealType* u,
+                                           const RealType* v,
+                                           const RealType* w,
+                                           const RealType* aVecX,
+                                           const RealType* aVecY,
+                                           const RealType* aVecZ,
+                                           const uint8_t* ownership,
+                                           RealType* divAccNode,
+                                           size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    RealType flux = u[i] * aVecX[i] + v[i] * aVecY[i] + w[i] * aVecZ[i];
+    divAccNode[i] += flux;
+}
+
 // DOF-indexed solver output -> per-node array. Reused for all velocity solves
 // and the pressure solve.
 template<typename RealType>
@@ -2303,6 +2374,39 @@ struct NSStepper
     // off the outlet). Used only by the through-flow diagnostic to measure
     // Q_out = sum_owned( u . outletAreaVec ). Filled by the driver.
     cstone::DeviceVector<RealType> d_outletAreaVecX, d_outletAreaVecY, d_outletAreaVecZ;
+
+    // Per-node OUTWARD inlet area-vectors (un-normalized, nodeCount-sized, zero
+    // off the inlet). Filled by the driver when useOpeningFluxSource is on. The
+    // magnitude at a node is its share of the opening area; direction is outward.
+    cstone::DeviceVector<RealType> d_inletAreaVecX, d_inletAreaVecY, d_inletAreaVecZ;
+
+    // FIX 1 -- opening-flux source. The CVFEM divergence operator integrates
+    // ONLY interior median-dual SCS faces (each scsLR pair links two NODES of the
+    // SAME element, so sum_nodes(divAccNode)==0 identically). The exterior opening
+    // face of a boundary node's dual cell -- the part lying ON the inlet/outlet
+    // surface -- is in NO scsLR pair, so the prescribed opening flux never enters
+    // divAccNode and the pressure solve is never told mass crosses the boundary.
+    // We add the missing boundary surface integral sum( u . areaVec_opening ) to
+    // divAccNode in the SAME raw volumetric-flux units as the interior scatter
+    // (NOT pre-multiplied by rho/dt -- the RHS coef does that). areaVec is OUTWARD,
+    // so u.areaVec is NEGATIVE at the inlet (inward jet, a source) and POSITIVE at
+    // the outlet (a sink) -- the same convention as the interior scatter, where
+    // positive divAccNode means net outflow. Inlet + outlet net to ~0 (mass in =
+    // mass out), so the single-pin Neumann pressure system stays solvable. Off by
+    // default; --opening-flux-source turns it on for the pump through-flow case so
+    // it can be A/B-ed safely.
+    bool useOpeningFluxSource = false;
+
+    // FIX 2 -- Dirichlet lift on the velocity diffusion. The symmetric col-zero
+    // (enforceBcColMatrixKernelByNode) drops K[interior_row, boundary_col] with no
+    // RHS compensation, so the inlet's prescribed velocity contributes ZERO viscous
+    // momentum to its interior neighbors and the jet dies at the inlet. The lift
+    // restores it: lift[row] = sum_col K[row,col]*qTarget[col] over boundary cols,
+    // captured ONCE at setup (qTarget is steady for the pump) BEFORE the col-zero,
+    // then subtracted from the velocity RHS every step. Walls (qTarget=0) add
+    // nothing; only the nonzero inlet target lifts. Per-component (u,v,w).
+    bool useDirichletLift = true;
+    cstone::DeviceVector<RealType> d_velLiftU, d_velLiftV, d_velLiftW;  // owned-DOF sized
 
     // Constant streamwise (and orthogonal) momentum body force, added in the
     // predictor as +dt*f/rho (BDF1) and +(2dt/3)*f/rho (BDF2). Defaults to 0
@@ -3775,16 +3879,41 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
             // enough that the existing asymmetric row-clear converges fine
             // (same rationale as DDT-cavity at lines ~3500-3508).
             //
-            // NOTE: no Dirichlet "lift" yet. For zero qTarget (wall no-slip)
-            // it isn't needed. For non-zero qTarget (inlet/extra u=Uinf)
-            // this introduces an O(off-diag * Uinf) perturbation localized to
-            // the 1-cell ring around those faces. Acceptable for the "BC
-            // actually runs" milestone; promote to a proper lift kernel as
-            // a follow-up after validating convergence.
+            // FIX 2 (Dirichlet lift): the col-zero below drops K[row, boundary_col]
+            // with no RHS compensation, so the inlet's prescribed velocity adds zero
+            // viscous momentum to interior neighbors and the jet dies at the inlet.
+            // BEFORE zeroing (matrix still intact) capture the per-component lift
+            // lift[row] = sum_col K[row,col]*qTarget[col]; the per-step velocity RHS
+            // subtracts it. qTarget is steady for the pump so this is a one-time
+            // setup cost. The off-diagonal K entries are identical for Avel and
+            // Avel_bdf2 (only the mass diagonal differs, never touched here), so one
+            // lift serves both. Gated by useDirichletLift for A/B.
             if ((s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Channel
                  || s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Pump)
                 && s.d_isBdryNode.size() == static_cast<size_t>(s.nodeCount))
             {
+                // Pump-only: the lift is the pump through-flow fix. Channel keeps
+                // its prior (no-lift) behavior so its regression is untouched.
+                if (s.useDirichletLift
+                    && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Pump)
+                {
+                    s.d_velLiftU.resize(s.numOwnedDofs);
+                    s.d_velLiftV.resize(s.numOwnedDofs);
+                    s.d_velLiftW.resize(s.numOwnedDofs);
+                    computeBcColLiftKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
+                        s.d_isBdryNode.data(), s.d_dofToNode.data(), s.numTotalDofs,
+                        s.d_rowPtr.data(), s.d_colInd.data(), s.d_valuesVel.data(),
+                        s.d_uTarget.data(), s.d_velLiftU.data(), s.numOwnedDofs);
+                    computeBcColLiftKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
+                        s.d_isBdryNode.data(), s.d_dofToNode.data(), s.numTotalDofs,
+                        s.d_rowPtr.data(), s.d_colInd.data(), s.d_valuesVel.data(),
+                        s.d_vTarget.data(), s.d_velLiftV.data(), s.numOwnedDofs);
+                    computeBcColLiftKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
+                        s.d_isBdryNode.data(), s.d_dofToNode.data(), s.numTotalDofs,
+                        s.d_rowPtr.data(), s.d_colInd.data(), s.d_valuesVel.data(),
+                        s.d_wTarget.data(), s.d_velLiftW.data(), s.numOwnedDofs);
+                    cudaDeviceSynchronize();
+                }
                 enforceBcColMatrixKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
                     s.d_isBdryNode.data(),
                     s.d_node_to_dof.data(), s.d_dofToNode.data(), s.numTotalDofs,
@@ -6289,7 +6418,8 @@ void runImplicitDiffusionStep(NSStepper<KeyType, RealType, ElementTag>& s, RealT
 
     auto runImplicit = [&] (cstone::DeviceVector<RealType>& qStar,
                              cstone::DeviceVector<RealType>& qStarStar,
-                             cstone::DeviceVector<RealType>& qTarget) -> int
+                             cstone::DeviceVector<RealType>& qTarget,
+                             const cstone::DeviceVector<RealType>& qLift) -> int
     {
         // RHS = (mass coef) * mass * qStar; coef = 1/dt for BDF1, 3/(2dt) for BDF2.
         thrust::fill(thrust::device_pointer_cast(b.data()),
@@ -6299,6 +6429,18 @@ void runImplicitDiffusionStep(NSStepper<KeyType, RealType, ElementTag>& s, RealT
             qStar.data(), s.d_node_to_dof.data(), d_nodeOwnership.data(),
             s.d_mass.data(), invDt, b.data(), s.nodeCount, s.numOwnedDofs);
         cudaDeviceSynchronize();
+
+        // FIX 2: subtract the Dirichlet lift on interior rows (b -= K[row,bdry]*qTarget),
+        // captured once at setup. Dirichlet rows carry lift=0 and are overwritten by
+        // enforceBcRhsFromTargetKernel below, so order is safe.
+        if (s.useDirichletLift && qLift.size() == static_cast<size_t>(s.numOwnedDofs))
+        {
+            auto bp = thrust::device_pointer_cast(b.data());
+            thrust::transform(thrust::device, bp, bp + s.numOwnedDofs,
+                              thrust::device_pointer_cast(qLift.data()), bp,
+                              thrust::minus<RealType>());
+            cudaDeviceSynchronize();
+        }
 
         enforceBcRhsFromTargetKernel<RealType><<<nodeBlocks, s.blockSize>>>(
             s.d_isBdryDof.data(), qTarget.data(),
@@ -6351,9 +6493,9 @@ void runImplicitDiffusionStep(NSStepper<KeyType, RealType, ElementTag>& s, RealT
             bdf2Active ? s.Avel_bdf2 : s.Avel);
     };
 
-    s.lastUIters = runImplicit(s.d_uStar, s.d_uStarStar, s.d_uTarget);
-    s.lastVIters = runImplicit(s.d_vStar, s.d_vStarStar, s.d_vTarget);
-    s.lastWIters = runImplicit(s.d_wStar, s.d_wStarStar, s.d_wTarget);
+    s.lastUIters = runImplicit(s.d_uStar, s.d_uStarStar, s.d_uTarget, s.d_velLiftU);
+    s.lastVIters = runImplicit(s.d_vStar, s.d_vStarStar, s.d_vTarget, s.d_velLiftV);
+    s.lastWIters = runImplicit(s.d_wStar, s.d_wStarStar, s.d_wTarget, s.d_velLiftW);
 
     // Sync ghosts of q** for the divergence scatter (face donors read q** at
     // ghost corners on rank boundaries).
@@ -6533,6 +6675,29 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
     }
     s.domain.reverseExchangeNodeHaloAdd(d_divAccNode);
     maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_divAccNode);
+
+    // FIX 1: add the inlet+outlet opening surface flux that the interior SCS
+    // scatter cannot reach. divAccNode is now owner-complete; the per-node opening
+    // area-vectors are owner-complete too (driver does reverse-halo-add then publish,
+    // counted once per owned node), so restricting the add to owned nodes is exact
+    // and rank-safe. Uses the SAME post-diffusion velocity the divergence scatter
+    // used (d_uStarStar): inlet nodes carry the prescribed inflow, outlet nodes the
+    // post-diffusion outflow, so inlet flux + outlet flux net to ~0 and the single-pin
+    // Neumann pressure system stays solvable. Off unless --opening-flux-source.
+    if (s.useOpeningFluxSource
+        && s.d_inletAreaVecX.size() == s.nodeCount
+        && s.d_outletAreaVecX.size() == s.nodeCount)
+    {
+        addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            s.d_uStarStar.data(), s.d_vStarStar.data(), s.d_wStarStar.data(),
+            s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
+            d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
+        addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            s.d_uStarStar.data(), s.d_vStarStar.data(), s.d_wStarStar.data(),
+            s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data(),
+            d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+    }
 
     // Source-of-NaN trace: count non-finite divAccNode over ALL owned nodes and
     // over the owned-BOUNDARY subset separately. The interior diagnostic below
@@ -7283,6 +7448,109 @@ inline RealType fluxThroughOwned(NSStepper<KeyType, RealType, ElementTag>& s,
     MPI_Datatype mpi_r = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
     MPI_Allreduce(&local, &global, 1, mpi_r, MPI_SUM, MPI_COMM_WORLD);
     return global;
+}
+
+// FIX 3: interior cut-plane flux probe. For every INTERIOR median-dual SCS face
+// whose two endpoints straddle the plane axis==cut, add the SOLVED face flux
+// u_f . scsAreaVec (u_f = 0.5*(u_L+u_R), the exact interpolation the divergence
+// scatter uses) to a per-block accumulator. This reads the SOLVED interior field,
+// so unlike the outlet Q_out it CANNOT be faked by the BC relock at the openings:
+// if flow truly threads the passage the probe is nonzero and ~equal at every cut;
+// if it dies near the inlet, the mid/outlet cuts read ~0. Owned elements only;
+// the host wrapper MPI_Allreduces. Straddle test on the L/R node coords means each
+// crossing dual face is counted once with a consistent orientation (areaVec points
+// L->R by construction), so the signed sum is the net flux across the plane.
+template<typename KeyType, typename RealType, typename ElementTag>
+__global__ void interiorCutFluxKernel(const KeyType* c0, const KeyType* c1,
+                                      const KeyType* c2, const KeyType* c3,
+                                      const KeyType* c4, const KeyType* c5,
+                                      const KeyType* c6, const KeyType* c7,
+                                      const RealType* vx, const RealType* vy, const RealType* vz,
+                                      const RealType* nodeAxis,   // node coord along the cut axis
+                                      const RealType* areaVecX,
+                                      const RealType* areaVecY,
+                                      const RealType* areaVecZ,
+                                      RealType cut,
+                                      double* partial,            // one slot per block
+                                      size_t startElem, size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    double mine = 0.0;
+    if (k < numLocal)
+    {
+        size_t e = startElem + k;
+        constexpr int NPE  = ElemTraits<ElementTag>::NodesPerElem;
+        constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+        const KeyType* cc[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+        KeyType n[NPE];
+        for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+        for (int ip = 0; ip < NSCS; ++ip)
+        {
+            int nodeL, nodeR; scsLR<ElementTag>(ip, nodeL, nodeR);
+            KeyType iL = n[nodeL];
+            KeyType iR = n[nodeR];
+            RealType aL = nodeAxis[iL];
+            RealType aR = nodeAxis[iR];
+            // dual face crosses the plane iff its endpoints are on opposite sides
+            bool straddle = (aL <= cut && aR > cut) || (aR <= cut && aL > cut);
+            if (!straddle) continue;
+            RealType vfx = RealType(0.5) * (vx[iL] + vx[iR]);
+            RealType vfy = RealType(0.5) * (vy[iL] + vy[iR]);
+            RealType vfz = RealType(0.5) * (vz[iL] + vz[iR]);
+            size_t off = e * NSCS + ip;
+            mine += double(vfx * areaVecX[off] + vfy * areaVecY[off] + vfz * areaVecZ[off]);
+        }
+    }
+    // block reduce into shared then one atomic per block
+    __shared__ double sdata[256];
+    int t = threadIdx.x;
+    sdata[t] = mine;
+    __syncthreads();
+    for (int s2 = blockDim.x / 2; s2 > 0; s2 >>= 1) {
+        if (t < s2) sdata[t] += sdata[t + s2];
+        __syncthreads();
+    }
+    if (t == 0) partial[blockIdx.x] = sdata[0];
+}
+
+// Host wrapper: signed interior flux across the plane (cut along the given axis,
+// 0=x,1=y,2=z). Owned elements only; globally reduced. Reads s.d_u/v/w.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+inline RealType interiorCutFlux(NSStepper<KeyType, RealType, ElementTag>& s,
+                                int axis, RealType cut)
+{
+    const auto& d_conn = s.domain.getElementToNodeConnectivity();
+    auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+    const KeyType* c0 = cp[0]; const KeyType* c1 = cp[1];
+    const KeyType* c2 = cp[2]; const KeyType* c3 = cp[3];
+    const KeyType* c4 = nullptr; const KeyType* c5 = nullptr;
+    const KeyType* c6 = nullptr; const KeyType* c7 = nullptr;
+    if constexpr (std::is_same_v<ElementTag, HexTag>) { c4 = cp[4]; c5 = cp[5]; c6 = cp[6]; c7 = cp[7]; }
+    size_t startElem = s.domain.startIndex();
+    size_t numLocal  = s.domain.localElementCount();
+    int blk = 256;
+    int eBlocks = numLocal > 0 ? int((numLocal + blk - 1) / blk) : 0;
+
+    const RealType* nodeAxis = (axis == 0) ? s.domain.getNodeX().data()
+                             : (axis == 1) ? s.domain.getNodeY().data()
+                                           : s.domain.getNodeZ().data();
+    double local = 0.0;
+    if (eBlocks > 0)
+    {
+        cstone::DeviceVector<double> d_partial(eBlocks, 0.0);
+        interiorCutFluxKernel<KeyType, RealType, ElementTag><<<eBlocks, blk>>>(
+            c0, c1, c2, c3, c4, c5, c6, c7,
+            s.d_u.data(), s.d_v.data(), s.d_w.data(),
+            nodeAxis,
+            s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+            cut, d_partial.data(), startElem, numLocal);
+        cudaDeviceSynchronize();
+        auto pp = thrust::device_pointer_cast(d_partial.data());
+        local = thrust::reduce(thrust::device, pp, pp + eBlocks, 0.0, thrust::plus<double>());
+    }
+    double global = 0.0;
+    MPI_Allreduce(&local, &global, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    return RealType(global);
 }
 
 // Sum of an owned-node device vector (e.g. divergence accumulator). Used to

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -64,15 +64,15 @@ int main(int argc, char** argv)
     std::string meshFile;
     std::string vtuPrefix;
     std::string bcMode   = "pump";    // "pump" (Exodus side-sets) or "cavity" (tet NS validation)
-    // Default mass-conserving: a velocity-inlet + free pressure-outlet leaves an
-    // UNPROJECTABLE net flux -- the divergence operator only sees interior faces,
-    // so sum(div)==0 and the pressure solve is never told mass entered -> no
-    // through-flow (flow dies at the inlet, pressure parks in the body). The
-    // mass-conserving outlet removes exactly Q (velocity outflow) + a single p=0
-    // pin, balancing the flux so the projection builds the inlet->outlet gradient
-    // that drives flow THROUGH the passage. --outlet=do-nothing selects the free
-    // pressure outlet (only correct once a boundary-flux source term is added).
-    std::string outletMode = "mass-conserving";
+    // Default do-nothing: pin p=0 over the WHOLE outlet face and leave the outlet
+    // velocity FREE (natural-Neumann). This is the channel-proven pairing -- a
+    // fixed-pressure outlet against a velocity-inlet forces the interior pressure
+    // to ramp inlet->outlet, building the cross-passage head that drives flow
+    // THROUGH the passage. Pinning BOTH ends as velocity-Dirichlet + a single p=0
+    // pin (mass-conserving) leaves a flat-pressure tank-recirculation solution ->
+    // dead passage. --outlet=mass-conserving restores the single-pin velocity
+    // outflow (kept selectable for A/B against the legacy pump state).
+    std::string outletMode = "do-nothing";
     // Advection scheme: "skew" (KE-conserving, default), "upwind" (1st-order),
     // or "barth-jespersen" (2nd-order limited, matches mesh developers' legacy).
     std::string advScheme  = "skew";
@@ -96,6 +96,14 @@ int main(int argc, char** argv)
     // uniform (Uinf,0,0) IC seeds spurious +x flow in both tanks; --pump-uniform-ic
     // restores it for comparison.
     bool pumpUniformIC = false;
+    // GUARDED, off by default. Integrate the prescribed inlet velocity over the
+    // inlet boundary faces and add the net inflow as a source into the pressure-
+    // Poisson divergence at inlet nodes. The interior SCS scatter already gives a
+    // LOCAL inlet source, but the EXTERIOR boundary-face flux through the opening
+    // is in no element's interior sub-control-surface, so it is never integrated.
+    // This adds exactly that missing term. Default false keeps the do-nothing
+    // path byte-identical until we A/B it.
+    bool addInletFluxSource = false;
     RealType    inletU   = 0.5;        // inlet speed (m/s)
     RealType    rho      = 1000.0;     // water (kg/m^3)
     RealType    nu       = 1.0e-6;     // water kinematic viscosity (m^2/s) = mu/rho
@@ -116,8 +124,9 @@ int main(int argc, char** argv)
         if      (a.rfind("--mesh=", 0) == 0)         meshFile  = a.substr(7);
         else if (a.rfind("--vtu-output=", 0) == 0)   vtuPrefix = a.substr(13);
         else if (a == "--bc=cavity")                 bcMode    = "cavity";  // tet NS validation: lid-driven cavity, no side-sets
-        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // free velocity + p=0 face (unprojectable w/o a flux source)
-        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // DEFAULT: velocity outflow + single pin (drives through-flow)
+        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // DEFAULT: whole-face p=0 + free outlet velocity (through-flow driver)
+        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // velocity outflow + single p=0 pin (legacy pump state)
+        else if (a == "--inlet-flux-source")         addInletFluxSource = true;      // add prescribed inlet flux as a divergence source (GUARDED, off by default)
         else if (a == "--upwind")                    advScheme  = "upwind";  // 1st-order upwind
         else if (a == "--skew")                      advScheme  = "skew";    // skew-symmetric (default)
         else if (a == "--bj")                        advScheme  = "barth-jespersen"; // 2nd-order limited
@@ -154,6 +163,11 @@ int main(int argc, char** argv)
                     "  --inlet-ss=NAME      inlet side-set name (required for pump BC)\n"
                     "  --inlet-flip-normal  flip inlet normal sign (use if vectors come out OUTWARD)\n"
                     "  --outlet-ss=NAME     outlet side-set name (required for pump BC)\n"
+                    "  --outlet=MODE        do-nothing (DEFAULT: whole-face p=0 + FREE outlet velocity,\n"
+                    "                       the through-flow driver) | mass-conserving (velocity outflow\n"
+                    "                       + single p=0 pin, legacy pump state)\n"
+                    "  --inlet-flux-source  add the prescribed inlet boundary flux as a pressure-Poisson\n"
+                    "                       divergence source at inlet nodes (GUARDED, off by default)\n"
                     "  --inlet-velocity=V   inlet speed along x (default 0.5)\n"
                     "  --no-inlet-pernode-normal  use one global inlet normal (default: per-node)\n"
                     "  --advection=NAME     skew (default) | upwind | barth-jespersen (--bj)\n"
@@ -197,7 +211,11 @@ int main(int argc, char** argv)
             std::cout << "BC          = lid-driven cavity (lid u = " << inletU << ")\n";
         else
             std::cout << "Inlet  SS   = " << inletSS  << "  (u = " << inletU << ")\n"
-                      << "Outlet SS   = " << outletSS << "  (p = 0)\n"
+                      << "Outlet SS   = " << outletSS
+                      << (outletMode == "mass-conserving"
+                            ? "  (velocity outflow + single p=0 pin)"
+                            : "  (whole-face p=0, FREE outlet velocity -- through-flow driver)") << "\n"
+                      << "Inlet flux  = " << (addInletFluxSource ? "boundary-flux source ON" : "OFF (interior SCS only)") << "\n"
                       << "Walls       = all other side-sets (no-slip)\n";
         std::cout << "rho         = " << rho << "   nu = " << nu << "\n"
                   << "dt          = " << dt << "   steps = " << numSteps << "\n"
@@ -291,6 +309,12 @@ int main(int argc, char** argv)
     // mass-conserving (velocity-Dirichlet outflow + single pin). The latter
     // over-constrains velocity and was seen to blow up after several flow-throughs.
     s.outletDoNothing = (outletMode != "mass-conserving");
+    s.addInletFluxSource = addInletFluxSource;
+
+    // Prescribed inlet volume flux Q_in = inletU * areaIn, captured at function
+    // scope so the per-step through-flow diagnostic can compare it to the measured
+    // outlet flux. <0 means "not a pump case / no inlet area".
+    double qIn = -1.0;
 
     // -------- Resolve side-sets to local node lists (pump semantics) --------
     if (!cavityMode)
@@ -492,9 +516,69 @@ int main(int argc, char** argv)
             return std::sqrt(out[0]*out[0] + out[1]*out[1] + out[2]*out[2]);
         };
 
+        // Per-node OUTWARD area-vector for a side-set, nodeCount-sized, zero off
+        // the set. Same once-per-face owned scatter + reverse-halo-add + forward-
+        // halo publish as the inlet-normal path, so a node whose incident faces
+        // span ranks still gets the complete owner sum. The magnitude at a node is
+        // its share of the opening area; the direction is outward (Exodus winding).
+        // Reused by the inlet per-node normals, the inlet flux source, and the
+        // through-flow diagnostic so the geometry is computed one consistent way.
+        auto perNodeAreaVec = [&](const std::string& nm,
+                                  std::vector<RealType>& outX,
+                                  std::vector<RealType>& outY,
+                                  std::vector<RealType>& outZ)
+        {
+            const size_t nNodes = amr.domain().getNodeCount();
+            outX.assign(nNodes, RealType(0));
+            outY.assign(nNodes, RealType(0));
+            outZ.assign(nNodes, RealType(0));
+            auto tit = ss.triangleCoordsByName.find(nm);
+            if (tit != ss.triangleCoordsByName.end())
+            {
+                std::vector<int> triLocal =
+                    amr.domain().resolveSideSetNodesToLocalKeepMisses(tit->second);
+                for (size_t f = 0; f + 2 < tit->second.size(); f += 3)
+                {
+                    int la = triLocal[f];
+                    if (la < 0 || hostOwnFA[la] != 1) continue;   // count once: owner of first node
+                    const auto& A = tit->second[f];
+                    const auto& B = tit->second[f + 1];
+                    const auto& C = tit->second[f + 2];
+                    double e1x = B[0]-A[0], e1y = B[1]-A[1], e1z = B[2]-A[2];
+                    double e2x = C[0]-A[0], e2y = C[1]-A[1], e2z = C[2]-A[2];
+                    double ax = 0.5*(e1y*e2z - e1z*e2y);
+                    double ay = 0.5*(e1z*e2x - e1x*e2z);
+                    double az = 0.5*(e1x*e2y - e1y*e2x);
+                    // Spread the triangle area-vector equally over its 3 vertices.
+                    for (int j = 0; j < 3; ++j)
+                    {
+                        int li = triLocal[f + j];
+                        if (li < 0 || (size_t)li >= nNodes) continue;
+                        outX[li] += RealType(ax / 3.0);
+                        outY[li] += RealType(ay / 3.0);
+                        outZ[li] += RealType(az / 3.0);
+                    }
+                }
+            }
+            cstone::DeviceVector<RealType> dX(nNodes), dY(nNodes), dZ(nNodes);
+            cudaMemcpy(dX.data(), outX.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(dY.data(), outY.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(dZ.data(), outZ.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            amr.domain().reverseExchangeNodeHaloAdd(dX);
+            amr.domain().reverseExchangeNodeHaloAdd(dY);
+            amr.domain().reverseExchangeNodeHaloAdd(dZ);
+            amr.domain().exchangeNodeHalo(dX);
+            amr.domain().exchangeNodeHalo(dY);
+            amr.domain().exchangeNodeHalo(dZ);
+            cudaMemcpy(outX.data(), dX.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
+            cudaMemcpy(outY.data(), dY.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
+            cudaMemcpy(outZ.data(), dZ.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
+        };
+
         double aIn[3], aOut[3];
         double areaIn  = faceAreaVec(inletSS,  aIn);
         double areaOut = faceAreaVec(outletSS, aOut);
+        qIn = double(inletU) * areaIn;   // prescribed inflow for the through-flow diagnostic
 
         // Inlet velocity along the INWARD normal (-outward), magnitude Uinf.
         // sgn flips the whole convention if the mesh's face winding makes the
@@ -507,75 +591,23 @@ int main(int argc, char** argv)
             s.inletDirZ = RealType(sgn * aIn[2] / areaIn);
         }
 
+        // -------- Per-node inlet OUTWARD area-vectors --------
+        // One halo-complete per-node inlet area-vector field feeds two things: the
+        // per-node inward normals (direction = -areaVec/|areaVec|) and the guarded
+        // inlet flux source (flux = uTarget . areaVec). Computing it once keeps the
+        // two consistent.
+        std::vector<RealType> h_inAx, h_inAy, h_inAz;
+        if (areaIn > 1e-30) perNodeAreaVec(inletSS, h_inAx, h_inAy, h_inAz);
+
         // -------- Per-node inlet inward normals --------
-        // The single global inletDir makes every inlet vector parallel, which on
-        // a curved inlet looks non-normal. Instead give each inlet node its OWN
-        // normal: the area-weighted sum of the inlet faces touching it. The
-        // accumulation is keyed by runtime local node id (same id space as
-        // s.inletNodes, which sideSetNodes() returns) and folded across ranks
-        // with the standard node-halo primitives, so a node whose incident faces
-        // span ranks still gets the full sum before normalizing.
+        // The single global inletDir makes every inlet vector parallel, which on a
+        // curved inlet looks non-normal. Give each inlet node its OWN normal from
+        // the area-vector above (sign flips to INWARD, matching -aIn/areaIn).
+        // Degenerate sums fall back to the global inlet direction so no node is
+        // left unset.
         if (inletPernodeNormal && areaIn > 1e-30)
         {
             const size_t nNodes = amr.domain().getNodeCount();
-            std::vector<RealType> h_nx(nNodes, RealType(0)),
-                                  h_ny(nNodes, RealType(0)),
-                                  h_nz(nNodes, RealType(0));
-            auto tit = ss.triangleCoordsByName.find(inletSS);
-            if (tit != ss.triangleCoordsByName.end())
-            {
-                // Resolve every triangle vertex to its local id (KeepMisses keeps
-                // 1:1 alignment with the coord array). Scatter each face exactly
-                // ONCE globally -- on the rank that OWNS its first node -- the
-                // same once-per-face gate faceAreaVec uses. reverseExchangeNodeHaloAdd
-                // then routes any contribution that landed on a ghost endpoint to
-                // that node's true owner; the forward exchange publishes the
-                // complete owner sum back to all ghosts. This mirrors the lumped-
-                // mass scatter pattern (owned-only scatter + reverse-add + forward).
-                std::vector<int> triLocal =
-                    amr.domain().resolveSideSetNodesToLocalKeepMisses(tit->second);
-                for (size_t f = 0; f + 2 < tit->second.size(); f += 3)
-                {
-                    int la = triLocal[f];
-                    if (la < 0 || hostOwnFA[la] != 1) continue;  // count once: owner of first node
-                    const auto& A = tit->second[f];
-                    const auto& B = tit->second[f + 1];
-                    const auto& C = tit->second[f + 2];
-                    double e1x = B[0]-A[0], e1y = B[1]-A[1], e1z = B[2]-A[2];
-                    double e2x = C[0]-A[0], e2y = C[1]-A[1], e2z = C[2]-A[2];
-                    double ax = 0.5*(e1y*e2z - e1z*e2y);
-                    double ay = 0.5*(e1z*e2x - e1x*e2z);
-                    double az = 0.5*(e1x*e2y - e1y*e2x);
-                    for (int j = 0; j < 3; ++j)
-                    {
-                        int li = triLocal[f + j];
-                        if (li < 0 || (size_t)li >= nNodes) continue;
-                        h_nx[li] += RealType(ax);
-                        h_ny[li] += RealType(ay);
-                        h_nz[li] += RealType(az);
-                    }
-                }
-            }
-
-            // Fold cross-rank partials onto owners, then publish complete sums
-            // back to ghosts (mirrors every other nodal-accumulate path here).
-            cstone::DeviceVector<RealType> d_nx(nNodes), d_ny(nNodes), d_nz(nNodes);
-            cudaMemcpy(d_nx.data(), h_nx.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
-            cudaMemcpy(d_ny.data(), h_ny.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
-            cudaMemcpy(d_nz.data(), h_nz.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
-            amr.domain().reverseExchangeNodeHaloAdd(d_nx);
-            amr.domain().reverseExchangeNodeHaloAdd(d_ny);
-            amr.domain().reverseExchangeNodeHaloAdd(d_nz);
-            amr.domain().exchangeNodeHalo(d_nx);
-            amr.domain().exchangeNodeHalo(d_ny);
-            amr.domain().exchangeNodeHalo(d_nz);
-            cudaMemcpy(h_nx.data(), d_nx.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
-            cudaMemcpy(h_ny.data(), d_ny.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
-            cudaMemcpy(h_nz.data(), d_nz.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
-
-            // Per inlet node: normalize then flip to INWARD (negate), matching the
-            // -aIn/areaIn convention of the global normal. Degenerate sums fall
-            // back to the global inlet direction so no node is left unset.
             s.inletDirXPerNode.resize(s.inletNodes.size());
             s.inletDirYPerNode.resize(s.inletNodes.size());
             s.inletDirZPerNode.resize(s.inletNodes.size());
@@ -585,7 +617,7 @@ int main(int argc, char** argv)
                 double nx = 0, ny = 0, nz = 0;
                 if (li >= 0 && (size_t)li < nNodes)
                 {
-                    nx = h_nx[li]; ny = h_ny[li]; nz = h_nz[li];
+                    nx = h_inAx[li]; ny = h_inAy[li]; nz = h_inAz[li];
                 }
                 double len = std::sqrt(nx*nx + ny*ny + nz*nz);
                 if (len > 1e-30)
@@ -605,7 +637,35 @@ int main(int argc, char** argv)
                 std::cout << "    inlet:  per-node inward normals ON ("
                           << s.inletNodes.size() << " local nodes; --no-inlet-pernode-normal to disable)\n";
         }
-        // Mass-conserving outlet: a velocity-inlet + pressure-only outlet leaves
+
+        // Plumb the per-node inlet area-vectors to the solver for the guarded
+        // inlet flux source. Stored ONLY when the source is enabled, so the
+        // default path allocates nothing new.
+        if (addInletFluxSource && areaIn > 1e-30)
+        {
+            const size_t nNodes = amr.domain().getNodeCount();
+            s.d_inletAreaVecX.resize(nNodes);
+            s.d_inletAreaVecY.resize(nNodes);
+            s.d_inletAreaVecZ.resize(nNodes);
+            cudaMemcpy(s.d_inletAreaVecX.data(), h_inAx.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_inletAreaVecY.data(), h_inAy.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_inletAreaVecZ.data(), h_inAz.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+        }
+
+        // Per-node OUTWARD outlet area-vectors for the through-flow diagnostic
+        // (Q_out = sum_owned u.areaVec). Always available for the pump print.
+        if (areaOut > 1e-30)
+        {
+            const size_t nNodes = amr.domain().getNodeCount();
+            std::vector<RealType> h_outAx, h_outAy, h_outAz;
+            perNodeAreaVec(outletSS, h_outAx, h_outAy, h_outAz);
+            s.d_outletAreaVecX.resize(nNodes);
+            s.d_outletAreaVecY.resize(nNodes);
+            s.d_outletAreaVecZ.resize(nNodes);
+            cudaMemcpy(s.d_outletAreaVecX.data(), h_outAx.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_outletAreaVecY.data(), h_outAy.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_outletAreaVecZ.data(), h_outAz.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+        }
         // Outlet BC depends on the mode:
         //  - do-nothing (default): leave outletU<=0 so the solver masks the WHOLE
         //    outlet face as p=0 Dirichlet with FREE velocity. The inlet injects
@@ -861,6 +921,15 @@ int main(int argc, char** argv)
             RealType vmx = maxOwnedInteriorAbs<KeyType, RealType, TetTag>(s, s.d_v);
             RealType wmx = maxOwnedInteriorAbs<KeyType, RealType, TetTag>(s, s.d_w);
             double uMax = std::sqrt(double(umx)*double(umx) + double(vmx)*double(vmx) + double(wmx)*double(wmx));
+            // Through-flow: measured outlet flux Q_out = sum_owned(u . outletAreaVec)
+            // vs the prescribed inflow Q_in. Ratio -> 1 means mass crosses the whole
+            // domain (passage is live). fluxThroughOwned is collective -> all ranks.
+            double qOut = 0.0;
+            bool haveFlux = !cavityMode && qIn > 0.0 && s.d_outletAreaVecX.size() == s.nodeCount;
+            if (haveFlux)
+                qOut = double(fluxThroughOwned<KeyType, RealType, TetTag>(
+                    s, s.d_u, s.d_v, s.d_w,
+                    s.d_outletAreaVecX, s.d_outletAreaVecY, s.d_outletAreaVecZ));
             double divND = (inletU > 0 && Lscale > 0)
                            ? double(s.lastDivMax) * Lscale / inletU : double(s.lastDivMax);
             // RC-flux divergence (the operator RC actually zeros); only meaningful
@@ -886,6 +955,12 @@ int main(int argc, char** argv)
                           << "  pres_res=" << std::scientific << std::setprecision(3) << s.lastPressResid
                           << "  cg_uvw=" << s.lastUIters
                           << "\n" << std::defaultfloat;
+                if (haveFlux)
+                    std::cout << "  [through-flow] Q_in=" << std::scientific << std::setprecision(3) << qIn
+                              << "  Q_out=" << qOut
+                              << "  ratio=" << std::fixed << std::setprecision(3)
+                              << (std::abs(qIn) > 0 ? qOut / qIn : 0.0)
+                              << "\n" << std::defaultfloat;
             }
         }
         if (!vtuPrefix.empty() && (step % vtuEvery == 0 || step == numSteps))

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -64,15 +64,14 @@ int main(int argc, char** argv)
     std::string meshFile;
     std::string vtuPrefix;
     std::string bcMode   = "pump";    // "pump" (Exodus side-sets) or "cavity" (tet NS validation)
-    // Default do-nothing: pin p=0 over the WHOLE outlet face and leave the outlet
-    // velocity FREE (natural-Neumann). This is the channel-proven pairing -- a
-    // fixed-pressure outlet against a velocity-inlet forces the interior pressure
-    // to ramp inlet->outlet, building the cross-passage head that drives flow
-    // THROUGH the passage. Pinning BOTH ends as velocity-Dirichlet + a single p=0
-    // pin (mass-conserving) leaves a flat-pressure tank-recirculation solution ->
-    // dead passage. --outlet=mass-conserving restores the single-pin velocity
-    // outflow (kept selectable for A/B against the legacy pump state).
-    std::string outletMode = "do-nothing";
+    // Default mass-conserving: velocity-Dirichlet outflow U_out = U_in*A_in/A_out
+    // along the outward normal + a single p=0 pin. This FORCES Q_out=Q_in by
+    // construction and is the validated through-flow-capable config (legacy pump
+    // state). The do-nothing alternative (p=0 over the WHOLE outlet face + free
+    // outlet velocity) does NOT self-drive a small interior outlet: it was verified
+    // to leave the passage dead (through-flow ratio=0). --outlet=do-nothing kept
+    // selectable for diagnostics only.
+    std::string outletMode = "mass-conserving";
     // Advection scheme: "skew" (KE-conserving, default), "upwind" (1st-order),
     // or "barth-jespersen" (2nd-order limited, matches mesh developers' legacy).
     std::string advScheme  = "skew";
@@ -96,14 +95,6 @@ int main(int argc, char** argv)
     // uniform (Uinf,0,0) IC seeds spurious +x flow in both tanks; --pump-uniform-ic
     // restores it for comparison.
     bool pumpUniformIC = false;
-    // GUARDED, off by default. Integrate the prescribed inlet velocity over the
-    // inlet boundary faces and add the net inflow as a source into the pressure-
-    // Poisson divergence at inlet nodes. The interior SCS scatter already gives a
-    // LOCAL inlet source, but the EXTERIOR boundary-face flux through the opening
-    // is in no element's interior sub-control-surface, so it is never integrated.
-    // This adds exactly that missing term. Default false keeps the do-nothing
-    // path byte-identical until we A/B it.
-    bool addInletFluxSource = false;
     RealType    inletU   = 0.5;        // inlet speed (m/s)
     RealType    rho      = 1000.0;     // water (kg/m^3)
     RealType    nu       = 1.0e-6;     // water kinematic viscosity (m^2/s) = mu/rho
@@ -124,9 +115,8 @@ int main(int argc, char** argv)
         if      (a.rfind("--mesh=", 0) == 0)         meshFile  = a.substr(7);
         else if (a.rfind("--vtu-output=", 0) == 0)   vtuPrefix = a.substr(13);
         else if (a == "--bc=cavity")                 bcMode    = "cavity";  // tet NS validation: lid-driven cavity, no side-sets
-        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // DEFAULT: whole-face p=0 + free outlet velocity (through-flow driver)
-        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // velocity outflow + single p=0 pin (legacy pump state)
-        else if (a == "--inlet-flux-source")         addInletFluxSource = true;      // add prescribed inlet flux as a divergence source (GUARDED, off by default)
+        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // whole-face p=0 + free outlet velocity (diagnostic; does NOT drive through-flow)
+        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // DEFAULT: velocity outflow + single p=0 pin, forces Q_out=Q_in (legacy pump state)
         else if (a == "--upwind")                    advScheme  = "upwind";  // 1st-order upwind
         else if (a == "--skew")                      advScheme  = "skew";    // skew-symmetric (default)
         else if (a == "--bj")                        advScheme  = "barth-jespersen"; // 2nd-order limited
@@ -163,11 +153,9 @@ int main(int argc, char** argv)
                     "  --inlet-ss=NAME      inlet side-set name (required for pump BC)\n"
                     "  --inlet-flip-normal  flip inlet normal sign (use if vectors come out OUTWARD)\n"
                     "  --outlet-ss=NAME     outlet side-set name (required for pump BC)\n"
-                    "  --outlet=MODE        do-nothing (DEFAULT: whole-face p=0 + FREE outlet velocity,\n"
-                    "                       the through-flow driver) | mass-conserving (velocity outflow\n"
-                    "                       + single p=0 pin, legacy pump state)\n"
-                    "  --inlet-flux-source  add the prescribed inlet boundary flux as a pressure-Poisson\n"
-                    "                       divergence source at inlet nodes (GUARDED, off by default)\n"
+                    "  --outlet=MODE        mass-conserving (DEFAULT: velocity outflow + single p=0\n"
+                    "                       pin, forces Q_out=Q_in) | do-nothing (whole-face p=0 + FREE\n"
+                    "                       outlet velocity, diagnostic only -- does NOT drive through-flow)\n"
                     "  --inlet-velocity=V   inlet speed along x (default 0.5)\n"
                     "  --no-inlet-pernode-normal  use one global inlet normal (default: per-node)\n"
                     "  --advection=NAME     skew (default) | upwind | barth-jespersen (--bj)\n"
@@ -213,9 +201,8 @@ int main(int argc, char** argv)
             std::cout << "Inlet  SS   = " << inletSS  << "  (u = " << inletU << ")\n"
                       << "Outlet SS   = " << outletSS
                       << (outletMode == "mass-conserving"
-                            ? "  (velocity outflow + single p=0 pin)"
-                            : "  (whole-face p=0, FREE outlet velocity -- through-flow driver)") << "\n"
-                      << "Inlet flux  = " << (addInletFluxSource ? "boundary-flux source ON" : "OFF (interior SCS only)") << "\n"
+                            ? "  (velocity outflow + single p=0 pin, forces Q_out=Q_in)"
+                            : "  (whole-face p=0, FREE outlet velocity -- diagnostic, no through-flow)") << "\n"
                       << "Walls       = all other side-sets (no-slip)\n";
         std::cout << "rho         = " << rho << "   nu = " << nu << "\n"
                   << "dt          = " << dt << "   steps = " << numSteps << "\n"
@@ -305,11 +292,10 @@ int main(int argc, char** argv)
         ? NSStepper<KeyType, RealType, TetTag>::BCKind::Cavity
         : NSStepper<KeyType, RealType, TetTag>::BCKind::Pump;
     s.lidU = RealType(inletU);   // cavity lid speed reuses the inlet-velocity flag
-    // Outlet treatment: do-nothing (free velocity + p=0 face, default, stable) or
-    // mass-conserving (velocity-Dirichlet outflow + single pin). The latter
-    // over-constrains velocity and was seen to blow up after several flow-throughs.
+    // Outlet treatment: mass-conserving (velocity-Dirichlet outflow + single pin,
+    // default, forces Q_out=Q_in) or do-nothing (free velocity + whole-face p=0,
+    // diagnostic only -- does not self-drive the passage).
     s.outletDoNothing = (outletMode != "mass-conserving");
-    s.addInletFluxSource = addInletFluxSource;
 
     // Prescribed inlet volume flux Q_in = inletU * areaIn, captured at function
     // scope so the per-step through-flow diagnostic can compare it to the measured
@@ -592,10 +578,8 @@ int main(int argc, char** argv)
         }
 
         // -------- Per-node inlet OUTWARD area-vectors --------
-        // One halo-complete per-node inlet area-vector field feeds two things: the
-        // per-node inward normals (direction = -areaVec/|areaVec|) and the guarded
-        // inlet flux source (flux = uTarget . areaVec). Computing it once keeps the
-        // two consistent.
+        // Halo-complete per-node inlet area-vector field; feeds the per-node inward
+        // normals below (direction = -areaVec/|areaVec|).
         std::vector<RealType> h_inAx, h_inAy, h_inAz;
         if (areaIn > 1e-30) perNodeAreaVec(inletSS, h_inAx, h_inAy, h_inAz);
 
@@ -636,20 +620,6 @@ int main(int argc, char** argv)
             if (rank == 0)
                 std::cout << "    inlet:  per-node inward normals ON ("
                           << s.inletNodes.size() << " local nodes; --no-inlet-pernode-normal to disable)\n";
-        }
-
-        // Plumb the per-node inlet area-vectors to the solver for the guarded
-        // inlet flux source. Stored ONLY when the source is enabled, so the
-        // default path allocates nothing new.
-        if (addInletFluxSource && areaIn > 1e-30)
-        {
-            const size_t nNodes = amr.domain().getNodeCount();
-            s.d_inletAreaVecX.resize(nNodes);
-            s.d_inletAreaVecY.resize(nNodes);
-            s.d_inletAreaVecZ.resize(nNodes);
-            cudaMemcpy(s.d_inletAreaVecX.data(), h_inAx.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
-            cudaMemcpy(s.d_inletAreaVecY.data(), h_inAy.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
-            cudaMemcpy(s.d_inletAreaVecZ.data(), h_inAz.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
         }
 
         // Per-node OUTWARD outlet area-vectors for the through-flow diagnostic

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -108,6 +108,11 @@ int main(int argc, char** argv)
     int         blockSize  = 256;
     int         bucketSize = 64;
     RealType    icPerturb  = 0.0;
+    // FIX 1/2 through-flow toggles. Opening-flux source OFF by default so it can
+    // be A/B-ed safely (a prior naive surface-source attempt blew up). Dirichlet
+    // lift ON (a correctness fix); --no-dirichlet-lift disables for comparison.
+    bool        openingFluxSource = false;
+    bool        dirichletLift     = true;
 
     for (int i = 1; i < argc; ++i)
     {
@@ -143,6 +148,10 @@ int main(int argc, char** argv)
         else if (a.rfind("--max-iter=", 0) == 0)     maxIter   = std::stoi(a.substr(11));
         else if (a.rfind("--tol=", 0) == 0)          tolerance = std::stod(a.substr(6));
         else if (a.rfind("--ic-perturb=", 0) == 0)   icPerturb = std::stod(a.substr(13));
+        else if (a == "--opening-flux-source")        openingFluxSource = true;   // FIX 1: add inlet+outlet boundary surface flux to the pressure RHS
+        else if (a == "--no-opening-flux-source")     openingFluxSource = false;
+        else if (a == "--dirichlet-lift")             dirichletLift = true;       // FIX 2: lift inlet momentum into interior diffusion (default ON)
+        else if (a == "--no-dirichlet-lift")          dirichletLift = false;
         else if (a == "--help" || a == "-h")
         {
             if (rank == 0)
@@ -166,7 +175,11 @@ int main(int argc, char** argv)
                     "  --dt=V --num-steps=N time stepping (default 1e-3, 200)\n"
                     "  --cfl=C              adaptive dt: cap advective CFL at C (~0.5 for BJ+BDF2)\n"
                     "  --vtu-output=PREFIX --vtu-every=N   VTU/PVTU output\n"
-                    "  --ic-perturb=F       interior IC perturbation (break symmetry)\n";
+                    "  --ic-perturb=F       interior IC perturbation (break symmetry)\n"
+                    "  --opening-flux-source  add inlet+outlet boundary surface flux to the\n"
+                    "                       pressure RHS (FIX 1, off by default; A/B with --no-...)\n"
+                    "  --no-dirichlet-lift  disable the velocity-diffusion Dirichlet lift (FIX 2,\n"
+                    "                       on by default)\n";
             }
             MPI_Finalize();
             return 0;
@@ -283,6 +296,8 @@ int main(int argc, char** argv)
     s.useBdf2 = useBdf2;
     s.useRhieChow = useRhieChow;
     s.useVMSStab  = useVMSStab;   // Nalu VMS pressure stabilization (tet-only)
+    s.useOpeningFluxSource = openingFluxSource;   // FIX 1 (off by default)
+    s.useDirichletLift     = dirichletLift;       // FIX 2 (on by default)
     s.rhieChowTau = rhieTau;   // <=0 -> kernel falls back to dt/rho
     // Cavity = lid-driven cavity (geometric BC, no side-sets) -- a controlled
     // tet-NS validation case with a known flow pattern. Pump = per-side-set
@@ -582,6 +597,21 @@ int main(int argc, char** argv)
         // normals below (direction = -areaVec/|areaVec|).
         std::vector<RealType> h_inAx, h_inAy, h_inAz;
         if (areaIn > 1e-30) perNodeAreaVec(inletSS, h_inAx, h_inAy, h_inAz);
+
+        // FIX 1: push the per-node OUTWARD inlet area-vectors to the device so the
+        // opening-flux source can add ( u . areaVec ) at each inlet node. Same owner-
+        // complete field used for the inward normals above; outlet area-vecs are
+        // uploaded separately below. Only needed when the source is enabled.
+        if (openingFluxSource && areaIn > 1e-30)
+        {
+            const size_t nNodes = amr.domain().getNodeCount();
+            s.d_inletAreaVecX.resize(nNodes);
+            s.d_inletAreaVecY.resize(nNodes);
+            s.d_inletAreaVecZ.resize(nNodes);
+            cudaMemcpy(s.d_inletAreaVecX.data(), h_inAx.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_inletAreaVecY.data(), h_inAy.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_inletAreaVecZ.data(), h_inAz.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+        }
 
         // -------- Per-node inlet inward normals --------
         // The single global inletDir makes every inlet vector parallel, which on a
@@ -891,15 +921,36 @@ int main(int argc, char** argv)
             RealType vmx = maxOwnedInteriorAbs<KeyType, RealType, TetTag>(s, s.d_v);
             RealType wmx = maxOwnedInteriorAbs<KeyType, RealType, TetTag>(s, s.d_w);
             double uMax = std::sqrt(double(umx)*double(umx) + double(vmx)*double(vmx) + double(wmx)*double(wmx));
-            // Through-flow: measured outlet flux Q_out = sum_owned(u . outletAreaVec)
-            // vs the prescribed inflow Q_in. Ratio -> 1 means mass crosses the whole
-            // domain (passage is live). fluxThroughOwned is collective -> all ranks.
+            // [bc-sanity] Q_out = sum_owned(u . outletAreaVec) vs prescribed Q_in.
+            // NOT a through-flow proof: the corrector relocks the outlet nodes to
+            // the prescribed outletU, so for the mass-conserving outlet Q_out=Q_in
+            // by construction. Kept only as a BC sanity check. fluxThroughOwned is
+            // collective -> call on all ranks.
             double qOut = 0.0;
             bool haveFlux = !cavityMode && qIn > 0.0 && s.d_outletAreaVecX.size() == s.nodeCount;
             if (haveFlux)
                 qOut = double(fluxThroughOwned<KeyType, RealType, TetTag>(
                     s, s.d_u, s.d_v, s.d_w,
                     s.d_outletAreaVecX, s.d_outletAreaVecY, s.d_outletAreaVecZ));
+            // FIX 3: interior cut-plane flux probe. Reads the SOLVED interior field,
+            // so it cannot be fooled by the BC relock at the openings. Probe at
+            // 0.25/0.5/0.75 of the longest bbox axis: all three ~equal and nonzero =
+            // real through-flow; inlet-end nonzero with mid/outlet ~0 = flow dies.
+            // interiorCutFlux is collective -> compute on every rank.
+            double qc25 = 0.0, qc50 = 0.0, qc75 = 0.0;
+            int cutAxis = 0;
+            if (!cavityMode)
+            {
+                double spanX = double(s.xmax) - double(s.xmin);
+                double spanY = double(s.ymax) - double(s.ymin);
+                double spanZ = double(s.zmax) - double(s.zmin);
+                cutAxis = (spanX >= spanY && spanX >= spanZ) ? 0 : (spanY >= spanZ ? 1 : 2);
+                double lo  = (cutAxis == 0) ? double(s.xmin) : (cutAxis == 1 ? double(s.ymin) : double(s.zmin));
+                double span = (cutAxis == 0) ? spanX : (cutAxis == 1 ? spanY : spanZ);
+                qc25 = double(interiorCutFlux<KeyType, RealType, TetTag>(s, cutAxis, RealType(lo + 0.25*span)));
+                qc50 = double(interiorCutFlux<KeyType, RealType, TetTag>(s, cutAxis, RealType(lo + 0.50*span)));
+                qc75 = double(interiorCutFlux<KeyType, RealType, TetTag>(s, cutAxis, RealType(lo + 0.75*span)));
+            }
             double divND = (inletU > 0 && Lscale > 0)
                            ? double(s.lastDivMax) * Lscale / inletU : double(s.lastDivMax);
             // RC-flux divergence (the operator RC actually zeros); only meaningful
@@ -926,11 +977,22 @@ int main(int argc, char** argv)
                           << "  cg_uvw=" << s.lastUIters
                           << "\n" << std::defaultfloat;
                 if (haveFlux)
-                    std::cout << "  [through-flow] Q_in=" << std::scientific << std::setprecision(3) << qIn
+                    std::cout << "  [bc-sanity] Q_in=" << std::scientific << std::setprecision(3) << qIn
                               << "  Q_out=" << qOut
                               << "  ratio=" << std::fixed << std::setprecision(3)
                               << (std::abs(qIn) > 0 ? qOut / qIn : 0.0)
+                              << "  (prescribed-BC check, NOT through-flow)"
                               << "\n" << std::defaultfloat;
+                if (!cavityMode)
+                {
+                    const char axc[3] = {'x', 'y', 'z'};
+                    std::cout << "  [interior-flux] axis=" << axc[cutAxis]
+                              << "  cut@25%=" << std::scientific << std::setprecision(3) << qc25
+                              << "  cut@50%=" << qc50
+                              << "  cut@75%=" << qc75
+                              << "  (solved interior; ~equal+nonzero = real through-flow)"
+                              << "\n" << std::defaultfloat;
+                }
             }
         }
         if (!vtuPrefix.empty() && (step % vtuEvery == 0 || step == numSteps))

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -64,7 +64,15 @@ int main(int argc, char** argv)
     std::string meshFile;
     std::string vtuPrefix;
     std::string bcMode   = "pump";    // "pump" (Exodus side-sets) or "cavity" (tet NS validation)
-    std::string outletMode = "do-nothing";  // "do-nothing" (free vel + p=0 face) or "mass-conserving" (vel outflow + pin)
+    // Default mass-conserving: a velocity-inlet + free pressure-outlet leaves an
+    // UNPROJECTABLE net flux -- the divergence operator only sees interior faces,
+    // so sum(div)==0 and the pressure solve is never told mass entered -> no
+    // through-flow (flow dies at the inlet, pressure parks in the body). The
+    // mass-conserving outlet removes exactly Q (velocity outflow) + a single p=0
+    // pin, balancing the flux so the projection builds the inlet->outlet gradient
+    // that drives flow THROUGH the passage. --outlet=do-nothing selects the free
+    // pressure outlet (only correct once a boundary-flux source term is added).
+    std::string outletMode = "mass-conserving";
     // Advection scheme: "skew" (KE-conserving, default), "upwind" (1st-order),
     // or "barth-jespersen" (2nd-order limited, matches mesh developers' legacy).
     std::string advScheme  = "skew";
@@ -108,8 +116,8 @@ int main(int argc, char** argv)
         if      (a.rfind("--mesh=", 0) == 0)         meshFile  = a.substr(7);
         else if (a.rfind("--vtu-output=", 0) == 0)   vtuPrefix = a.substr(13);
         else if (a == "--bc=cavity")                 bcMode    = "cavity";  // tet NS validation: lid-driven cavity, no side-sets
-        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // free velocity + p=0 face (default)
-        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // velocity-Dirichlet outflow + single pin
+        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // free velocity + p=0 face (unprojectable w/o a flux source)
+        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // DEFAULT: velocity outflow + single pin (drives through-flow)
         else if (a == "--upwind")                    advScheme  = "upwind";  // 1st-order upwind
         else if (a == "--skew")                      advScheme  = "skew";    // skew-symmetric (default)
         else if (a == "--bj")                        advScheme  = "barth-jespersen"; // 2nd-order limited

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -598,13 +598,16 @@ int main(int argc, char** argv)
                           << s.inletNodes.size() << " local nodes; --no-inlet-pernode-normal to disable)\n";
         }
         // Mass-conserving outlet: a velocity-inlet + pressure-only outlet leaves
-        // an unprojectable net flux (the inlet injects U*A_in with no balanced
-        // sink). Make the outlet a Dirichlet OUTFLOW that removes exactly the
-        // inlet volume flux: U_out = (U_in * A_in) / A_out, along the OUTWARD
-        // normal. Then div(u**) is in range of the projection and flow can
-        // establish a clean inlet->outlet path. The outlet keeps p=0 for the
-        // pressure null-space (set in the stepper).
-        if (areaOut > 1e-30)
+        // Outlet BC depends on the mode:
+        //  - do-nothing (default): leave outletU<=0 so the solver masks the WHOLE
+        //    outlet face as p=0 Dirichlet with FREE velocity. The inlet injects
+        //    flux against a fixed-pressure outlet, so the interior pressure MUST
+        //    ramp outlet->suction -- a real cross-passage gradient that drives
+        //    flow THROUGH the passage. (Both-ends velocity-Dirichlet instead
+        //    admits a flat-pressure tank-recirculation solution -> no through-flow.)
+        //  - mass-conserving: velocity-Dirichlet outflow U_out=(U_in*A_in)/A_out
+        //    along the outward normal + a single p=0 pin.
+        if (!s.outletDoNothing && areaOut > 1e-30)
         {
             double Uout = (double(inletU) * areaIn) / areaOut;
             s.outletU    = RealType(Uout);


### PR DESCRIPTION
- **fix(pump): revive the pressure outlet (the REAL through-flow fix). outletU was set unconditionally -> always velocity-Dirichlet outlet -> both-ends-Dirichlet admits a flat-pressure tank-recirculation div=0 solution -> NO flow through the passage (confirmed: 1e-10 pressure solve gave identical flat-p, so it's structural not convergence -- AMG would NOT help). Gate outletU on !outletDoNothing so do-nothing (default) leaves outletU<=0 -> solver masks the WHOLE outlet face p=0 + frees outlet velocity (singlePin=false, solver:4080) -> inlet flux against fixed-p outlet FORCES the outlet->suction gradient -> through-flow. The dead --outlet flag now actually works**
- **fix(pump): default outlet back to MASS-CONSERVING (the correct design). Root cause found: the divergence operator only loops interior faces (sum(div)==0 always), so the pressure solve is NEVER told mass enters at the inlet -> a velocity-inlet + free pressure-outlet is UNPROJECTABLE -> no through-flow (flow dies at inlet, pressure parks in body). The code's own comment (solver:2295) flags this. My prior do-nothing default was backwards: the mass-conserving outlet (vel outflow removes Q + single pin) BALANCES the flux so the projection builds the inlet->outlet gradient that drives flow through the passage. The dead-flag gate stays so do-nothing is still selectable (needs a boundary-flux source term to be correct -- separate work)**
- **pump through-flow: (1) default to do-nothing outlet = whole-face p=0 + FREE outlet velocity (the channel-proven pairing that builds the inlet->outlet pressure head; both-ends-velocity-Dirichlet + single pin gave a flat-pressure dead-passage solution). (2) --inlet-flux-source (GUARDED, off): add the prescribed inlet flux as a boundary divergence source -- the exterior opening flux is in no interior SCS so it's never integrated (verified not a double-count); A/B it. (3) [through-flow] Q_in/Q_out/ratio diagnostic each step so we MEASURE through-flow (ratio->1) instead of eyeballing uMax. mass-conserving still selectable. cavity/channel/TGV unaffected**
- **pump: REMOVE the broken --inlet-flux-source (double-counted the inlet flux already registered via interior SCS scatter; full-opening-area x rho/dt -> instant blowup, ratio=garbage) and revert default to MASS-CONSERVING outlet. Verified high-confidence: the inlet flux is already in the divergence for a velocity-Dirichlet inlet, so the only correct inlet boundary source is ZERO. do-nothing (whole-face p=0 + free outlet) does NOT self-drive a small interior outlet -> ratio=0 (no through-flow); the prior do-nothing-default + comments were disproven by the A/B. mass-conserving (U_out=Uin*Ain/Aout + single pin) forces Q_out=Q_in by construction. Kept the [through-flow] Q diagnostic (correct + useful)**
- **pump through-flow REWORK (verified root cause): the reference flows through the pump with ANY scheme (bj/upwind) so the dead passage is OUR bug, not Re/scheme. TWO real defects fixed: FIX1 --opening-flux-source (GUARDED off): inlet/outlet OPENING faces are exterior, in no interior SCS, so the prescribed opening flux never reaches the pressure RHS -> pressure flat -> no through-flow. Add it as a COMPATIBLE surface integral (u.n)*A_share, SAME scale as interior scatter, NOT x rho/dt (RHS does it), net~0 -- verified NOT a double-count (telescoping interior pairs never touch the opening face). FIX2 --dirichlet-lift (default ON): velocity-diffusion col-zero had no Dirichlet lift -> inlet momentum never diffused inward -> jet died at inlet. Add b-=K[row,bdry]*uTarget. FIX3: replace TAUTOLOGICAL Q_out (relocked to prescribed outletU) with an INTERIOR cut-plane flux probe at 25/50/75% -- measures SOLVED through-flow, can't be faked. old line relabeled [bc-sanity]**
