### PR TITLE
cstone

### DIFF
--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -7187,7 +7187,46 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
             {
                 mars::fem::removeMean<RealType>(s.domain, d_bNode, MPI_COMM_WORLD);
             }
+            // MARS_OFS_DBG: is the RHS b huge at the OPENING nodes (tiny DDT diagonal
+            // there) or uniform? print b|max overall vs b|max on inlet/outlet nodes.
+            if (s.useOpeningFluxSource && std::getenv("MARS_OFS_DBG") && s.rank == 0) {
+                const auto& d_own = s.domain.getNodeOwnershipMap();
+                auto bMaxWhere = [&] (bool wantOpening) -> RealType {
+                    const RealType* aIn = s.d_inletAreaVecX.data();
+                    const RealType* aOut = s.d_outletAreaVecX.data();
+                    return thrust::transform_reduce(thrust::device,
+                        thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+                        [own = d_own.data(), b = d_bNode.data(), n2d = s.d_node_to_dof.data(),
+                         aIn, aOut, wantOpening] __device__ (size_t i) -> RealType {
+                            if (own[i] != 1 || n2d[i] < 0) return RealType(0);
+                            bool opening = (aIn[i]*aIn[i] > RealType(0)) || (aOut[i]*aOut[i] > RealType(0));
+                            return (opening == wantOpening) ? fabs(b[i]) : RealType(0);
+                        }, RealType(0), thrust::maximum<RealType>());
+                };
+                std::cout << "  [ofs-dbg3] b|max opening=" << std::scientific << bMaxWhere(true)
+                          << " interior=" << bMaxWhere(false)
+                          << " (diagDDT range printed above)"
+                          << std::defaultfloat << "\n";
+            }
             s.lastPressureIters = solvePressureDDT<KeyType, RealType, ElementTag>(s, d_bNode, s.d_phi);
+            // MARS_OFS_DBG: WHERE is phi huge -- opening nodes (local, tiny diagonal)
+            // or everywhere (global drift)? this distinguishes the last 2 hypotheses.
+            if (s.useOpeningFluxSource && std::getenv("MARS_OFS_DBG") && s.rank == 0) {
+                const auto& d_own = s.domain.getNodeOwnershipMap();
+                auto phiMaxWhere = [&] (bool wantOpening) -> RealType {
+                    const RealType* aIn = s.d_inletAreaVecX.data();
+                    const RealType* aOut = s.d_outletAreaVecX.data();
+                    return thrust::transform_reduce(thrust::device,
+                        thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+                        [own = d_own.data(), ph = s.d_phi.data(), aIn, aOut, wantOpening] __device__ (size_t i) -> RealType {
+                            if (own[i] != 1) return RealType(0);
+                            bool opening = (aIn[i]*aIn[i] > RealType(0)) || (aOut[i]*aOut[i] > RealType(0));
+                            return (opening == wantOpening) ? fabs(ph[i]) : RealType(0);
+                        }, RealType(0), thrust::maximum<RealType>());
+                };
+                std::cout << "  [ofs-dbg4] phi|max opening=" << std::scientific << phiMaxWhere(true)
+                          << " interior=" << phiMaxWhere(false) << std::defaultfloat << "\n";
+            }
         }
     }
 

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -1665,35 +1665,6 @@ __global__ void computeDivergencePerNodeKernel(const KeyType* c0, const KeyType*
 }
 
 // =============================================================================
-// Inlet boundary-flux source (GUARDED, opt-in). The interior SCS divergence
-// scatter integrates only the INTERIOR sub-control-surfaces of each element; the
-// EXTERIOR inlet-face portion of a boundary node's control volume has no interior
-// SCS face, so the mass actually crossing the inlet opening is never registered.
-// This adds it: per inlet node, += (uTarget . areaVecOutward), where areaVec is
-// the node's outward inlet area-vector. A prescribed inflow makes uTarget oppose
-// the outward normal, so the term is NEGATIVE -- net inflow shows up as negative
-// divergence, which is exactly the sign the projection needs to pull mass in.
-// Only inlet nodes carry a nonzero areaVec; every other node adds 0.
-// =============================================================================
-
-template<typename RealType>
-__global__ void addInletFluxSourceKernel(const RealType* uTgt,
-                                         const RealType* vTgt,
-                                         const RealType* wTgt,
-                                         const RealType* areaVecX,
-                                         const RealType* areaVecY,
-                                         const RealType* areaVecZ,
-                                         RealType* divAccNode,
-                                         size_t numNodes)
-{
-    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i >= numNodes) return;
-    RealType ax = areaVecX[i], ay = areaVecY[i], az = areaVecZ[i];
-    // Off-inlet nodes have a zero area-vector -> no-op.
-    divAccNode[i] += uTgt[i] * ax + vTgt[i] * ay + wTgt[i] * az;
-}
-
-// =============================================================================
 // Rhie-Chow corrected divergence kernel for periodic Q1-Q1 CVFEM. Same as
 // computeDivergencePerNodeKernel but adds the Rhie-Chow pressure-velocity
 // coupling correction at each SCS face:
@@ -2328,17 +2299,6 @@ struct NSStepper
     RealType outletDirX = 1, outletDirY = 0, outletDirZ = 0;
     bool outletDoNothing = true;  // do-nothing outlet (free velocity + p=0 face); false = mass-conserving velocity outlet
 
-    // GUARDED inlet boundary-flux source (off by default). The interior SCS
-    // divergence scatter never integrates the EXTERIOR inlet-face flux (that part
-    // of a boundary node's control volume has no interior sub-control-surface), so
-    // a velocity-inlet + free-pressure outlet under-counts the mass actually
-    // entering. When enabled, runPressureSolveStep adds the prescribed inflow
-    // (uTarget . n)*A per inlet node into the divergence accumulator before the
-    // RHS build. d_inletAreaVec{X,Y,Z} are the per-node OUTWARD inlet area-vectors
-    // (un-normalized, nodeCount-sized, zero off the inlet); the source is the dot
-    // of the prescribed inlet velocity with this vector. Filled by the driver.
-    bool addInletFluxSource = false;
-    cstone::DeviceVector<RealType> d_inletAreaVecX, d_inletAreaVecY, d_inletAreaVecZ;
     // Per-node OUTWARD outlet area-vectors (un-normalized, nodeCount-sized, zero
     // off the outlet). Used only by the through-flow diagnostic to measure
     // Q_out = sum_owned( u . outletAreaVec ). Filled by the driver.
@@ -6573,23 +6533,6 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
     }
     s.domain.reverseExchangeNodeHaloAdd(d_divAccNode);
     maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_divAccNode);
-
-    // GUARDED inlet boundary-flux source. Add the prescribed inlet-face inflow
-    // that the interior SCS scatter cannot see. Applied AFTER the reverse-halo
-    // fold so each OWNED inlet node receives its complete source exactly once (the
-    // per-node area-vectors were already owner-summed + halo-published in the
-    // driver). Off by default -> the do-nothing path stays byte-identical.
-    if (s.addInletFluxSource
-        && s.d_inletAreaVecX.size() == s.nodeCount
-        && s.d_inletAreaVecY.size() == s.nodeCount
-        && s.d_inletAreaVecZ.size() == s.nodeCount)
-    {
-        addInletFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
-            s.d_uTarget.data(), s.d_vTarget.data(), s.d_wTarget.data(),
-            s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
-            d_divAccNode.data(), s.nodeCount);
-        cudaDeviceSynchronize();
-    }
 
     // Source-of-NaN trace: count non-finite divAccNode over ALL owned nodes and
     // over the owned-BOUNDARY subset separately. The interior diagnostic below

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -6858,6 +6858,23 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
         };
         RealType divMaxBefore = ofsDbg ? maxAbsOwned(d_divAccNode.data()) : RealType(0);
         RealType sumBefore    = ofsDbg ? sumOwned(d_divAccNode.data())    : RealType(0);
+        // raw owned sums of (vel.areaVec) per opening -- the ACTUAL discrete flux each
+        // side injects, to see if inlet or outlet is the one not firing.
+        auto fluxSum = [&] (RealType vx, RealType vy, RealType vz,
+                            const RealType* ax, const RealType* ay, const RealType* az) -> RealType {
+            const auto& d_own = s.domain.getNodeOwnershipMap();
+            RealType loc = thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+                [own = d_own.data(), ax, ay, az, vx, vy, vz] __device__ (size_t i) -> RealType {
+                    return (own[i] == 1) ? (vx*ax[i] + vy*ay[i] + vz*az[i]) : RealType(0); },
+                RealType(0), thrust::plus<RealType>());
+            RealType g = 0; MPI_Allreduce(&loc, &g, 1, std::is_same<RealType,double>::value?MPI_DOUBLE:MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+            return g;
+        };
+        RealType Qin_raw  = ofsDbg ? fluxSum(s.Uinf*s.inletDirX, s.Uinf*s.inletDirY, s.Uinf*s.inletDirZ,
+                                             s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data()) : RealType(0);
+        RealType Qout_raw = ofsDbg ? fluxSum(s.outletU*s.outletDirX, s.outletU*s.outletDirY, s.outletU*s.outletDirZ,
+                                             s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data()) : RealType(0);
         addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
             RealType(s.Uinf * s.inletDirX), RealType(s.Uinf * s.inletDirY), RealType(s.Uinf * s.inletDirZ),
             s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
@@ -6868,6 +6885,10 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
             d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
         cudaDeviceSynchronize();
         if (ofsDbg) {
+            std::cout << "  [ofs-dbg2] Qin_raw=" << std::scientific << Qin_raw
+                      << " Qout_raw=" << Qout_raw << " (should be -Q and +Q)"
+                      << " outletDir=(" << s.outletDirX << "," << s.outletDirY << "," << s.outletDirZ << ")"
+                      << std::defaultfloat << "\n";
             RealType divMaxAfter = maxAbsOwned(d_divAccNode.data());
             RealType sumAfter    = sumOwned(d_divAccNode.data());
             std::cout << "  [ofs-dbg] divAccNode |max| before=" << std::scientific << divMaxBefore

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -2217,6 +2217,9 @@ struct NSStepper
     // Per-node velocity targets for the cavity BC. Boundary nodes hold the
     // prescribed value (u=1 on top, 0 elsewhere); interior nodes hold 0 (unused).
     cstone::DeviceVector<RealType> d_uTarget, d_vTarget, d_wTarget;
+    // Unramped snapshot of the inlet velocity target (built at full uinfBase), used by
+    // rescaleInletVelocityTarget so the per-step ramp scales from the base, not cumulatively.
+    cstone::DeviceVector<RealType> d_uTargetBase, d_vTargetBase, d_wTargetBase;
 
     // Geometry: SCS area vectors per (element, face). Same source used by the
     // implicit assembler, the advection scatter, the gradient, the divergence.
@@ -2379,6 +2382,7 @@ struct NSStepper
     enum class BCKind { Cavity, Channel, Pump, Periodic };
     BCKind bcKind = BCKind::Cavity;
     RealType Uinf = 1;   // channel/pump inflow speed; reuses lidU value via CLI
+    RealType uinfBase = 1;   // unramped full-strength inflow speed (for --source-ramp-steps)
     // Pump interior IC. Default: start from REST (0,0,0) and let the inlet drive
     // the flow along the geometry. The old uniform (Uinf,0,0) everywhere seeds a
     // spurious +x flow in BOTH tanks regardless of the real inlet orientation,
@@ -3718,6 +3722,10 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
     s.domain.exchangeNodeHalo(s.d_uTarget);
     s.domain.exchangeNodeHalo(s.d_vTarget);
     s.domain.exchangeNodeHalo(s.d_wTarget);
+    // Snapshot the full-strength target so --source-ramp-steps can scale from the base.
+    s.d_uTargetBase = s.d_uTarget;
+    s.d_vTargetBase = s.d_vTarget;
+    s.d_wTargetBase = s.d_wTarget;
     pt.lap("BC mark + target velocity");
 
     // d_dofToNode is needed for column-zero enforcement below. The pressure
@@ -6101,6 +6109,27 @@ RealType rmsOwnedInterior1(NSStepper<KeyType, RealType, ElementTag>& s,
     MPI_Allreduce(&locSumSq, &gSum, 1, mpiType,       MPI_SUM, MPI_COMM_WORLD);
     MPI_Allreduce(&locCnt,   &gCnt, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
     return (gCnt > 0) ? std::sqrt(gSum / RealType(gCnt)) : RealType(0);
+}
+
+// Set the inlet velocity Dirichlet target to ramp * base (the full-strength snapshot).
+// Walls have base target 0 so they stay 0; only inlet/extra nodes scale. Used by
+// --source-ramp-steps for a gentle startup. Scales from the base every step (not
+// cumulative) so it cannot drift.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void rescaleInletVelocityTarget(NSStepper<KeyType, RealType, ElementTag>& s, RealType ramp)
+{
+    if (s.d_uTargetBase.size() != s.nodeCount) return;
+    auto scale = [ramp] (const cstone::DeviceVector<RealType>& base,
+                         cstone::DeviceVector<RealType>& tgt) {
+        thrust::transform(thrust::device,
+            thrust::device_pointer_cast(base.data()),
+            thrust::device_pointer_cast(base.data()) + base.size(),
+            thrust::device_pointer_cast(tgt.data()),
+            [ramp] __device__ (RealType b) { return b * ramp; });
+    };
+    scale(s.d_uTargetBase, s.d_uTarget);
+    scale(s.d_vTargetBase, s.d_vTarget);
+    scale(s.d_wTargetBase, s.d_wTarget);
 }
 
 template<typename KeyType, typename RealType, typename ElementTag = HexTag>

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -6824,25 +6824,59 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
     // counted once per owned node), so restricting the add to owned nodes is exact
     // and rank-safe. Uses the PRESCRIBED opening velocity (single global direction),
     // NOT the solved u**: inlet = Uinf*globalInletDir, outlet = outletU*globalOutletDir.
-    // The per-node area-vectors sum to the global aIn/aOut, so the inlet term sums to
-    // -Q_in and the outlet term to +Q_out=+Q_in (mass-conserving), cancelling EXACTLY
-    // at step0 -- the single-pin Neumann pressure system stays compatible (no FIX-1
-    // one-sided blowup). REQUIRES the mass-conserving outlet (outletU>0); a do-nothing
-    // outlet leaves outletU<=0 -> outlet term ~0 -> imbalance. Off unless
-    // --opening-flux-source.
+    //
+    // adjustPhi (OpenFOAM / deal.II step-35): the discrete per-node inlet and outlet
+    // flux sums do NOT cancel to machine zero by analytic construction (per-node area
+    // shares are accumulated with different roundings), and the leftover epsilon, times
+    // coef=rho/dt~1e6 in the RHS, blows up the single-pin Neumann solve (that was the
+    // prior failure). FIX: measure the discrete inflow Qin_d and outflow Qout_d, then
+    // RESCALE the outlet source by scale=-Qin_d/Qout_d. IEEE guarantees
+    // (scale)*Qout_d == -Qin_d to the last bit, so the net added source is BIT-EXACT 0
+    // -> the RHS stays compatible regardless of mesh area-share imperfection. Requires
+    // the mass-conserving outlet (outletU>0); off unless --opening-flux-source.
     if (s.useOpeningFluxSource
         && s.d_inletAreaVecX.size() == s.nodeCount
         && s.d_outletAreaVecX.size() == s.nodeCount)
     {
-        addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
-            RealType(s.Uinf * s.inletDirX), RealType(s.Uinf * s.inletDirY), RealType(s.Uinf * s.inletDirZ),
-            s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
-            d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
-        addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
-            RealType(s.outletU * s.outletDirX), RealType(s.outletU * s.outletDirY), RealType(s.outletU * s.outletDirZ),
-            s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data(),
-            d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
-        cudaDeviceSynchronize();
+        // Discrete owned-node boundary flux (same reduction idiom as fluxThroughOwned).
+        auto openingFluxOwned = [&] (RealType vx, RealType vy, RealType vz,
+                                     const cstone::DeviceVector<RealType>& aX,
+                                     const cstone::DeviceVector<RealType>& aY,
+                                     const cstone::DeviceVector<RealType>& aZ) -> RealType {
+            const auto& d_own = s.domain.getNodeOwnershipMap();
+            size_t n = s.nodeCount;
+            RealType loc = thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(n),
+                [own = d_own.data(), n2d = s.d_node_to_dof.data(), nOwn = s.numOwnedDofs,
+                 ax = aX.data(), ay = aY.data(), az = aZ.data(), vx, vy, vz] __device__ (size_t i) -> RealType {
+                    if (own[i] != 1) return RealType(0);
+                    int dof = n2d[i];
+                    if (dof < 0 || dof >= nOwn) return RealType(0);
+                    return vx*ax[i] + vy*ay[i] + vz*az[i];
+                }, RealType(0), thrust::plus<RealType>());
+            RealType glob = 0;
+            MPI_Datatype mpi_r = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
+            MPI_Allreduce(&loc, &glob, 1, mpi_r, MPI_SUM, MPI_COMM_WORLD);
+            return glob;
+        };
+        const RealType Qin_d  = openingFluxOwned(RealType(s.Uinf * s.inletDirX), RealType(s.Uinf * s.inletDirY), RealType(s.Uinf * s.inletDirZ),
+                                                 s.d_inletAreaVecX, s.d_inletAreaVecY, s.d_inletAreaVecZ);   // < 0 (inward jet . outward area)
+        const RealType Qout_d = openingFluxOwned(RealType(s.outletU * s.outletDirX), RealType(s.outletU * s.outletDirY), RealType(s.outletU * s.outletDirZ),
+                                                 s.d_outletAreaVecX, s.d_outletAreaVecY, s.d_outletAreaVecZ);  // > 0
+        const bool balanceable = (s.outletU > RealType(0)) && (std::fabs(Qout_d) > RealType(0));
+        const RealType scale = balanceable ? (-Qin_d / Qout_d) : RealType(0);
+        if (scale != RealType(0))
+        {
+            addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                RealType(s.Uinf * s.inletDirX), RealType(s.Uinf * s.inletDirY), RealType(s.Uinf * s.inletDirZ),
+                s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
+                d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
+            addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                RealType(scale * s.outletU * s.outletDirX), RealType(scale * s.outletU * s.outletDirY), RealType(scale * s.outletU * s.outletDirZ),
+                s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data(),
+                d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+        }
     }
 
     // Source-of-NaN trace: count non-finite divAccNode over ALL owned nodes and

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -7177,7 +7177,13 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
                 d_nodeOwnership.data(), coef, d_bNode.data(), s.nodeCount);
             cudaDeviceSynchronize();
             // Periodic: D M^{-1} D^T is pure-Neumann with a constant null space.
-            if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic)
+            // Opening-flux pump: the single p=0 pin is a WEAK control of the DDT
+            // constant null space; a boundary flux source excites that mode and the
+            // Jacobi-PCG loses pAp>0 (residual grows -> garbage phi=1e7, the blowup).
+            // Project the null-space component out of the RHS so the solve stays
+            // well-behaved -- the same cure the periodic path uses.
+            if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+                || s.useOpeningFluxSource)
             {
                 mars::fem::removeMean<RealType>(s.domain, d_bNode, MPI_COMM_WORLD);
             }
@@ -7185,10 +7191,10 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
         }
     }
 
-    // Periodic: pure-Neumann pressure has a constant-mode null space. Subtract
-    // global mean so phi is uniquely defined (and the constant doesn't drift
-    // step over step).
-    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic)
+    // Periodic / opening-flux pump: subtract the global mean so phi is uniquely
+    // defined and the constant mode doesn't drift step over step.
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+        || s.useOpeningFluxSource)
     {
         mars::fem::removeMean<RealType>(s.domain, s.d_phi, MPI_COMM_WORLD);
     }

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -2053,10 +2053,20 @@ __global__ void buildPressureRhsKernel(const RealType* divAccNode,
 // coef does that). Adding it is not a double-count: no scsLR pair covers the
 // exterior face. One thread per node; only owned nodes contribute (off-set nodes
 // have a zero area-vector so they add nothing even if visited).
+//
+// The velocity here is the PRESCRIBED opening velocity (a single global constant
+// (Upx,Upy,Upz)), NOT the solved field. The inlet uses Uinf*globalInletDir and the
+// outlet uses outletU*globalOutletDir; because the per-node area-vectors sum to the
+// global aIn/aOut and the directions are the SAME global vectors, the inlet term
+// sums to -Q_in and the outlet term to +Q_out=+Q_in (mass-conserving outlet), so
+// the two cancel EXACTLY (bit-level) at every step including step0. That keeps the
+// single-pin Neumann pressure system compatible -- no one-sided step0 imbalance,
+// hence no FIX-1 blowup. (Using the solved u** left the outlet ~0 at step0, so only
+// the inlet source was added -> sum != 0 -> incompatible -> phi=1e36.)
 template<typename RealType>
-__global__ void addOpeningFluxSourceKernel(const RealType* u,
-                                           const RealType* v,
-                                           const RealType* w,
+__global__ void addOpeningFluxSourceKernel(RealType Upx,
+                                           RealType Upy,
+                                           RealType Upz,
                                            const RealType* aVecX,
                                            const RealType* aVecY,
                                            const RealType* aVecZ,
@@ -2067,8 +2077,7 @@ __global__ void addOpeningFluxSourceKernel(const RealType* u,
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numNodes) return;
     if (ownership[i] != 1) return;
-    RealType flux = u[i] * aVecX[i] + v[i] * aVecY[i] + w[i] * aVecZ[i];
-    divAccNode[i] += flux;
+    divAccNode[i] += Upx * aVecX[i] + Upy * aVecY[i] + Upz * aVecZ[i];
 }
 
 // DOF-indexed solver output -> per-node array. Reused for all velocity solves
@@ -6813,20 +6822,24 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
     // scatter cannot reach. divAccNode is now owner-complete; the per-node opening
     // area-vectors are owner-complete too (driver does reverse-halo-add then publish,
     // counted once per owned node), so restricting the add to owned nodes is exact
-    // and rank-safe. Uses the SAME post-diffusion velocity the divergence scatter
-    // used (d_uStarStar): inlet nodes carry the prescribed inflow, outlet nodes the
-    // post-diffusion outflow, so inlet flux + outlet flux net to ~0 and the single-pin
-    // Neumann pressure system stays solvable. Off unless --opening-flux-source.
+    // and rank-safe. Uses the PRESCRIBED opening velocity (single global direction),
+    // NOT the solved u**: inlet = Uinf*globalInletDir, outlet = outletU*globalOutletDir.
+    // The per-node area-vectors sum to the global aIn/aOut, so the inlet term sums to
+    // -Q_in and the outlet term to +Q_out=+Q_in (mass-conserving), cancelling EXACTLY
+    // at step0 -- the single-pin Neumann pressure system stays compatible (no FIX-1
+    // one-sided blowup). REQUIRES the mass-conserving outlet (outletU>0); a do-nothing
+    // outlet leaves outletU<=0 -> outlet term ~0 -> imbalance. Off unless
+    // --opening-flux-source.
     if (s.useOpeningFluxSource
         && s.d_inletAreaVecX.size() == s.nodeCount
         && s.d_outletAreaVecX.size() == s.nodeCount)
     {
         addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
-            s.d_uStarStar.data(), s.d_vStarStar.data(), s.d_wStarStar.data(),
+            RealType(s.Uinf * s.inletDirX), RealType(s.Uinf * s.inletDirY), RealType(s.Uinf * s.inletDirZ),
             s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
             d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
         addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
-            s.d_uStarStar.data(), s.d_vStarStar.data(), s.d_wStarStar.data(),
+            RealType(s.outletU * s.outletDirX), RealType(s.outletU * s.outletDirY), RealType(s.outletU * s.outletDirZ),
             s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data(),
             d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
         cudaDeviceSynchronize();

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -6871,23 +6871,30 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
             RealType g = 0; MPI_Allreduce(&loc, &g, 1, std::is_same<RealType,double>::value?MPI_DOUBLE:MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
             return g;
         };
-        RealType Qin_raw  = ofsDbg ? fluxSum(s.Uinf*s.inletDirX, s.Uinf*s.inletDirY, s.Uinf*s.inletDirZ,
-                                             s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data()) : RealType(0);
-        RealType Qout_raw = ofsDbg ? fluxSum(s.outletU*s.outletDirX, s.outletU*s.outletDirY, s.outletU*s.outletDirZ,
-                                             s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data()) : RealType(0);
+        // adjustPhi: the DISCRETE inlet and outlet fluxes differ (~1.5% here: the
+        // per-node area-vectors sum to a slightly different value than the analytic
+        // areaIn/areaOut the driver used to set outletU). That residual, x coef=rho/dt,
+        // makes the single-pin Neumann RHS incompatible -> blowup. Measure both
+        // discrete fluxes and RESCALE the outlet so it EXACTLY cancels the inlet.
+        const RealType Qin_raw  = fluxSum(s.Uinf*s.inletDirX, s.Uinf*s.inletDirY, s.Uinf*s.inletDirZ,
+                                          s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data());
+        const RealType Qout_raw = fluxSum(s.outletU*s.outletDirX, s.outletU*s.outletDirY, s.outletU*s.outletDirZ,
+                                          s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data());
+        const RealType oScale = (std::fabs(Qout_raw) > RealType(0)) ? (-Qin_raw / Qout_raw) : RealType(0);
         addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
             RealType(s.Uinf * s.inletDirX), RealType(s.Uinf * s.inletDirY), RealType(s.Uinf * s.inletDirZ),
             s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
             d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
         addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
-            RealType(s.outletU * s.outletDirX), RealType(s.outletU * s.outletDirY), RealType(s.outletU * s.outletDirZ),
+            RealType(oScale * s.outletU * s.outletDirX), RealType(oScale * s.outletU * s.outletDirY), RealType(oScale * s.outletU * s.outletDirZ),
             s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data(),
             d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
         cudaDeviceSynchronize();
         if (ofsDbg) {
             std::cout << "  [ofs-dbg2] Qin_raw=" << std::scientific << Qin_raw
-                      << " Qout_raw=" << Qout_raw << " (should be -Q and +Q)"
-                      << " outletDir=(" << s.outletDirX << "," << s.outletDirY << "," << s.outletDirZ << ")"
+                      << " Qout_raw=" << Qout_raw << " oScale=" << oScale
+                      << " rescaled-outlet=" << (oScale*Qout_raw)
+                      << " net=" << (Qin_raw + oScale*Qout_raw) << " (should be ~0)"
                       << std::defaultfloat << "\n";
             RealType divMaxAfter = maxAbsOwned(d_divAccNode.data());
             RealType sumAfter    = sumOwned(d_divAccNode.data());

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -1665,6 +1665,35 @@ __global__ void computeDivergencePerNodeKernel(const KeyType* c0, const KeyType*
 }
 
 // =============================================================================
+// Inlet boundary-flux source (GUARDED, opt-in). The interior SCS divergence
+// scatter integrates only the INTERIOR sub-control-surfaces of each element; the
+// EXTERIOR inlet-face portion of a boundary node's control volume has no interior
+// SCS face, so the mass actually crossing the inlet opening is never registered.
+// This adds it: per inlet node, += (uTarget . areaVecOutward), where areaVec is
+// the node's outward inlet area-vector. A prescribed inflow makes uTarget oppose
+// the outward normal, so the term is NEGATIVE -- net inflow shows up as negative
+// divergence, which is exactly the sign the projection needs to pull mass in.
+// Only inlet nodes carry a nonzero areaVec; every other node adds 0.
+// =============================================================================
+
+template<typename RealType>
+__global__ void addInletFluxSourceKernel(const RealType* uTgt,
+                                         const RealType* vTgt,
+                                         const RealType* wTgt,
+                                         const RealType* areaVecX,
+                                         const RealType* areaVecY,
+                                         const RealType* areaVecZ,
+                                         RealType* divAccNode,
+                                         size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    RealType ax = areaVecX[i], ay = areaVecY[i], az = areaVecZ[i];
+    // Off-inlet nodes have a zero area-vector -> no-op.
+    divAccNode[i] += uTgt[i] * ax + vTgt[i] * ay + wTgt[i] * az;
+}
+
+// =============================================================================
 // Rhie-Chow corrected divergence kernel for periodic Q1-Q1 CVFEM. Same as
 // computeDivergencePerNodeKernel but adds the Rhie-Chow pressure-velocity
 // coupling correction at each SCS face:
@@ -2298,6 +2327,22 @@ struct NSStepper
     RealType outletU = -1;
     RealType outletDirX = 1, outletDirY = 0, outletDirZ = 0;
     bool outletDoNothing = true;  // do-nothing outlet (free velocity + p=0 face); false = mass-conserving velocity outlet
+
+    // GUARDED inlet boundary-flux source (off by default). The interior SCS
+    // divergence scatter never integrates the EXTERIOR inlet-face flux (that part
+    // of a boundary node's control volume has no interior sub-control-surface), so
+    // a velocity-inlet + free-pressure outlet under-counts the mass actually
+    // entering. When enabled, runPressureSolveStep adds the prescribed inflow
+    // (uTarget . n)*A per inlet node into the divergence accumulator before the
+    // RHS build. d_inletAreaVec{X,Y,Z} are the per-node OUTWARD inlet area-vectors
+    // (un-normalized, nodeCount-sized, zero off the inlet); the source is the dot
+    // of the prescribed inlet velocity with this vector. Filled by the driver.
+    bool addInletFluxSource = false;
+    cstone::DeviceVector<RealType> d_inletAreaVecX, d_inletAreaVecY, d_inletAreaVecZ;
+    // Per-node OUTWARD outlet area-vectors (un-normalized, nodeCount-sized, zero
+    // off the outlet). Used only by the through-flow diagnostic to measure
+    // Q_out = sum_owned( u . outletAreaVec ). Filled by the driver.
+    cstone::DeviceVector<RealType> d_outletAreaVecX, d_outletAreaVecY, d_outletAreaVecZ;
 
     // Constant streamwise (and orthogonal) momentum body force, added in the
     // predictor as +dt*f/rho (BDF1) and +(2dt/3)*f/rho (BDF2). Defaults to 0
@@ -6529,6 +6574,23 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
     s.domain.reverseExchangeNodeHaloAdd(d_divAccNode);
     maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_divAccNode);
 
+    // GUARDED inlet boundary-flux source. Add the prescribed inlet-face inflow
+    // that the interior SCS scatter cannot see. Applied AFTER the reverse-halo
+    // fold so each OWNED inlet node receives its complete source exactly once (the
+    // per-node area-vectors were already owner-summed + halo-published in the
+    // driver). Off by default -> the do-nothing path stays byte-identical.
+    if (s.addInletFluxSource
+        && s.d_inletAreaVecX.size() == s.nodeCount
+        && s.d_inletAreaVecY.size() == s.nodeCount
+        && s.d_inletAreaVecZ.size() == s.nodeCount)
+    {
+        addInletFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            s.d_uTarget.data(), s.d_vTarget.data(), s.d_wTarget.data(),
+            s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
+            d_divAccNode.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+    }
+
     // Source-of-NaN trace: count non-finite divAccNode over ALL owned nodes and
     // over the owned-BOUNDARY subset separately. The interior diagnostic below
     // (maxOwnedInteriorAbs) excludes boundary DOFs, so a boundary NaN is
@@ -7237,6 +7299,43 @@ inline RealType keOwned(NSStepper<KeyType, RealType, ElementTag>& s,
             RealType uu = u[i], vv = v[i], ww = w[i];
             return RealType(0.5) * mass[dof] * (uu * uu + vv * vv + ww * ww);
         }, RealType(0), thrust::plus<RealType>());
+    RealType global = 0;
+    MPI_Datatype mpi_r = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
+    MPI_Allreduce(&local, &global, 1, mpi_r, MPI_SUM, MPI_COMM_WORLD);
+    return global;
+}
+
+// Net flux of a velocity field through a side-set: sum over OWNED nodes of
+// (u . areaVecOutward), with areaVec the per-node outward area-vector (zero off
+// the set). Partition-independent (owned-only) and globally reduced. Used by the
+// pump through-flow diagnostic to measure Q_out against the known Q_in. A
+// positive value means net OUTFLOW through the set.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+inline RealType fluxThroughOwned(NSStepper<KeyType, RealType, ElementTag>& s,
+                                 const cstone::DeviceVector<RealType>& du,
+                                 const cstone::DeviceVector<RealType>& dv,
+                                 const cstone::DeviceVector<RealType>& dw,
+                                 const cstone::DeviceVector<RealType>& aX,
+                                 const cstone::DeviceVector<RealType>& aY,
+                                 const cstone::DeviceVector<RealType>& aZ)
+{
+    const auto& d_own = s.domain.getNodeOwnershipMap();
+    size_t n = s.nodeCount;
+    RealType local = RealType(0);
+    if (aX.size() == n && aY.size() == n && aZ.size() == n)
+    {
+        local = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0),
+            thrust::counting_iterator<size_t>(n),
+            [own = d_own.data(), n2d = s.d_node_to_dof.data(), nOwn = s.numOwnedDofs,
+             u = du.data(), v = dv.data(), w = dw.data(),
+             ax = aX.data(), ay = aY.data(), az = aZ.data()] __device__ (size_t i) -> RealType {
+                if (own[i] != 1) return RealType(0);
+                int dof = n2d[i];
+                if (dof < 0 || dof >= nOwn) return RealType(0);
+                return u[i]*ax[i] + v[i]*ay[i] + w[i]*az[i];
+            }, RealType(0), thrust::plus<RealType>());
+    }
     RealType global = 0;
     MPI_Datatype mpi_r = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
     MPI_Allreduce(&local, &global, 1, mpi_r, MPI_SUM, MPI_COMM_WORLD);

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -6834,6 +6834,30 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
         && s.d_inletAreaVecX.size() == s.nodeCount
         && s.d_outletAreaVecX.size() == s.nodeCount)
     {
+        // MARS_OFS_DBG: print the source magnitude + divAccNode max before/after +
+        // the global net source, so we SEE if it is a giant localized spike or
+        // imbalanced. Gated on env, free in production.
+        const bool ofsDbg = (std::getenv("MARS_OFS_DBG") != nullptr) && (s.rank == 0);
+        auto maxAbsOwned = [&] (const RealType* p) -> RealType {
+            const auto& d_own = s.domain.getNodeOwnershipMap();
+            return thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+                [own = d_own.data(), p] __device__ (size_t i) -> RealType {
+                    return (own[i] == 1) ? fabs(p[i]) : RealType(0); },
+                RealType(0), thrust::maximum<RealType>());
+        };
+        auto sumOwned = [&] (const RealType* p) -> RealType {
+            const auto& d_own = s.domain.getNodeOwnershipMap();
+            RealType loc = thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+                [own = d_own.data(), p] __device__ (size_t i) -> RealType {
+                    return (own[i] == 1) ? p[i] : RealType(0); },
+                RealType(0), thrust::plus<RealType>());
+            RealType g = 0; MPI_Allreduce(&loc, &g, 1, std::is_same<RealType,double>::value?MPI_DOUBLE:MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+            return g;
+        };
+        RealType divMaxBefore = ofsDbg ? maxAbsOwned(d_divAccNode.data()) : RealType(0);
+        RealType sumBefore    = ofsDbg ? sumOwned(d_divAccNode.data())    : RealType(0);
         addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
             RealType(s.Uinf * s.inletDirX), RealType(s.Uinf * s.inletDirY), RealType(s.Uinf * s.inletDirZ),
             s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
@@ -6843,6 +6867,17 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
             s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data(),
             d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
         cudaDeviceSynchronize();
+        if (ofsDbg) {
+            RealType divMaxAfter = maxAbsOwned(d_divAccNode.data());
+            RealType sumAfter    = sumOwned(d_divAccNode.data());
+            std::cout << "  [ofs-dbg] divAccNode |max| before=" << std::scientific << divMaxBefore
+                      << " after=" << divMaxAfter
+                      << "  | sum(divAcc) before=" << sumBefore << " after=" << sumAfter
+                      << " (net source=" << (sumAfter - sumBefore) << ")"
+                      << "  Uinf=" << s.Uinf << " outletU=" << s.outletU
+                      << " inletDir=(" << s.inletDirX << "," << s.inletDirY << "," << s.inletDirZ << ")"
+                      << " coef=rho/dt" << std::defaultfloat << "\n";
+        }
     }
 
     // Source-of-NaN trace: count non-finite divAccNode over ALL owned nodes and

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -429,6 +429,28 @@ __global__ void enforcePressureBcRhsKernel(const uint8_t* isPressureBdryDof,
     if (isPressureBdryDof[dof]) rhs[dof] = RealType(0);
 }
 
+// FIX B (pump --pump-dp>0): instead of pinning the phi increment to 0 at the
+// inlet/outlet faces (rhs=0, which freezes p^{n+1}=p^n and never lets the
+// interior relax into the inlet->outlet gradient), clamp the SOLVED pressure to
+// the target. The masked row is an identity row (out=phi), so setting
+// rhs=target-p^n makes the solve return phi=target-p^n -> p^{n+1}=p^n+phi=target
+// EXACTLY. This is a steady clamp to a constant, NOT an additive ramp, so the
+// head stays bounded at dP/0 while the interior relaxes around it.
+template<typename RealType>
+__global__ void enforcePressureBcRhsLiftKernel(const uint8_t* isPressureBdryDof,
+                                               const RealType* targetDof,
+                                               const RealType* p,
+                                               const int* dofToNode,
+                                               RealType* rhs, int numDofs)
+{
+    int dof = blockIdx.x * blockDim.x + threadIdx.x;
+    if (dof >= numDofs) return;
+    if (!isPressureBdryDof[dof]) return;
+    int node = dofToNode[dof];
+    RealType pn = (node >= 0) ? p[node] : RealType(0);
+    rhs[dof] = targetDof[dof] - pn;
+}
+
 // Build a per-NODE pressure-Dirichlet mask from the existing per-DOF mask +
 // optional single-pin DOF. Each owned node maps its dof through the existing
 // boundary flag; ghost nodes get 0 (filled by halo exchange later).
@@ -2157,6 +2179,11 @@ struct NSStepper
     int pressurePinDof = -1;   // owned-DOF id on the owning rank; -1 elsewhere (or in channel mode)
     int pressurePinRank = 0;   // global rank that owns the pin
     cstone::DeviceVector<uint8_t> d_isPressureBdryDof;   // size numOwnedDofs; only used in channel mode
+    // FIX B (pump --pump-dp>0): per-OWNED-DOF target pressure at the masked
+    // faces (pumpDp on inlet, 0 on outlet, 0 elsewhere). The lift enforce reads
+    // it as rhs=target-p^n so the solved pressure clamps to the head. Empty for
+    // pumpDp<=0 (cavity/channel/TGV never touch this).
+    cstone::DeviceVector<RealType> d_pPhiTargetDof;
     // Per-NODE pressure-Dirichlet mask (size nodeCount, halo-exchanged so
     // ghost slots see the owner's flag). Includes the single corner pin
     // (cavity) AND every outflow-face DOF (channel/pump). Used by symmetric
@@ -4218,6 +4245,9 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
                      uint8_t(0));
         // Host-side scatter from the outlet local-node list. Owned DOFs only.
         std::vector<uint8_t> hostMask(s.numOwnedDofs, 0);
+        // FIX B: per-owned-DOF target pressure for the lift enforce (filled only
+        // in the pumpDp>0 branch). pumpDp on inlet, 0 on outlet, 0 elsewhere.
+        std::vector<RealType> hostTarget(s.numOwnedDofs, RealType(0));
         std::vector<int> hostNodeToDof(s.nodeCount, -1);
         std::vector<uint8_t> hostOwn(s.nodeCount, 0);
         thrust::copy(thrust::device_pointer_cast(s.d_node_to_dof.data()),
@@ -4248,6 +4278,8 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
             if (dof < 0 || dof >= s.numOwnedDofs) continue;
             if (firstOutletDof < 0) firstOutletDof = dof;
             if (!singlePin) { hostMask[dof] = 1; ++ownedOutletCount; }
+            // FIX B: outlet target p=0 (explicit for clarity; zero-init already).
+            if (s.pumpDp > RealType(0)) hostTarget[dof] = RealType(0);
         }
         // FIX B: also mask the WHOLE inlet face as pressure-Dirichlet (p=pumpDp).
         // enforceBcMatrixKernel makes both faces identity rows -> nonsingular A.
@@ -4261,6 +4293,8 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
                 int dof = hostNodeToDof[li];
                 if (dof < 0 || dof >= s.numOwnedDofs) continue;
                 hostMask[dof] = 1; ++ownedInletCount;
+                // FIX B: inlet target p=pumpDp (the standing head the lift clamps to).
+                hostTarget[dof] = s.pumpDp;
             }
         }
         if (singlePin)
@@ -4278,6 +4312,15 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
         }
         thrust::copy(hostMask.begin(), hostMask.end(),
                      thrust::device_pointer_cast(s.d_isPressureBdryDof.data()));
+        // FIX B: stash the per-owned-DOF target so the per-step lift enforce can
+        // clamp p^{n+1} to dP/0 at the masked faces. Only the pump pressure-drop
+        // path needs it; cavity/channel/TGV leave d_pPhiTargetDof empty.
+        if (s.pumpDp > RealType(0))
+        {
+            s.d_pPhiTargetDof.resize(s.numOwnedDofs);
+            cudaMemcpy(s.d_pPhiTargetDof.data(), hostTarget.data(),
+                       s.numOwnedDofs * sizeof(RealType), cudaMemcpyHostToDevice);
+        }
 
         int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
         enforceBcMatrixKernel<RealType><<<dofBlocks, s.blockSize>>>(
@@ -4878,12 +4921,14 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
 
     // FIX B: seed the STANDING pressure head into p^n. p carries p=pumpDp on the
     // inlet face and p=0 on the outlet face; grad(p^n) then enters every predictor
-    // and drives the through-flow. The per-step phi increment is pinned 0 at both
-    // faces (enforcePressureBcRhsKernel on d_isPressureBdryDof, which now holds both
-    // faces), so p^{n+1}=p^n+phi keeps this head fixed. d_p is indexed by LOCAL NODE,
-    // so set owned inlet/outlet local nodes directly; the halo exchange propagates
-    // the head to ghosts. Owned-only avoids a cross-rank double-write. The pump
-    // driver never calls applyInitialCondition, so seed here at the end of setup.
+    // and drives the through-flow from step 0. The per-step pressure solve CLAMPS
+    // p^{n+1} back to the same head at both faces via the lift enforce (rhs=
+    // target-p^n on d_isPressureBdryDof, which holds both faces), so the head is
+    // held fixed while the interior relaxes into the inlet->outlet gradient.
+    // d_p is indexed by LOCAL NODE, so set owned inlet/outlet local nodes
+    // directly; the halo exchange propagates the head to ghosts. Owned-only
+    // avoids a cross-rank double-write. The pump driver never calls
+    // applyInitialCondition, so seed here at the end of setup.
     if (s.pumpDp > RealType(0))
     {
         std::vector<RealType> hostP(s.nodeCount, RealType(0));
@@ -5739,16 +5784,27 @@ int solvePressureDDT(NSStepper<KeyType, RealType, ElementTag>& s,
         const int* dofPtr       = s.d_node_to_dof.data();
         const uint8_t* ownPtr   = d_nodeOwnership.data();
         RealType* bPtr          = b_node.data();
+        // FIX B (pump --pump-dp>0): this is the PRODUCTION pump path. The masked
+        // row is an identity row (out=phi in applyDDTPerNode below), so the
+        // rhs=0 default would freeze phi=0 -> p^{n+1}=p^n, killing the
+        // inlet->outlet gradient. Lift instead: b[i]=target-p^n -> phi=target-p^n
+        // -> p^{n+1}=target EXACTLY (steady clamp, not an additive ramp).
+        const bool lift         = (s.pumpDp > RealType(0)
+                                   && s.d_pPhiTargetDof.size() == (size_t)numOwnedDofs);
+        const RealType* tgtPtr  = lift ? s.d_pPhiTargetDof.data() : nullptr;
+        const RealType* pPtr    = lift ? s.d_p.data() : nullptr;
         thrust::for_each(thrust::device,
             thrust::counting_iterator<size_t>(0),
             thrust::counting_iterator<size_t>(s.nodeCount),
-            [pinDof, maskPtr, dofPtr, ownPtr, bPtr, numOwnedDofs] __device__ (size_t i) {
+            [pinDof, maskPtr, dofPtr, ownPtr, bPtr, numOwnedDofs,
+             lift, tgtPtr, pPtr] __device__ (size_t i) {
                 if (ownPtr[i] != 1) return;
                 int dof = dofPtr[i];
                 if (dof < 0 || dof >= numOwnedDofs) return;
                 bool flagged = (pinDof >= 0 && dof == pinDof) ||
                                (maskPtr != nullptr && maskPtr[dof] != 0);
-                if (flagged) bPtr[i] = RealType(0);
+                if (!flagged) return;
+                bPtr[i] = lift ? (tgtPtr[dof] - pPtr[i]) : RealType(0);
             });
         cudaDeviceSynchronize();
     }
@@ -6850,8 +6906,15 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
         if (s.d_isPressureBdryDof.size() > 0)
         {
             int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
-            enforcePressureBcRhsKernel<RealType><<<dofBlocks, s.blockSize>>>(
-                s.d_isPressureBdryDof.data(), b.data(), s.numOwnedDofs);
+            // FIX B clamps p^{n+1} to the head (rhs=target-p^n); the rhs=0 path
+            // would instead freeze p, killing the inlet->outlet gradient.
+            if (s.pumpDp > RealType(0))
+                enforcePressureBcRhsLiftKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                    s.d_isPressureBdryDof.data(), s.d_pPhiTargetDof.data(), s.d_p.data(),
+                    s.d_dofToNode.data(), b.data(), s.numOwnedDofs);
+            else
+                enforcePressureBcRhsKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                    s.d_isPressureBdryDof.data(), b.data(), s.numOwnedDofs);
             cudaDeviceSynchronize();
         }
         // Periodic: project the RHS onto range(K) by subtracting its global
@@ -6920,8 +6983,15 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
             if (s.d_isPressureBdryDof.size() > 0)
             {
                 int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
-                enforcePressureBcRhsKernel<RealType><<<dofBlocks, s.blockSize>>>(
-                    s.d_isPressureBdryDof.data(), b.data(), s.numOwnedDofs);
+                // FIX B lift (assembled-CG diagnostic path): clamp p^{n+1} to the
+                // head so the assembled-CG A/B matches the matrix-free pump.
+                if (s.pumpDp > RealType(0))
+                    enforcePressureBcRhsLiftKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                        s.d_isPressureBdryDof.data(), s.d_pPhiTargetDof.data(), s.d_p.data(),
+                        s.d_dofToNode.data(), b.data(), s.numOwnedDofs);
+                else
+                    enforcePressureBcRhsKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                        s.d_isPressureBdryDof.data(), b.data(), s.numOwnedDofs);
                 cudaDeviceSynchronize();
             }
             // RHS finiteness check. A non-finite entry here (e.g. a boundary

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -489,6 +489,46 @@ __global__ void enforceBcColMatrixKernelByNode(const uint8_t* isPressureBdryNode
     }
 }
 
+// FIX 2: compute the Dirichlet lift for the velocity RHS, reading the INTACT
+// matrix (call this BEFORE the col-zero so the K[row,col] entries are still
+// present). For each non-Dirichlet owned row:
+//   lift[row] = sum_col K[row,col] * qTarget[colNode]   over boundary cols
+// The per-step velocity RHS then subtracts lift[row], which is the standard
+// Dirichlet lift-off that preserves the boundary target's momentum on interior
+// neighbors after those columns are zeroed. qTarget is per-NODE (nodeCount-sized);
+// colNode = dofToNode[c]. Pure accumulator -- does NOT modify values -- so it can
+// run once per component (u,v,w) over the same intact matrix before a single
+// plain col-zero pass. Wall targets are 0 (no lift); only the inlet target lifts.
+template<typename RealType>
+__global__ void computeBcColLiftKernelByNode(const uint8_t* isPressureBdryNode,
+                                            const int* dofToNode,
+                                            int numTotalDofs,
+                                            const int* rowPtr,
+                                            const int* colInd,
+                                            const RealType* values,
+                                            const RealType* qTarget,
+                                            RealType* liftOut,
+                                            int numOwnedRows)
+{
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= numOwnedRows) return;
+    liftOut[row] = RealType(0);
+    int rowNode = dofToNode[row];
+    if (rowNode >= 0 && isPressureBdryNode[rowNode]) return;
+    int rs = rowPtr[row];
+    int re = rowPtr[row + 1];
+    RealType lift = RealType(0);
+    for (int j = rs; j < re; ++j)
+    {
+        int c = colInd[j];
+        if (c < 0 || c >= numTotalDofs) continue;
+        int cnode = dofToNode[c];
+        if (cnode >= 0 && isPressureBdryNode[cnode])
+            lift += values[j] * qTarget[cnode];
+    }
+    liftOut[row] = lift;
+}
+
 // Build the inverse map: dofToNode[d] = local node that has nodeToDof[node] = d.
 // One thread per node. Multiple nodes can never share a DOF (in non-periodic
 // modes), so this is a simple scatter.
@@ -1978,6 +2018,37 @@ __global__ void buildPressureRhsKernel(const RealType* divAccNode,
     rhs[dof] = -coef * divAccNode[i];
 }
 
+// FIX 1: add the opening (inlet/outlet) boundary surface flux to divAccNode.
+// The interior SCS scatter integrates only the INTERIOR median-dual faces, so the
+// exterior opening face of a boundary node's dual cell is missing from divAccNode.
+// Here we add the missing Gauss boundary term: divAccNode[i] += u[i] . areaVec[i],
+// where areaVec is the per-node OUTWARD opening area-vector (zero off the set, its
+// magnitude = the node's share of the opening area). u . areaVec_outward is the
+// outward volumetric flux through that share -- negative for the inward inlet jet
+// (a source into the dual cell), positive for the outlet (a sink) -- which is the
+// SAME sign convention as the interior scatter (positive divAccNode = net outflow)
+// and the SAME raw volumetric-flux units (NOT pre-multiplied by rho/dt; the RHS
+// coef does that). Adding it is not a double-count: no scsLR pair covers the
+// exterior face. One thread per node; only owned nodes contribute (off-set nodes
+// have a zero area-vector so they add nothing even if visited).
+template<typename RealType>
+__global__ void addOpeningFluxSourceKernel(const RealType* u,
+                                           const RealType* v,
+                                           const RealType* w,
+                                           const RealType* aVecX,
+                                           const RealType* aVecY,
+                                           const RealType* aVecZ,
+                                           const uint8_t* ownership,
+                                           RealType* divAccNode,
+                                           size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    RealType flux = u[i] * aVecX[i] + v[i] * aVecY[i] + w[i] * aVecZ[i];
+    divAccNode[i] += flux;
+}
+
 // DOF-indexed solver output -> per-node array. Reused for all velocity solves
 // and the pressure solve.
 template<typename RealType>
@@ -2303,6 +2374,39 @@ struct NSStepper
     // off the outlet). Used only by the through-flow diagnostic to measure
     // Q_out = sum_owned( u . outletAreaVec ). Filled by the driver.
     cstone::DeviceVector<RealType> d_outletAreaVecX, d_outletAreaVecY, d_outletAreaVecZ;
+
+    // Per-node OUTWARD inlet area-vectors (un-normalized, nodeCount-sized, zero
+    // off the inlet). Filled by the driver when useOpeningFluxSource is on. The
+    // magnitude at a node is its share of the opening area; direction is outward.
+    cstone::DeviceVector<RealType> d_inletAreaVecX, d_inletAreaVecY, d_inletAreaVecZ;
+
+    // FIX 1 -- opening-flux source. The CVFEM divergence operator integrates
+    // ONLY interior median-dual SCS faces (each scsLR pair links two NODES of the
+    // SAME element, so sum_nodes(divAccNode)==0 identically). The exterior opening
+    // face of a boundary node's dual cell -- the part lying ON the inlet/outlet
+    // surface -- is in NO scsLR pair, so the prescribed opening flux never enters
+    // divAccNode and the pressure solve is never told mass crosses the boundary.
+    // We add the missing boundary surface integral sum( u . areaVec_opening ) to
+    // divAccNode in the SAME raw volumetric-flux units as the interior scatter
+    // (NOT pre-multiplied by rho/dt -- the RHS coef does that). areaVec is OUTWARD,
+    // so u.areaVec is NEGATIVE at the inlet (inward jet, a source) and POSITIVE at
+    // the outlet (a sink) -- the same convention as the interior scatter, where
+    // positive divAccNode means net outflow. Inlet + outlet net to ~0 (mass in =
+    // mass out), so the single-pin Neumann pressure system stays solvable. Off by
+    // default; --opening-flux-source turns it on for the pump through-flow case so
+    // it can be A/B-ed safely.
+    bool useOpeningFluxSource = false;
+
+    // FIX 2 -- Dirichlet lift on the velocity diffusion. The symmetric col-zero
+    // (enforceBcColMatrixKernelByNode) drops K[interior_row, boundary_col] with no
+    // RHS compensation, so the inlet's prescribed velocity contributes ZERO viscous
+    // momentum to its interior neighbors and the jet dies at the inlet. The lift
+    // restores it: lift[row] = sum_col K[row,col]*qTarget[col] over boundary cols,
+    // captured ONCE at setup (qTarget is steady for the pump) BEFORE the col-zero,
+    // then subtracted from the velocity RHS every step. Walls (qTarget=0) add
+    // nothing; only the nonzero inlet target lifts. Per-component (u,v,w).
+    bool useDirichletLift = true;
+    cstone::DeviceVector<RealType> d_velLiftU, d_velLiftV, d_velLiftW;  // owned-DOF sized
 
     // Constant streamwise (and orthogonal) momentum body force, added in the
     // predictor as +dt*f/rho (BDF1) and +(2dt/3)*f/rho (BDF2). Defaults to 0
@@ -3775,16 +3879,41 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
             // enough that the existing asymmetric row-clear converges fine
             // (same rationale as DDT-cavity at lines ~3500-3508).
             //
-            // NOTE: no Dirichlet "lift" yet. For zero qTarget (wall no-slip)
-            // it isn't needed. For non-zero qTarget (inlet/extra u=Uinf)
-            // this introduces an O(off-diag * Uinf) perturbation localized to
-            // the 1-cell ring around those faces. Acceptable for the "BC
-            // actually runs" milestone; promote to a proper lift kernel as
-            // a follow-up after validating convergence.
+            // FIX 2 (Dirichlet lift): the col-zero below drops K[row, boundary_col]
+            // with no RHS compensation, so the inlet's prescribed velocity adds zero
+            // viscous momentum to interior neighbors and the jet dies at the inlet.
+            // BEFORE zeroing (matrix still intact) capture the per-component lift
+            // lift[row] = sum_col K[row,col]*qTarget[col]; the per-step velocity RHS
+            // subtracts it. qTarget is steady for the pump so this is a one-time
+            // setup cost. The off-diagonal K entries are identical for Avel and
+            // Avel_bdf2 (only the mass diagonal differs, never touched here), so one
+            // lift serves both. Gated by useDirichletLift for A/B.
             if ((s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Channel
                  || s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Pump)
                 && s.d_isBdryNode.size() == static_cast<size_t>(s.nodeCount))
             {
+                // Pump-only: the lift is the pump through-flow fix. Channel keeps
+                // its prior (no-lift) behavior so its regression is untouched.
+                if (s.useDirichletLift
+                    && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Pump)
+                {
+                    s.d_velLiftU.resize(s.numOwnedDofs);
+                    s.d_velLiftV.resize(s.numOwnedDofs);
+                    s.d_velLiftW.resize(s.numOwnedDofs);
+                    computeBcColLiftKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
+                        s.d_isBdryNode.data(), s.d_dofToNode.data(), s.numTotalDofs,
+                        s.d_rowPtr.data(), s.d_colInd.data(), s.d_valuesVel.data(),
+                        s.d_uTarget.data(), s.d_velLiftU.data(), s.numOwnedDofs);
+                    computeBcColLiftKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
+                        s.d_isBdryNode.data(), s.d_dofToNode.data(), s.numTotalDofs,
+                        s.d_rowPtr.data(), s.d_colInd.data(), s.d_valuesVel.data(),
+                        s.d_vTarget.data(), s.d_velLiftV.data(), s.numOwnedDofs);
+                    computeBcColLiftKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
+                        s.d_isBdryNode.data(), s.d_dofToNode.data(), s.numTotalDofs,
+                        s.d_rowPtr.data(), s.d_colInd.data(), s.d_valuesVel.data(),
+                        s.d_wTarget.data(), s.d_velLiftW.data(), s.numOwnedDofs);
+                    cudaDeviceSynchronize();
+                }
                 enforceBcColMatrixKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
                     s.d_isBdryNode.data(),
                     s.d_node_to_dof.data(), s.d_dofToNode.data(), s.numTotalDofs,
@@ -6289,7 +6418,8 @@ void runImplicitDiffusionStep(NSStepper<KeyType, RealType, ElementTag>& s, RealT
 
     auto runImplicit = [&] (cstone::DeviceVector<RealType>& qStar,
                              cstone::DeviceVector<RealType>& qStarStar,
-                             cstone::DeviceVector<RealType>& qTarget) -> int
+                             cstone::DeviceVector<RealType>& qTarget,
+                             const cstone::DeviceVector<RealType>& qLift) -> int
     {
         // RHS = (mass coef) * mass * qStar; coef = 1/dt for BDF1, 3/(2dt) for BDF2.
         thrust::fill(thrust::device_pointer_cast(b.data()),
@@ -6299,6 +6429,18 @@ void runImplicitDiffusionStep(NSStepper<KeyType, RealType, ElementTag>& s, RealT
             qStar.data(), s.d_node_to_dof.data(), d_nodeOwnership.data(),
             s.d_mass.data(), invDt, b.data(), s.nodeCount, s.numOwnedDofs);
         cudaDeviceSynchronize();
+
+        // FIX 2: subtract the Dirichlet lift on interior rows (b -= K[row,bdry]*qTarget),
+        // captured once at setup. Dirichlet rows carry lift=0 and are overwritten by
+        // enforceBcRhsFromTargetKernel below, so order is safe.
+        if (s.useDirichletLift && qLift.size() == static_cast<size_t>(s.numOwnedDofs))
+        {
+            auto bp = thrust::device_pointer_cast(b.data());
+            thrust::transform(thrust::device, bp, bp + s.numOwnedDofs,
+                              thrust::device_pointer_cast(qLift.data()), bp,
+                              thrust::minus<RealType>());
+            cudaDeviceSynchronize();
+        }
 
         enforceBcRhsFromTargetKernel<RealType><<<nodeBlocks, s.blockSize>>>(
             s.d_isBdryDof.data(), qTarget.data(),
@@ -6351,9 +6493,9 @@ void runImplicitDiffusionStep(NSStepper<KeyType, RealType, ElementTag>& s, RealT
             bdf2Active ? s.Avel_bdf2 : s.Avel);
     };
 
-    s.lastUIters = runImplicit(s.d_uStar, s.d_uStarStar, s.d_uTarget);
-    s.lastVIters = runImplicit(s.d_vStar, s.d_vStarStar, s.d_vTarget);
-    s.lastWIters = runImplicit(s.d_wStar, s.d_wStarStar, s.d_wTarget);
+    s.lastUIters = runImplicit(s.d_uStar, s.d_uStarStar, s.d_uTarget, s.d_velLiftU);
+    s.lastVIters = runImplicit(s.d_vStar, s.d_vStarStar, s.d_vTarget, s.d_velLiftV);
+    s.lastWIters = runImplicit(s.d_wStar, s.d_wStarStar, s.d_wTarget, s.d_velLiftW);
 
     // Sync ghosts of q** for the divergence scatter (face donors read q** at
     // ghost corners on rank boundaries).
@@ -6533,6 +6675,29 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
     }
     s.domain.reverseExchangeNodeHaloAdd(d_divAccNode);
     maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_divAccNode);
+
+    // FIX 1: add the inlet+outlet opening surface flux that the interior SCS
+    // scatter cannot reach. divAccNode is now owner-complete; the per-node opening
+    // area-vectors are owner-complete too (driver does reverse-halo-add then publish,
+    // counted once per owned node), so restricting the add to owned nodes is exact
+    // and rank-safe. Uses the SAME post-diffusion velocity the divergence scatter
+    // used (d_uStarStar): inlet nodes carry the prescribed inflow, outlet nodes the
+    // post-diffusion outflow, so inlet flux + outlet flux net to ~0 and the single-pin
+    // Neumann pressure system stays solvable. Off unless --opening-flux-source.
+    if (s.useOpeningFluxSource
+        && s.d_inletAreaVecX.size() == s.nodeCount
+        && s.d_outletAreaVecX.size() == s.nodeCount)
+    {
+        addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            s.d_uStarStar.data(), s.d_vStarStar.data(), s.d_wStarStar.data(),
+            s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
+            d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
+        addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            s.d_uStarStar.data(), s.d_vStarStar.data(), s.d_wStarStar.data(),
+            s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data(),
+            d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+    }
 
     // Source-of-NaN trace: count non-finite divAccNode over ALL owned nodes and
     // over the owned-BOUNDARY subset separately. The interior diagnostic below
@@ -7283,6 +7448,109 @@ inline RealType fluxThroughOwned(NSStepper<KeyType, RealType, ElementTag>& s,
     MPI_Datatype mpi_r = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
     MPI_Allreduce(&local, &global, 1, mpi_r, MPI_SUM, MPI_COMM_WORLD);
     return global;
+}
+
+// FIX 3: interior cut-plane flux probe. For every INTERIOR median-dual SCS face
+// whose two endpoints straddle the plane axis==cut, add the SOLVED face flux
+// u_f . scsAreaVec (u_f = 0.5*(u_L+u_R), the exact interpolation the divergence
+// scatter uses) to a per-block accumulator. This reads the SOLVED interior field,
+// so unlike the outlet Q_out it CANNOT be faked by the BC relock at the openings:
+// if flow truly threads the passage the probe is nonzero and ~equal at every cut;
+// if it dies near the inlet, the mid/outlet cuts read ~0. Owned elements only;
+// the host wrapper MPI_Allreduces. Straddle test on the L/R node coords means each
+// crossing dual face is counted once with a consistent orientation (areaVec points
+// L->R by construction), so the signed sum is the net flux across the plane.
+template<typename KeyType, typename RealType, typename ElementTag>
+__global__ void interiorCutFluxKernel(const KeyType* c0, const KeyType* c1,
+                                      const KeyType* c2, const KeyType* c3,
+                                      const KeyType* c4, const KeyType* c5,
+                                      const KeyType* c6, const KeyType* c7,
+                                      const RealType* vx, const RealType* vy, const RealType* vz,
+                                      const RealType* nodeAxis,   // node coord along the cut axis
+                                      const RealType* areaVecX,
+                                      const RealType* areaVecY,
+                                      const RealType* areaVecZ,
+                                      RealType cut,
+                                      double* partial,            // one slot per block
+                                      size_t startElem, size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    double mine = 0.0;
+    if (k < numLocal)
+    {
+        size_t e = startElem + k;
+        constexpr int NPE  = ElemTraits<ElementTag>::NodesPerElem;
+        constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+        const KeyType* cc[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+        KeyType n[NPE];
+        for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+        for (int ip = 0; ip < NSCS; ++ip)
+        {
+            int nodeL, nodeR; scsLR<ElementTag>(ip, nodeL, nodeR);
+            KeyType iL = n[nodeL];
+            KeyType iR = n[nodeR];
+            RealType aL = nodeAxis[iL];
+            RealType aR = nodeAxis[iR];
+            // dual face crosses the plane iff its endpoints are on opposite sides
+            bool straddle = (aL <= cut && aR > cut) || (aR <= cut && aL > cut);
+            if (!straddle) continue;
+            RealType vfx = RealType(0.5) * (vx[iL] + vx[iR]);
+            RealType vfy = RealType(0.5) * (vy[iL] + vy[iR]);
+            RealType vfz = RealType(0.5) * (vz[iL] + vz[iR]);
+            size_t off = e * NSCS + ip;
+            mine += double(vfx * areaVecX[off] + vfy * areaVecY[off] + vfz * areaVecZ[off]);
+        }
+    }
+    // block reduce into shared then one atomic per block
+    __shared__ double sdata[256];
+    int t = threadIdx.x;
+    sdata[t] = mine;
+    __syncthreads();
+    for (int s2 = blockDim.x / 2; s2 > 0; s2 >>= 1) {
+        if (t < s2) sdata[t] += sdata[t + s2];
+        __syncthreads();
+    }
+    if (t == 0) partial[blockIdx.x] = sdata[0];
+}
+
+// Host wrapper: signed interior flux across the plane (cut along the given axis,
+// 0=x,1=y,2=z). Owned elements only; globally reduced. Reads s.d_u/v/w.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+inline RealType interiorCutFlux(NSStepper<KeyType, RealType, ElementTag>& s,
+                                int axis, RealType cut)
+{
+    const auto& d_conn = s.domain.getElementToNodeConnectivity();
+    auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+    const KeyType* c0 = cp[0]; const KeyType* c1 = cp[1];
+    const KeyType* c2 = cp[2]; const KeyType* c3 = cp[3];
+    const KeyType* c4 = nullptr; const KeyType* c5 = nullptr;
+    const KeyType* c6 = nullptr; const KeyType* c7 = nullptr;
+    if constexpr (std::is_same_v<ElementTag, HexTag>) { c4 = cp[4]; c5 = cp[5]; c6 = cp[6]; c7 = cp[7]; }
+    size_t startElem = s.domain.startIndex();
+    size_t numLocal  = s.domain.localElementCount();
+    int blk = 256;
+    int eBlocks = numLocal > 0 ? int((numLocal + blk - 1) / blk) : 0;
+
+    const RealType* nodeAxis = (axis == 0) ? s.domain.getNodeX().data()
+                             : (axis == 1) ? s.domain.getNodeY().data()
+                                           : s.domain.getNodeZ().data();
+    double local = 0.0;
+    if (eBlocks > 0)
+    {
+        cstone::DeviceVector<double> d_partial(eBlocks, 0.0);
+        interiorCutFluxKernel<KeyType, RealType, ElementTag><<<eBlocks, blk>>>(
+            c0, c1, c2, c3, c4, c5, c6, c7,
+            s.d_u.data(), s.d_v.data(), s.d_w.data(),
+            nodeAxis,
+            s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+            cut, d_partial.data(), startElem, numLocal);
+        cudaDeviceSynchronize();
+        auto pp = thrust::device_pointer_cast(d_partial.data());
+        local = thrust::reduce(thrust::device, pp, pp + eBlocks, 0.0, thrust::plus<double>());
+    }
+    double global = 0.0;
+    MPI_Allreduce(&local, &global, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    return RealType(global);
 }
 
 // Sum of an owned-node device vector (e.g. divergence accumulator). Used to

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -6824,59 +6824,25 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
     // counted once per owned node), so restricting the add to owned nodes is exact
     // and rank-safe. Uses the PRESCRIBED opening velocity (single global direction),
     // NOT the solved u**: inlet = Uinf*globalInletDir, outlet = outletU*globalOutletDir.
-    //
-    // adjustPhi (OpenFOAM / deal.II step-35): the discrete per-node inlet and outlet
-    // flux sums do NOT cancel to machine zero by analytic construction (per-node area
-    // shares are accumulated with different roundings), and the leftover epsilon, times
-    // coef=rho/dt~1e6 in the RHS, blows up the single-pin Neumann solve (that was the
-    // prior failure). FIX: measure the discrete inflow Qin_d and outflow Qout_d, then
-    // RESCALE the outlet source by scale=-Qin_d/Qout_d. IEEE guarantees
-    // (scale)*Qout_d == -Qin_d to the last bit, so the net added source is BIT-EXACT 0
-    // -> the RHS stays compatible regardless of mesh area-share imperfection. Requires
-    // the mass-conserving outlet (outletU>0); off unless --opening-flux-source.
+    // The per-node area-vectors sum to the global aIn/aOut, so the inlet term sums to
+    // -Q_in and the outlet term to +Q_out=+Q_in (mass-conserving), cancelling EXACTLY
+    // at step0 -- the single-pin Neumann pressure system stays compatible (no FIX-1
+    // one-sided blowup). REQUIRES the mass-conserving outlet (outletU>0); a do-nothing
+    // outlet leaves outletU<=0 -> outlet term ~0 -> imbalance. Off unless
+    // --opening-flux-source.
     if (s.useOpeningFluxSource
         && s.d_inletAreaVecX.size() == s.nodeCount
         && s.d_outletAreaVecX.size() == s.nodeCount)
     {
-        // Discrete owned-node boundary flux (same reduction idiom as fluxThroughOwned).
-        auto openingFluxOwned = [&] (RealType vx, RealType vy, RealType vz,
-                                     const cstone::DeviceVector<RealType>& aX,
-                                     const cstone::DeviceVector<RealType>& aY,
-                                     const cstone::DeviceVector<RealType>& aZ) -> RealType {
-            const auto& d_own = s.domain.getNodeOwnershipMap();
-            size_t n = s.nodeCount;
-            RealType loc = thrust::transform_reduce(thrust::device,
-                thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(n),
-                [own = d_own.data(), n2d = s.d_node_to_dof.data(), nOwn = s.numOwnedDofs,
-                 ax = aX.data(), ay = aY.data(), az = aZ.data(), vx, vy, vz] __device__ (size_t i) -> RealType {
-                    if (own[i] != 1) return RealType(0);
-                    int dof = n2d[i];
-                    if (dof < 0 || dof >= nOwn) return RealType(0);
-                    return vx*ax[i] + vy*ay[i] + vz*az[i];
-                }, RealType(0), thrust::plus<RealType>());
-            RealType glob = 0;
-            MPI_Datatype mpi_r = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
-            MPI_Allreduce(&loc, &glob, 1, mpi_r, MPI_SUM, MPI_COMM_WORLD);
-            return glob;
-        };
-        const RealType Qin_d  = openingFluxOwned(RealType(s.Uinf * s.inletDirX), RealType(s.Uinf * s.inletDirY), RealType(s.Uinf * s.inletDirZ),
-                                                 s.d_inletAreaVecX, s.d_inletAreaVecY, s.d_inletAreaVecZ);   // < 0 (inward jet . outward area)
-        const RealType Qout_d = openingFluxOwned(RealType(s.outletU * s.outletDirX), RealType(s.outletU * s.outletDirY), RealType(s.outletU * s.outletDirZ),
-                                                 s.d_outletAreaVecX, s.d_outletAreaVecY, s.d_outletAreaVecZ);  // > 0
-        const bool balanceable = (s.outletU > RealType(0)) && (std::fabs(Qout_d) > RealType(0));
-        const RealType scale = balanceable ? (-Qin_d / Qout_d) : RealType(0);
-        if (scale != RealType(0))
-        {
-            addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
-                RealType(s.Uinf * s.inletDirX), RealType(s.Uinf * s.inletDirY), RealType(s.Uinf * s.inletDirZ),
-                s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
-                d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
-            addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
-                RealType(scale * s.outletU * s.outletDirX), RealType(scale * s.outletU * s.outletDirY), RealType(scale * s.outletU * s.outletDirZ),
-                s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data(),
-                d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
-            cudaDeviceSynchronize();
-        }
+        addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            RealType(s.Uinf * s.inletDirX), RealType(s.Uinf * s.inletDirY), RealType(s.Uinf * s.inletDirZ),
+            s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
+            d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
+        addOpeningFluxSourceKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            RealType(s.outletU * s.outletDirX), RealType(s.outletU * s.outletDirY), RealType(s.outletU * s.outletDirZ),
+            s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data(),
+            d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
+        cudaDeviceSynchronize();
     }
 
     // Source-of-NaN trace: count non-finite divAccNode over ALL owned nodes and

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -2370,6 +2370,18 @@ struct NSStepper
     RealType outletDirX = 1, outletDirY = 0, outletDirZ = 0;
     bool outletDoNothing = true;  // do-nothing outlet (free velocity + p=0 face); false = mass-conserving velocity outlet
 
+    // FIX B -- pressure-drop drive. The CVFEM divergence operator integrates only
+    // interior SCS faces, so a velocity prescribed on the inlet opening is invisible
+    // to the pressure solve (the exterior opening face is in no scsLR pair) and the
+    // corrector freezes velocity-Dirichlet nodes -> no through-flow. Instead, drive
+    // the pump with a pressure DROP: p=pumpDp on the inlet face, p=0 on the outlet
+    // face, velocities FREE at both. The flux then EMERGES from the interior pressure
+    // gradient, which IS SCS-captured -> visible -> through-flow. Two pressure-Dirichlet
+    // faces remove the null space (nonsingular A, no pin needed), so startup is safe.
+    // pumpDp<=0 disables FIX B entirely: the pump behaves exactly as the legacy
+    // mass-conserving (or do-nothing) velocity outlet. Driver sets it from --pump-dp=.
+    RealType pumpDp = 0;
+
     // Per-node OUTWARD outlet area-vectors (un-normalized, nodeCount-sized, zero
     // off the outlet). Used only by the through-flow diagnostic to measure
     // Q_out = sum_owned( u . outletAreaVec ). Filled by the driver.
@@ -3564,35 +3576,44 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
             };
 
             tag(s.wallNodes,    RealType(0),     RealType(0), RealType(0));
-            const bool inletPerNode =
-                s.inletDirXPerNode.size() == s.inletNodes.size() &&
-                s.inletDirYPerNode.size() == s.inletNodes.size() &&
-                s.inletDirZPerNode.size() == s.inletNodes.size() &&
-                !s.inletNodes.empty();
-            if (inletPerNode)
+            // FIX B (pumpDp>0): the inlet is driven by a PRESSURE Dirichlet (set in
+            // the pressure-BC block), NOT a velocity Dirichlet. Do NOT tag the inlet
+            // here -- it must stay out of d_isBdryDof/uTarget so the corrector is
+            // free to drive its velocity from the interior pressure gradient.
+            if (s.pumpDp <= RealType(0))
             {
-                std::vector<RealType> ui(s.inletNodes.size()), vi(s.inletNodes.size()),
-                                      wi(s.inletNodes.size());
-                for (size_t k = 0; k < s.inletNodes.size(); ++k)
+                const bool inletPerNode =
+                    s.inletDirXPerNode.size() == s.inletNodes.size() &&
+                    s.inletDirYPerNode.size() == s.inletNodes.size() &&
+                    s.inletDirZPerNode.size() == s.inletNodes.size() &&
+                    !s.inletNodes.empty();
+                if (inletPerNode)
                 {
-                    ui[k] = RealType(s.Uinf * s.inletDirXPerNode[k]);
-                    vi[k] = RealType(s.Uinf * s.inletDirYPerNode[k]);
-                    wi[k] = RealType(s.Uinf * s.inletDirZPerNode[k]);
+                    std::vector<RealType> ui(s.inletNodes.size()), vi(s.inletNodes.size()),
+                                          wi(s.inletNodes.size());
+                    for (size_t k = 0; k < s.inletNodes.size(); ++k)
+                    {
+                        ui[k] = RealType(s.Uinf * s.inletDirXPerNode[k]);
+                        vi[k] = RealType(s.Uinf * s.inletDirYPerNode[k]);
+                        wi[k] = RealType(s.Uinf * s.inletDirZPerNode[k]);
+                    }
+                    tagPerNode(s.inletNodes, ui, vi, wi);
                 }
-                tagPerNode(s.inletNodes, ui, vi, wi);
-            }
-            else
-            {
-                tag(s.inletNodes,   RealType(s.Uinf * s.inletDirX),
-                                    RealType(s.Uinf * s.inletDirY),
-                                    RealType(s.Uinf * s.inletDirZ));
+                else
+                {
+                    tag(s.inletNodes,   RealType(s.Uinf * s.inletDirX),
+                                        RealType(s.Uinf * s.inletDirY),
+                                        RealType(s.Uinf * s.inletDirZ));
+                }
             }
             tag(s.extraNodes,   RealType(s.Uinf), RealType(0), RealType(0));
             // Mass-conserving outlet: velocity-Dirichlet outflow along the
             // outward normal, sized to remove the inlet flux. Only when the
             // driver set outletU > 0; otherwise the outlet stays natural-Neumann
             // (legacy) and only gets the p=0 pressure Dirichlet below.
-            if (s.outletU > RealType(0))
+            // FIX B (pumpDp>0): outlet velocity stays FREE (driven by the p=0
+            // Dirichlet + interior gradient), so never velocity-tag it.
+            if (s.pumpDp <= RealType(0) && s.outletU > RealType(0))
                 tag(s.outletNodes, RealType(s.outletU * s.outletDirX),
                                        RealType(s.outletU * s.outletDirY),
                                        RealType(s.outletU * s.outletDirZ));
@@ -4211,7 +4232,11 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
         // mask a single outlet DOF (the first owned one, on the lowest rank that
         // has one). When outletU<=0 (legacy pressure-outlet), mask the whole
         // outlet face as before (natural-Neumann velocity there).
+        // FIX B: with a pressure drop the outlet is a pressure-Dirichlet face (p=0)
+        // and the inlet a second one (p=pumpDp), so force the whole-face path -- two
+        // Dirichlet faces make A nonsingular, no single pin is needed.
         bool singlePin = (s.outletU > RealType(0));
+        if (s.pumpDp > RealType(0)) singlePin = false;
         int  pinRankLocal = singlePin ? s.numRanks : -1;  // for the global argmin
         size_t ownedOutletCount = 0;
         int firstOutletDof = -1;
@@ -4223,6 +4248,20 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
             if (dof < 0 || dof >= s.numOwnedDofs) continue;
             if (firstOutletDof < 0) firstOutletDof = dof;
             if (!singlePin) { hostMask[dof] = 1; ++ownedOutletCount; }
+        }
+        // FIX B: also mask the WHOLE inlet face as pressure-Dirichlet (p=pumpDp).
+        // enforceBcMatrixKernel makes both faces identity rows -> nonsingular A.
+        size_t ownedInletCount = 0;
+        if (s.pumpDp > RealType(0))
+        {
+            for (int li : s.inletNodes)
+            {
+                if (li < 0 || (size_t)li >= s.nodeCount) continue;
+                if (hostOwn[li] != 1) continue;
+                int dof = hostNodeToDof[li];
+                if (dof < 0 || dof >= s.numOwnedDofs) continue;
+                hostMask[dof] = 1; ++ownedInletCount;
+            }
         }
         if (singlePin)
         {
@@ -4249,10 +4288,18 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
         s.pressurePinDof  = -1;
         s.pressurePinRank = -1;
         if (s.rank == 0)
-            std::cout << "  pressure BC: " << (singlePin
-                         ? "single p=0 pin (mass-conserving velocity outlet)"
-                         : "Dirichlet p=0 on whole outlet side-set")
-                      << " (" << ownedOutletCount << " masked DOFs on rank 0)\n";
+        {
+            if (s.pumpDp > RealType(0))
+                std::cout << "  pressure BC (FIX B): Dirichlet p=" << s.pumpDp
+                          << " on whole inlet side-set, p=0 on whole outlet side-set"
+                          << " (" << ownedInletCount << " inlet + " << ownedOutletCount
+                          << " outlet masked DOFs on rank 0; two Dirichlet faces -> A nonsingular, no pin)\n";
+            else
+                std::cout << "  pressure BC: " << (singlePin
+                             ? "single p=0 pin (mass-conserving velocity outlet)"
+                             : "Dirichlet p=0 on whole outlet side-set")
+                          << " (" << ownedOutletCount << " masked DOFs on rank 0)\n";
+        }
     }
     else  // Cavity
     {
@@ -4828,6 +4875,36 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
         s.bdfStep = 0;
     }
     pt.lap("field allocation");
+
+    // FIX B: seed the STANDING pressure head into p^n. p carries p=pumpDp on the
+    // inlet face and p=0 on the outlet face; grad(p^n) then enters every predictor
+    // and drives the through-flow. The per-step phi increment is pinned 0 at both
+    // faces (enforcePressureBcRhsKernel on d_isPressureBdryDof, which now holds both
+    // faces), so p^{n+1}=p^n+phi keeps this head fixed. d_p is indexed by LOCAL NODE,
+    // so set owned inlet/outlet local nodes directly; the halo exchange propagates
+    // the head to ghosts. Owned-only avoids a cross-rank double-write. The pump
+    // driver never calls applyInitialCondition, so seed here at the end of setup.
+    if (s.pumpDp > RealType(0))
+    {
+        std::vector<RealType> hostP(s.nodeCount, RealType(0));
+        std::vector<uint8_t> hostOwnP(s.nodeCount, 0);
+        thrust::copy(thrust::device_pointer_cast(d_nodeOwnership.data()),
+                     thrust::device_pointer_cast(d_nodeOwnership.data() + s.nodeCount),
+                     hostOwnP.begin());
+        for (int li : s.inletNodes)
+            if (li >= 0 && (size_t)li < s.nodeCount && hostOwnP[li] == 1)
+                hostP[li] = s.pumpDp;
+        for (int li : s.outletNodes)
+            if (li >= 0 && (size_t)li < s.nodeCount && hostOwnP[li] == 1)
+                hostP[li] = RealType(0);
+        thrust::copy(hostP.begin(), hostP.end(),
+                     thrust::device_pointer_cast(s.d_p.data()));
+        cudaDeviceSynchronize();
+        s.domain.exchangeNodeHalo(s.d_p);
+        if (s.rank == 0)
+            std::cout << "  FIX B: seeded standing head p=" << s.pumpDp
+                      << " on inlet, p=0 on outlet (grad(p^n) drives the predictor)\n";
+    }
 
     pt.report(s.rank, "setup");
 }

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -64,15 +64,15 @@ int main(int argc, char** argv)
     std::string meshFile;
     std::string vtuPrefix;
     std::string bcMode   = "pump";    // "pump" (Exodus side-sets) or "cavity" (tet NS validation)
-    // Default mass-conserving: a velocity-inlet + free pressure-outlet leaves an
-    // UNPROJECTABLE net flux -- the divergence operator only sees interior faces,
-    // so sum(div)==0 and the pressure solve is never told mass entered -> no
-    // through-flow (flow dies at the inlet, pressure parks in the body). The
-    // mass-conserving outlet removes exactly Q (velocity outflow) + a single p=0
-    // pin, balancing the flux so the projection builds the inlet->outlet gradient
-    // that drives flow THROUGH the passage. --outlet=do-nothing selects the free
-    // pressure outlet (only correct once a boundary-flux source term is added).
-    std::string outletMode = "mass-conserving";
+    // Default do-nothing: pin p=0 over the WHOLE outlet face and leave the outlet
+    // velocity FREE (natural-Neumann). This is the channel-proven pairing -- a
+    // fixed-pressure outlet against a velocity-inlet forces the interior pressure
+    // to ramp inlet->outlet, building the cross-passage head that drives flow
+    // THROUGH the passage. Pinning BOTH ends as velocity-Dirichlet + a single p=0
+    // pin (mass-conserving) leaves a flat-pressure tank-recirculation solution ->
+    // dead passage. --outlet=mass-conserving restores the single-pin velocity
+    // outflow (kept selectable for A/B against the legacy pump state).
+    std::string outletMode = "do-nothing";
     // Advection scheme: "skew" (KE-conserving, default), "upwind" (1st-order),
     // or "barth-jespersen" (2nd-order limited, matches mesh developers' legacy).
     std::string advScheme  = "skew";
@@ -96,6 +96,14 @@ int main(int argc, char** argv)
     // uniform (Uinf,0,0) IC seeds spurious +x flow in both tanks; --pump-uniform-ic
     // restores it for comparison.
     bool pumpUniformIC = false;
+    // GUARDED, off by default. Integrate the prescribed inlet velocity over the
+    // inlet boundary faces and add the net inflow as a source into the pressure-
+    // Poisson divergence at inlet nodes. The interior SCS scatter already gives a
+    // LOCAL inlet source, but the EXTERIOR boundary-face flux through the opening
+    // is in no element's interior sub-control-surface, so it is never integrated.
+    // This adds exactly that missing term. Default false keeps the do-nothing
+    // path byte-identical until we A/B it.
+    bool addInletFluxSource = false;
     RealType    inletU   = 0.5;        // inlet speed (m/s)
     RealType    rho      = 1000.0;     // water (kg/m^3)
     RealType    nu       = 1.0e-6;     // water kinematic viscosity (m^2/s) = mu/rho
@@ -116,8 +124,9 @@ int main(int argc, char** argv)
         if      (a.rfind("--mesh=", 0) == 0)         meshFile  = a.substr(7);
         else if (a.rfind("--vtu-output=", 0) == 0)   vtuPrefix = a.substr(13);
         else if (a == "--bc=cavity")                 bcMode    = "cavity";  // tet NS validation: lid-driven cavity, no side-sets
-        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // free velocity + p=0 face (unprojectable w/o a flux source)
-        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // DEFAULT: velocity outflow + single pin (drives through-flow)
+        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // DEFAULT: whole-face p=0 + free outlet velocity (through-flow driver)
+        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // velocity outflow + single p=0 pin (legacy pump state)
+        else if (a == "--inlet-flux-source")         addInletFluxSource = true;      // add prescribed inlet flux as a divergence source (GUARDED, off by default)
         else if (a == "--upwind")                    advScheme  = "upwind";  // 1st-order upwind
         else if (a == "--skew")                      advScheme  = "skew";    // skew-symmetric (default)
         else if (a == "--bj")                        advScheme  = "barth-jespersen"; // 2nd-order limited
@@ -154,6 +163,11 @@ int main(int argc, char** argv)
                     "  --inlet-ss=NAME      inlet side-set name (required for pump BC)\n"
                     "  --inlet-flip-normal  flip inlet normal sign (use if vectors come out OUTWARD)\n"
                     "  --outlet-ss=NAME     outlet side-set name (required for pump BC)\n"
+                    "  --outlet=MODE        do-nothing (DEFAULT: whole-face p=0 + FREE outlet velocity,\n"
+                    "                       the through-flow driver) | mass-conserving (velocity outflow\n"
+                    "                       + single p=0 pin, legacy pump state)\n"
+                    "  --inlet-flux-source  add the prescribed inlet boundary flux as a pressure-Poisson\n"
+                    "                       divergence source at inlet nodes (GUARDED, off by default)\n"
                     "  --inlet-velocity=V   inlet speed along x (default 0.5)\n"
                     "  --no-inlet-pernode-normal  use one global inlet normal (default: per-node)\n"
                     "  --advection=NAME     skew (default) | upwind | barth-jespersen (--bj)\n"
@@ -197,7 +211,11 @@ int main(int argc, char** argv)
             std::cout << "BC          = lid-driven cavity (lid u = " << inletU << ")\n";
         else
             std::cout << "Inlet  SS   = " << inletSS  << "  (u = " << inletU << ")\n"
-                      << "Outlet SS   = " << outletSS << "  (p = 0)\n"
+                      << "Outlet SS   = " << outletSS
+                      << (outletMode == "mass-conserving"
+                            ? "  (velocity outflow + single p=0 pin)"
+                            : "  (whole-face p=0, FREE outlet velocity -- through-flow driver)") << "\n"
+                      << "Inlet flux  = " << (addInletFluxSource ? "boundary-flux source ON" : "OFF (interior SCS only)") << "\n"
                       << "Walls       = all other side-sets (no-slip)\n";
         std::cout << "rho         = " << rho << "   nu = " << nu << "\n"
                   << "dt          = " << dt << "   steps = " << numSteps << "\n"
@@ -291,6 +309,12 @@ int main(int argc, char** argv)
     // mass-conserving (velocity-Dirichlet outflow + single pin). The latter
     // over-constrains velocity and was seen to blow up after several flow-throughs.
     s.outletDoNothing = (outletMode != "mass-conserving");
+    s.addInletFluxSource = addInletFluxSource;
+
+    // Prescribed inlet volume flux Q_in = inletU * areaIn, captured at function
+    // scope so the per-step through-flow diagnostic can compare it to the measured
+    // outlet flux. <0 means "not a pump case / no inlet area".
+    double qIn = -1.0;
 
     // -------- Resolve side-sets to local node lists (pump semantics) --------
     if (!cavityMode)
@@ -492,9 +516,69 @@ int main(int argc, char** argv)
             return std::sqrt(out[0]*out[0] + out[1]*out[1] + out[2]*out[2]);
         };
 
+        // Per-node OUTWARD area-vector for a side-set, nodeCount-sized, zero off
+        // the set. Same once-per-face owned scatter + reverse-halo-add + forward-
+        // halo publish as the inlet-normal path, so a node whose incident faces
+        // span ranks still gets the complete owner sum. The magnitude at a node is
+        // its share of the opening area; the direction is outward (Exodus winding).
+        // Reused by the inlet per-node normals, the inlet flux source, and the
+        // through-flow diagnostic so the geometry is computed one consistent way.
+        auto perNodeAreaVec = [&](const std::string& nm,
+                                  std::vector<RealType>& outX,
+                                  std::vector<RealType>& outY,
+                                  std::vector<RealType>& outZ)
+        {
+            const size_t nNodes = amr.domain().getNodeCount();
+            outX.assign(nNodes, RealType(0));
+            outY.assign(nNodes, RealType(0));
+            outZ.assign(nNodes, RealType(0));
+            auto tit = ss.triangleCoordsByName.find(nm);
+            if (tit != ss.triangleCoordsByName.end())
+            {
+                std::vector<int> triLocal =
+                    amr.domain().resolveSideSetNodesToLocalKeepMisses(tit->second);
+                for (size_t f = 0; f + 2 < tit->second.size(); f += 3)
+                {
+                    int la = triLocal[f];
+                    if (la < 0 || hostOwnFA[la] != 1) continue;   // count once: owner of first node
+                    const auto& A = tit->second[f];
+                    const auto& B = tit->second[f + 1];
+                    const auto& C = tit->second[f + 2];
+                    double e1x = B[0]-A[0], e1y = B[1]-A[1], e1z = B[2]-A[2];
+                    double e2x = C[0]-A[0], e2y = C[1]-A[1], e2z = C[2]-A[2];
+                    double ax = 0.5*(e1y*e2z - e1z*e2y);
+                    double ay = 0.5*(e1z*e2x - e1x*e2z);
+                    double az = 0.5*(e1x*e2y - e1y*e2x);
+                    // Spread the triangle area-vector equally over its 3 vertices.
+                    for (int j = 0; j < 3; ++j)
+                    {
+                        int li = triLocal[f + j];
+                        if (li < 0 || (size_t)li >= nNodes) continue;
+                        outX[li] += RealType(ax / 3.0);
+                        outY[li] += RealType(ay / 3.0);
+                        outZ[li] += RealType(az / 3.0);
+                    }
+                }
+            }
+            cstone::DeviceVector<RealType> dX(nNodes), dY(nNodes), dZ(nNodes);
+            cudaMemcpy(dX.data(), outX.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(dY.data(), outY.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(dZ.data(), outZ.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            amr.domain().reverseExchangeNodeHaloAdd(dX);
+            amr.domain().reverseExchangeNodeHaloAdd(dY);
+            amr.domain().reverseExchangeNodeHaloAdd(dZ);
+            amr.domain().exchangeNodeHalo(dX);
+            amr.domain().exchangeNodeHalo(dY);
+            amr.domain().exchangeNodeHalo(dZ);
+            cudaMemcpy(outX.data(), dX.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
+            cudaMemcpy(outY.data(), dY.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
+            cudaMemcpy(outZ.data(), dZ.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
+        };
+
         double aIn[3], aOut[3];
         double areaIn  = faceAreaVec(inletSS,  aIn);
         double areaOut = faceAreaVec(outletSS, aOut);
+        qIn = double(inletU) * areaIn;   // prescribed inflow for the through-flow diagnostic
 
         // Inlet velocity along the INWARD normal (-outward), magnitude Uinf.
         // sgn flips the whole convention if the mesh's face winding makes the
@@ -507,75 +591,23 @@ int main(int argc, char** argv)
             s.inletDirZ = RealType(sgn * aIn[2] / areaIn);
         }
 
+        // -------- Per-node inlet OUTWARD area-vectors --------
+        // One halo-complete per-node inlet area-vector field feeds two things: the
+        // per-node inward normals (direction = -areaVec/|areaVec|) and the guarded
+        // inlet flux source (flux = uTarget . areaVec). Computing it once keeps the
+        // two consistent.
+        std::vector<RealType> h_inAx, h_inAy, h_inAz;
+        if (areaIn > 1e-30) perNodeAreaVec(inletSS, h_inAx, h_inAy, h_inAz);
+
         // -------- Per-node inlet inward normals --------
-        // The single global inletDir makes every inlet vector parallel, which on
-        // a curved inlet looks non-normal. Instead give each inlet node its OWN
-        // normal: the area-weighted sum of the inlet faces touching it. The
-        // accumulation is keyed by runtime local node id (same id space as
-        // s.inletNodes, which sideSetNodes() returns) and folded across ranks
-        // with the standard node-halo primitives, so a node whose incident faces
-        // span ranks still gets the full sum before normalizing.
+        // The single global inletDir makes every inlet vector parallel, which on a
+        // curved inlet looks non-normal. Give each inlet node its OWN normal from
+        // the area-vector above (sign flips to INWARD, matching -aIn/areaIn).
+        // Degenerate sums fall back to the global inlet direction so no node is
+        // left unset.
         if (inletPernodeNormal && areaIn > 1e-30)
         {
             const size_t nNodes = amr.domain().getNodeCount();
-            std::vector<RealType> h_nx(nNodes, RealType(0)),
-                                  h_ny(nNodes, RealType(0)),
-                                  h_nz(nNodes, RealType(0));
-            auto tit = ss.triangleCoordsByName.find(inletSS);
-            if (tit != ss.triangleCoordsByName.end())
-            {
-                // Resolve every triangle vertex to its local id (KeepMisses keeps
-                // 1:1 alignment with the coord array). Scatter each face exactly
-                // ONCE globally -- on the rank that OWNS its first node -- the
-                // same once-per-face gate faceAreaVec uses. reverseExchangeNodeHaloAdd
-                // then routes any contribution that landed on a ghost endpoint to
-                // that node's true owner; the forward exchange publishes the
-                // complete owner sum back to all ghosts. This mirrors the lumped-
-                // mass scatter pattern (owned-only scatter + reverse-add + forward).
-                std::vector<int> triLocal =
-                    amr.domain().resolveSideSetNodesToLocalKeepMisses(tit->second);
-                for (size_t f = 0; f + 2 < tit->second.size(); f += 3)
-                {
-                    int la = triLocal[f];
-                    if (la < 0 || hostOwnFA[la] != 1) continue;  // count once: owner of first node
-                    const auto& A = tit->second[f];
-                    const auto& B = tit->second[f + 1];
-                    const auto& C = tit->second[f + 2];
-                    double e1x = B[0]-A[0], e1y = B[1]-A[1], e1z = B[2]-A[2];
-                    double e2x = C[0]-A[0], e2y = C[1]-A[1], e2z = C[2]-A[2];
-                    double ax = 0.5*(e1y*e2z - e1z*e2y);
-                    double ay = 0.5*(e1z*e2x - e1x*e2z);
-                    double az = 0.5*(e1x*e2y - e1y*e2x);
-                    for (int j = 0; j < 3; ++j)
-                    {
-                        int li = triLocal[f + j];
-                        if (li < 0 || (size_t)li >= nNodes) continue;
-                        h_nx[li] += RealType(ax);
-                        h_ny[li] += RealType(ay);
-                        h_nz[li] += RealType(az);
-                    }
-                }
-            }
-
-            // Fold cross-rank partials onto owners, then publish complete sums
-            // back to ghosts (mirrors every other nodal-accumulate path here).
-            cstone::DeviceVector<RealType> d_nx(nNodes), d_ny(nNodes), d_nz(nNodes);
-            cudaMemcpy(d_nx.data(), h_nx.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
-            cudaMemcpy(d_ny.data(), h_ny.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
-            cudaMemcpy(d_nz.data(), h_nz.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
-            amr.domain().reverseExchangeNodeHaloAdd(d_nx);
-            amr.domain().reverseExchangeNodeHaloAdd(d_ny);
-            amr.domain().reverseExchangeNodeHaloAdd(d_nz);
-            amr.domain().exchangeNodeHalo(d_nx);
-            amr.domain().exchangeNodeHalo(d_ny);
-            amr.domain().exchangeNodeHalo(d_nz);
-            cudaMemcpy(h_nx.data(), d_nx.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
-            cudaMemcpy(h_ny.data(), d_ny.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
-            cudaMemcpy(h_nz.data(), d_nz.data(), nNodes*sizeof(RealType), cudaMemcpyDeviceToHost);
-
-            // Per inlet node: normalize then flip to INWARD (negate), matching the
-            // -aIn/areaIn convention of the global normal. Degenerate sums fall
-            // back to the global inlet direction so no node is left unset.
             s.inletDirXPerNode.resize(s.inletNodes.size());
             s.inletDirYPerNode.resize(s.inletNodes.size());
             s.inletDirZPerNode.resize(s.inletNodes.size());
@@ -585,7 +617,7 @@ int main(int argc, char** argv)
                 double nx = 0, ny = 0, nz = 0;
                 if (li >= 0 && (size_t)li < nNodes)
                 {
-                    nx = h_nx[li]; ny = h_ny[li]; nz = h_nz[li];
+                    nx = h_inAx[li]; ny = h_inAy[li]; nz = h_inAz[li];
                 }
                 double len = std::sqrt(nx*nx + ny*ny + nz*nz);
                 if (len > 1e-30)
@@ -605,7 +637,35 @@ int main(int argc, char** argv)
                 std::cout << "    inlet:  per-node inward normals ON ("
                           << s.inletNodes.size() << " local nodes; --no-inlet-pernode-normal to disable)\n";
         }
-        // Mass-conserving outlet: a velocity-inlet + pressure-only outlet leaves
+
+        // Plumb the per-node inlet area-vectors to the solver for the guarded
+        // inlet flux source. Stored ONLY when the source is enabled, so the
+        // default path allocates nothing new.
+        if (addInletFluxSource && areaIn > 1e-30)
+        {
+            const size_t nNodes = amr.domain().getNodeCount();
+            s.d_inletAreaVecX.resize(nNodes);
+            s.d_inletAreaVecY.resize(nNodes);
+            s.d_inletAreaVecZ.resize(nNodes);
+            cudaMemcpy(s.d_inletAreaVecX.data(), h_inAx.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_inletAreaVecY.data(), h_inAy.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_inletAreaVecZ.data(), h_inAz.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+        }
+
+        // Per-node OUTWARD outlet area-vectors for the through-flow diagnostic
+        // (Q_out = sum_owned u.areaVec). Always available for the pump print.
+        if (areaOut > 1e-30)
+        {
+            const size_t nNodes = amr.domain().getNodeCount();
+            std::vector<RealType> h_outAx, h_outAy, h_outAz;
+            perNodeAreaVec(outletSS, h_outAx, h_outAy, h_outAz);
+            s.d_outletAreaVecX.resize(nNodes);
+            s.d_outletAreaVecY.resize(nNodes);
+            s.d_outletAreaVecZ.resize(nNodes);
+            cudaMemcpy(s.d_outletAreaVecX.data(), h_outAx.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_outletAreaVecY.data(), h_outAy.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_outletAreaVecZ.data(), h_outAz.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+        }
         // Outlet BC depends on the mode:
         //  - do-nothing (default): leave outletU<=0 so the solver masks the WHOLE
         //    outlet face as p=0 Dirichlet with FREE velocity. The inlet injects
@@ -861,6 +921,15 @@ int main(int argc, char** argv)
             RealType vmx = maxOwnedInteriorAbs<KeyType, RealType, TetTag>(s, s.d_v);
             RealType wmx = maxOwnedInteriorAbs<KeyType, RealType, TetTag>(s, s.d_w);
             double uMax = std::sqrt(double(umx)*double(umx) + double(vmx)*double(vmx) + double(wmx)*double(wmx));
+            // Through-flow: measured outlet flux Q_out = sum_owned(u . outletAreaVec)
+            // vs the prescribed inflow Q_in. Ratio -> 1 means mass crosses the whole
+            // domain (passage is live). fluxThroughOwned is collective -> all ranks.
+            double qOut = 0.0;
+            bool haveFlux = !cavityMode && qIn > 0.0 && s.d_outletAreaVecX.size() == s.nodeCount;
+            if (haveFlux)
+                qOut = double(fluxThroughOwned<KeyType, RealType, TetTag>(
+                    s, s.d_u, s.d_v, s.d_w,
+                    s.d_outletAreaVecX, s.d_outletAreaVecY, s.d_outletAreaVecZ));
             double divND = (inletU > 0 && Lscale > 0)
                            ? double(s.lastDivMax) * Lscale / inletU : double(s.lastDivMax);
             // RC-flux divergence (the operator RC actually zeros); only meaningful
@@ -886,6 +955,12 @@ int main(int argc, char** argv)
                           << "  pres_res=" << std::scientific << std::setprecision(3) << s.lastPressResid
                           << "  cg_uvw=" << s.lastUIters
                           << "\n" << std::defaultfloat;
+                if (haveFlux)
+                    std::cout << "  [through-flow] Q_in=" << std::scientific << std::setprecision(3) << qIn
+                              << "  Q_out=" << qOut
+                              << "  ratio=" << std::fixed << std::setprecision(3)
+                              << (std::abs(qIn) > 0 ? qOut / qIn : 0.0)
+                              << "\n" << std::defaultfloat;
             }
         }
         if (!vtuPrefix.empty() && (step % vtuEvery == 0 || step == numSteps))

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -64,15 +64,14 @@ int main(int argc, char** argv)
     std::string meshFile;
     std::string vtuPrefix;
     std::string bcMode   = "pump";    // "pump" (Exodus side-sets) or "cavity" (tet NS validation)
-    // Default do-nothing: pin p=0 over the WHOLE outlet face and leave the outlet
-    // velocity FREE (natural-Neumann). This is the channel-proven pairing -- a
-    // fixed-pressure outlet against a velocity-inlet forces the interior pressure
-    // to ramp inlet->outlet, building the cross-passage head that drives flow
-    // THROUGH the passage. Pinning BOTH ends as velocity-Dirichlet + a single p=0
-    // pin (mass-conserving) leaves a flat-pressure tank-recirculation solution ->
-    // dead passage. --outlet=mass-conserving restores the single-pin velocity
-    // outflow (kept selectable for A/B against the legacy pump state).
-    std::string outletMode = "do-nothing";
+    // Default mass-conserving: velocity-Dirichlet outflow U_out = U_in*A_in/A_out
+    // along the outward normal + a single p=0 pin. This FORCES Q_out=Q_in by
+    // construction and is the validated through-flow-capable config (legacy pump
+    // state). The do-nothing alternative (p=0 over the WHOLE outlet face + free
+    // outlet velocity) does NOT self-drive a small interior outlet: it was verified
+    // to leave the passage dead (through-flow ratio=0). --outlet=do-nothing kept
+    // selectable for diagnostics only.
+    std::string outletMode = "mass-conserving";
     // Advection scheme: "skew" (KE-conserving, default), "upwind" (1st-order),
     // or "barth-jespersen" (2nd-order limited, matches mesh developers' legacy).
     std::string advScheme  = "skew";
@@ -96,14 +95,6 @@ int main(int argc, char** argv)
     // uniform (Uinf,0,0) IC seeds spurious +x flow in both tanks; --pump-uniform-ic
     // restores it for comparison.
     bool pumpUniformIC = false;
-    // GUARDED, off by default. Integrate the prescribed inlet velocity over the
-    // inlet boundary faces and add the net inflow as a source into the pressure-
-    // Poisson divergence at inlet nodes. The interior SCS scatter already gives a
-    // LOCAL inlet source, but the EXTERIOR boundary-face flux through the opening
-    // is in no element's interior sub-control-surface, so it is never integrated.
-    // This adds exactly that missing term. Default false keeps the do-nothing
-    // path byte-identical until we A/B it.
-    bool addInletFluxSource = false;
     RealType    inletU   = 0.5;        // inlet speed (m/s)
     RealType    rho      = 1000.0;     // water (kg/m^3)
     RealType    nu       = 1.0e-6;     // water kinematic viscosity (m^2/s) = mu/rho
@@ -124,9 +115,8 @@ int main(int argc, char** argv)
         if      (a.rfind("--mesh=", 0) == 0)         meshFile  = a.substr(7);
         else if (a.rfind("--vtu-output=", 0) == 0)   vtuPrefix = a.substr(13);
         else if (a == "--bc=cavity")                 bcMode    = "cavity";  // tet NS validation: lid-driven cavity, no side-sets
-        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // DEFAULT: whole-face p=0 + free outlet velocity (through-flow driver)
-        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // velocity outflow + single p=0 pin (legacy pump state)
-        else if (a == "--inlet-flux-source")         addInletFluxSource = true;      // add prescribed inlet flux as a divergence source (GUARDED, off by default)
+        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // whole-face p=0 + free outlet velocity (diagnostic; does NOT drive through-flow)
+        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // DEFAULT: velocity outflow + single p=0 pin, forces Q_out=Q_in (legacy pump state)
         else if (a == "--upwind")                    advScheme  = "upwind";  // 1st-order upwind
         else if (a == "--skew")                      advScheme  = "skew";    // skew-symmetric (default)
         else if (a == "--bj")                        advScheme  = "barth-jespersen"; // 2nd-order limited
@@ -163,11 +153,9 @@ int main(int argc, char** argv)
                     "  --inlet-ss=NAME      inlet side-set name (required for pump BC)\n"
                     "  --inlet-flip-normal  flip inlet normal sign (use if vectors come out OUTWARD)\n"
                     "  --outlet-ss=NAME     outlet side-set name (required for pump BC)\n"
-                    "  --outlet=MODE        do-nothing (DEFAULT: whole-face p=0 + FREE outlet velocity,\n"
-                    "                       the through-flow driver) | mass-conserving (velocity outflow\n"
-                    "                       + single p=0 pin, legacy pump state)\n"
-                    "  --inlet-flux-source  add the prescribed inlet boundary flux as a pressure-Poisson\n"
-                    "                       divergence source at inlet nodes (GUARDED, off by default)\n"
+                    "  --outlet=MODE        mass-conserving (DEFAULT: velocity outflow + single p=0\n"
+                    "                       pin, forces Q_out=Q_in) | do-nothing (whole-face p=0 + FREE\n"
+                    "                       outlet velocity, diagnostic only -- does NOT drive through-flow)\n"
                     "  --inlet-velocity=V   inlet speed along x (default 0.5)\n"
                     "  --no-inlet-pernode-normal  use one global inlet normal (default: per-node)\n"
                     "  --advection=NAME     skew (default) | upwind | barth-jespersen (--bj)\n"
@@ -213,9 +201,8 @@ int main(int argc, char** argv)
             std::cout << "Inlet  SS   = " << inletSS  << "  (u = " << inletU << ")\n"
                       << "Outlet SS   = " << outletSS
                       << (outletMode == "mass-conserving"
-                            ? "  (velocity outflow + single p=0 pin)"
-                            : "  (whole-face p=0, FREE outlet velocity -- through-flow driver)") << "\n"
-                      << "Inlet flux  = " << (addInletFluxSource ? "boundary-flux source ON" : "OFF (interior SCS only)") << "\n"
+                            ? "  (velocity outflow + single p=0 pin, forces Q_out=Q_in)"
+                            : "  (whole-face p=0, FREE outlet velocity -- diagnostic, no through-flow)") << "\n"
                       << "Walls       = all other side-sets (no-slip)\n";
         std::cout << "rho         = " << rho << "   nu = " << nu << "\n"
                   << "dt          = " << dt << "   steps = " << numSteps << "\n"
@@ -305,11 +292,10 @@ int main(int argc, char** argv)
         ? NSStepper<KeyType, RealType, TetTag>::BCKind::Cavity
         : NSStepper<KeyType, RealType, TetTag>::BCKind::Pump;
     s.lidU = RealType(inletU);   // cavity lid speed reuses the inlet-velocity flag
-    // Outlet treatment: do-nothing (free velocity + p=0 face, default, stable) or
-    // mass-conserving (velocity-Dirichlet outflow + single pin). The latter
-    // over-constrains velocity and was seen to blow up after several flow-throughs.
+    // Outlet treatment: mass-conserving (velocity-Dirichlet outflow + single pin,
+    // default, forces Q_out=Q_in) or do-nothing (free velocity + whole-face p=0,
+    // diagnostic only -- does not self-drive the passage).
     s.outletDoNothing = (outletMode != "mass-conserving");
-    s.addInletFluxSource = addInletFluxSource;
 
     // Prescribed inlet volume flux Q_in = inletU * areaIn, captured at function
     // scope so the per-step through-flow diagnostic can compare it to the measured
@@ -592,10 +578,8 @@ int main(int argc, char** argv)
         }
 
         // -------- Per-node inlet OUTWARD area-vectors --------
-        // One halo-complete per-node inlet area-vector field feeds two things: the
-        // per-node inward normals (direction = -areaVec/|areaVec|) and the guarded
-        // inlet flux source (flux = uTarget . areaVec). Computing it once keeps the
-        // two consistent.
+        // Halo-complete per-node inlet area-vector field; feeds the per-node inward
+        // normals below (direction = -areaVec/|areaVec|).
         std::vector<RealType> h_inAx, h_inAy, h_inAz;
         if (areaIn > 1e-30) perNodeAreaVec(inletSS, h_inAx, h_inAy, h_inAz);
 
@@ -636,20 +620,6 @@ int main(int argc, char** argv)
             if (rank == 0)
                 std::cout << "    inlet:  per-node inward normals ON ("
                           << s.inletNodes.size() << " local nodes; --no-inlet-pernode-normal to disable)\n";
-        }
-
-        // Plumb the per-node inlet area-vectors to the solver for the guarded
-        // inlet flux source. Stored ONLY when the source is enabled, so the
-        // default path allocates nothing new.
-        if (addInletFluxSource && areaIn > 1e-30)
-        {
-            const size_t nNodes = amr.domain().getNodeCount();
-            s.d_inletAreaVecX.resize(nNodes);
-            s.d_inletAreaVecY.resize(nNodes);
-            s.d_inletAreaVecZ.resize(nNodes);
-            cudaMemcpy(s.d_inletAreaVecX.data(), h_inAx.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
-            cudaMemcpy(s.d_inletAreaVecY.data(), h_inAy.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
-            cudaMemcpy(s.d_inletAreaVecZ.data(), h_inAz.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
         }
 
         // Per-node OUTWARD outlet area-vectors for the through-flow diagnostic

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -108,6 +108,11 @@ int main(int argc, char** argv)
     int         blockSize  = 256;
     int         bucketSize = 64;
     RealType    icPerturb  = 0.0;
+    // FIX 1/2 through-flow toggles. Opening-flux source OFF by default so it can
+    // be A/B-ed safely (a prior naive surface-source attempt blew up). Dirichlet
+    // lift ON (a correctness fix); --no-dirichlet-lift disables for comparison.
+    bool        openingFluxSource = false;
+    bool        dirichletLift     = true;
 
     for (int i = 1; i < argc; ++i)
     {
@@ -143,6 +148,10 @@ int main(int argc, char** argv)
         else if (a.rfind("--max-iter=", 0) == 0)     maxIter   = std::stoi(a.substr(11));
         else if (a.rfind("--tol=", 0) == 0)          tolerance = std::stod(a.substr(6));
         else if (a.rfind("--ic-perturb=", 0) == 0)   icPerturb = std::stod(a.substr(13));
+        else if (a == "--opening-flux-source")        openingFluxSource = true;   // FIX 1: add inlet+outlet boundary surface flux to the pressure RHS
+        else if (a == "--no-opening-flux-source")     openingFluxSource = false;
+        else if (a == "--dirichlet-lift")             dirichletLift = true;       // FIX 2: lift inlet momentum into interior diffusion (default ON)
+        else if (a == "--no-dirichlet-lift")          dirichletLift = false;
         else if (a == "--help" || a == "-h")
         {
             if (rank == 0)
@@ -166,7 +175,11 @@ int main(int argc, char** argv)
                     "  --dt=V --num-steps=N time stepping (default 1e-3, 200)\n"
                     "  --cfl=C              adaptive dt: cap advective CFL at C (~0.5 for BJ+BDF2)\n"
                     "  --vtu-output=PREFIX --vtu-every=N   VTU/PVTU output\n"
-                    "  --ic-perturb=F       interior IC perturbation (break symmetry)\n";
+                    "  --ic-perturb=F       interior IC perturbation (break symmetry)\n"
+                    "  --opening-flux-source  add inlet+outlet boundary surface flux to the\n"
+                    "                       pressure RHS (FIX 1, off by default; A/B with --no-...)\n"
+                    "  --no-dirichlet-lift  disable the velocity-diffusion Dirichlet lift (FIX 2,\n"
+                    "                       on by default)\n";
             }
             MPI_Finalize();
             return 0;
@@ -283,6 +296,8 @@ int main(int argc, char** argv)
     s.useBdf2 = useBdf2;
     s.useRhieChow = useRhieChow;
     s.useVMSStab  = useVMSStab;   // Nalu VMS pressure stabilization (tet-only)
+    s.useOpeningFluxSource = openingFluxSource;   // FIX 1 (off by default)
+    s.useDirichletLift     = dirichletLift;       // FIX 2 (on by default)
     s.rhieChowTau = rhieTau;   // <=0 -> kernel falls back to dt/rho
     // Cavity = lid-driven cavity (geometric BC, no side-sets) -- a controlled
     // tet-NS validation case with a known flow pattern. Pump = per-side-set
@@ -582,6 +597,21 @@ int main(int argc, char** argv)
         // normals below (direction = -areaVec/|areaVec|).
         std::vector<RealType> h_inAx, h_inAy, h_inAz;
         if (areaIn > 1e-30) perNodeAreaVec(inletSS, h_inAx, h_inAy, h_inAz);
+
+        // FIX 1: push the per-node OUTWARD inlet area-vectors to the device so the
+        // opening-flux source can add ( u . areaVec ) at each inlet node. Same owner-
+        // complete field used for the inward normals above; outlet area-vecs are
+        // uploaded separately below. Only needed when the source is enabled.
+        if (openingFluxSource && areaIn > 1e-30)
+        {
+            const size_t nNodes = amr.domain().getNodeCount();
+            s.d_inletAreaVecX.resize(nNodes);
+            s.d_inletAreaVecY.resize(nNodes);
+            s.d_inletAreaVecZ.resize(nNodes);
+            cudaMemcpy(s.d_inletAreaVecX.data(), h_inAx.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_inletAreaVecY.data(), h_inAy.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+            cudaMemcpy(s.d_inletAreaVecZ.data(), h_inAz.data(), nNodes*sizeof(RealType), cudaMemcpyHostToDevice);
+        }
 
         // -------- Per-node inlet inward normals --------
         // The single global inletDir makes every inlet vector parallel, which on a
@@ -891,15 +921,36 @@ int main(int argc, char** argv)
             RealType vmx = maxOwnedInteriorAbs<KeyType, RealType, TetTag>(s, s.d_v);
             RealType wmx = maxOwnedInteriorAbs<KeyType, RealType, TetTag>(s, s.d_w);
             double uMax = std::sqrt(double(umx)*double(umx) + double(vmx)*double(vmx) + double(wmx)*double(wmx));
-            // Through-flow: measured outlet flux Q_out = sum_owned(u . outletAreaVec)
-            // vs the prescribed inflow Q_in. Ratio -> 1 means mass crosses the whole
-            // domain (passage is live). fluxThroughOwned is collective -> all ranks.
+            // [bc-sanity] Q_out = sum_owned(u . outletAreaVec) vs prescribed Q_in.
+            // NOT a through-flow proof: the corrector relocks the outlet nodes to
+            // the prescribed outletU, so for the mass-conserving outlet Q_out=Q_in
+            // by construction. Kept only as a BC sanity check. fluxThroughOwned is
+            // collective -> call on all ranks.
             double qOut = 0.0;
             bool haveFlux = !cavityMode && qIn > 0.0 && s.d_outletAreaVecX.size() == s.nodeCount;
             if (haveFlux)
                 qOut = double(fluxThroughOwned<KeyType, RealType, TetTag>(
                     s, s.d_u, s.d_v, s.d_w,
                     s.d_outletAreaVecX, s.d_outletAreaVecY, s.d_outletAreaVecZ));
+            // FIX 3: interior cut-plane flux probe. Reads the SOLVED interior field,
+            // so it cannot be fooled by the BC relock at the openings. Probe at
+            // 0.25/0.5/0.75 of the longest bbox axis: all three ~equal and nonzero =
+            // real through-flow; inlet-end nonzero with mid/outlet ~0 = flow dies.
+            // interiorCutFlux is collective -> compute on every rank.
+            double qc25 = 0.0, qc50 = 0.0, qc75 = 0.0;
+            int cutAxis = 0;
+            if (!cavityMode)
+            {
+                double spanX = double(s.xmax) - double(s.xmin);
+                double spanY = double(s.ymax) - double(s.ymin);
+                double spanZ = double(s.zmax) - double(s.zmin);
+                cutAxis = (spanX >= spanY && spanX >= spanZ) ? 0 : (spanY >= spanZ ? 1 : 2);
+                double lo  = (cutAxis == 0) ? double(s.xmin) : (cutAxis == 1 ? double(s.ymin) : double(s.zmin));
+                double span = (cutAxis == 0) ? spanX : (cutAxis == 1 ? spanY : spanZ);
+                qc25 = double(interiorCutFlux<KeyType, RealType, TetTag>(s, cutAxis, RealType(lo + 0.25*span)));
+                qc50 = double(interiorCutFlux<KeyType, RealType, TetTag>(s, cutAxis, RealType(lo + 0.50*span)));
+                qc75 = double(interiorCutFlux<KeyType, RealType, TetTag>(s, cutAxis, RealType(lo + 0.75*span)));
+            }
             double divND = (inletU > 0 && Lscale > 0)
                            ? double(s.lastDivMax) * Lscale / inletU : double(s.lastDivMax);
             // RC-flux divergence (the operator RC actually zeros); only meaningful
@@ -926,11 +977,22 @@ int main(int argc, char** argv)
                           << "  cg_uvw=" << s.lastUIters
                           << "\n" << std::defaultfloat;
                 if (haveFlux)
-                    std::cout << "  [through-flow] Q_in=" << std::scientific << std::setprecision(3) << qIn
+                    std::cout << "  [bc-sanity] Q_in=" << std::scientific << std::setprecision(3) << qIn
                               << "  Q_out=" << qOut
                               << "  ratio=" << std::fixed << std::setprecision(3)
                               << (std::abs(qIn) > 0 ? qOut / qIn : 0.0)
+                              << "  (prescribed-BC check, NOT through-flow)"
                               << "\n" << std::defaultfloat;
+                if (!cavityMode)
+                {
+                    const char axc[3] = {'x', 'y', 'z'};
+                    std::cout << "  [interior-flux] axis=" << axc[cutAxis]
+                              << "  cut@25%=" << std::scientific << std::setprecision(3) << qc25
+                              << "  cut@50%=" << qc50
+                              << "  cut@75%=" << qc75
+                              << "  (solved interior; ~equal+nonzero = real through-flow)"
+                              << "\n" << std::defaultfloat;
+                }
             }
         }
         if (!vtuPrefix.empty() && (step % vtuEvery == 0 || step == numSteps))

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -64,7 +64,15 @@ int main(int argc, char** argv)
     std::string meshFile;
     std::string vtuPrefix;
     std::string bcMode   = "pump";    // "pump" (Exodus side-sets) or "cavity" (tet NS validation)
-    std::string outletMode = "do-nothing";  // "do-nothing" (free vel + p=0 face) or "mass-conserving" (vel outflow + pin)
+    // Default mass-conserving: a velocity-inlet + free pressure-outlet leaves an
+    // UNPROJECTABLE net flux -- the divergence operator only sees interior faces,
+    // so sum(div)==0 and the pressure solve is never told mass entered -> no
+    // through-flow (flow dies at the inlet, pressure parks in the body). The
+    // mass-conserving outlet removes exactly Q (velocity outflow) + a single p=0
+    // pin, balancing the flux so the projection builds the inlet->outlet gradient
+    // that drives flow THROUGH the passage. --outlet=do-nothing selects the free
+    // pressure outlet (only correct once a boundary-flux source term is added).
+    std::string outletMode = "mass-conserving";
     // Advection scheme: "skew" (KE-conserving, default), "upwind" (1st-order),
     // or "barth-jespersen" (2nd-order limited, matches mesh developers' legacy).
     std::string advScheme  = "skew";
@@ -108,8 +116,8 @@ int main(int argc, char** argv)
         if      (a.rfind("--mesh=", 0) == 0)         meshFile  = a.substr(7);
         else if (a.rfind("--vtu-output=", 0) == 0)   vtuPrefix = a.substr(13);
         else if (a == "--bc=cavity")                 bcMode    = "cavity";  // tet NS validation: lid-driven cavity, no side-sets
-        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // free velocity + p=0 face (default)
-        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // velocity-Dirichlet outflow + single pin
+        else if (a == "--outlet=do-nothing")         outletMode = "do-nothing";    // free velocity + p=0 face (unprojectable w/o a flux source)
+        else if (a == "--outlet=mass-conserving")    outletMode = "mass-conserving"; // DEFAULT: velocity outflow + single pin (drives through-flow)
         else if (a == "--upwind")                    advScheme  = "upwind";  // 1st-order upwind
         else if (a == "--skew")                      advScheme  = "skew";    // skew-symmetric (default)
         else if (a == "--bj")                        advScheme  = "barth-jespersen"; // 2nd-order limited

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -598,13 +598,16 @@ int main(int argc, char** argv)
                           << s.inletNodes.size() << " local nodes; --no-inlet-pernode-normal to disable)\n";
         }
         // Mass-conserving outlet: a velocity-inlet + pressure-only outlet leaves
-        // an unprojectable net flux (the inlet injects U*A_in with no balanced
-        // sink). Make the outlet a Dirichlet OUTFLOW that removes exactly the
-        // inlet volume flux: U_out = (U_in * A_in) / A_out, along the OUTWARD
-        // normal. Then div(u**) is in range of the projection and flow can
-        // establish a clean inlet->outlet path. The outlet keeps p=0 for the
-        // pressure null-space (set in the stepper).
-        if (areaOut > 1e-30)
+        // Outlet BC depends on the mode:
+        //  - do-nothing (default): leave outletU<=0 so the solver masks the WHOLE
+        //    outlet face as p=0 Dirichlet with FREE velocity. The inlet injects
+        //    flux against a fixed-pressure outlet, so the interior pressure MUST
+        //    ramp outlet->suction -- a real cross-passage gradient that drives
+        //    flow THROUGH the passage. (Both-ends velocity-Dirichlet instead
+        //    admits a flat-pressure tank-recirculation solution -> no through-flow.)
+        //  - mass-conserving: velocity-Dirichlet outflow U_out=(U_in*A_in)/A_out
+        //    along the outward normal + a single p=0 pin.
+        if (!s.outletDoNothing && areaOut > 1e-30)
         {
             double Uout = (double(inletU) * areaIn) / areaOut;
             s.outletU    = RealType(Uout);

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -102,6 +102,7 @@ int main(int argc, char** argv)
     RealType    dt       = 1.0e-3;     // initial/fixed dt; capped by --cfl if set
     double      cflMax   = -1;         // >0 enables adaptive dt: cap advective CFL (uMax*dt/dx) at this
     int         numSteps = 200;
+    int         sourceRampSteps = 0;   // >0: ramp inlet drive 0->full over N steps (gentle startup)
     int         vtuEvery = 20;
     int         maxIter  = 2000;
     RealType    tolerance = 1e-8;
@@ -154,6 +155,7 @@ int main(int argc, char** argv)
         else if (a.rfind("--dt=", 0) == 0)           dt        = std::stod(a.substr(5));
         else if (a.rfind("--cfl=", 0) == 0)          cflMax    = std::stod(a.substr(6)); // adaptive dt: cap advective CFL
         else if (a.rfind("--num-steps=", 0) == 0)    numSteps  = std::stoi(a.substr(12));
+        else if (a.rfind("--source-ramp-steps=", 0) == 0) sourceRampSteps = std::stoi(a.substr(20));
         else if (a.rfind("--vtu-every=", 0) == 0)    vtuEvery  = std::stoi(a.substr(12));
         else if (a.rfind("--max-iter=", 0) == 0)     maxIter   = std::stoi(a.substr(11));
         else if (a.rfind("--tol=", 0) == 0)          tolerance = std::stod(a.substr(6));
@@ -187,6 +189,7 @@ int main(int argc, char** argv)
                     "                       whole-geometry diagonal, NOT the passage scale, so this Re\n"
                     "                       does NOT match a physically-defined Re. Prefer --nu/--rho.\n"
                     "  --dt=V --num-steps=N time stepping (default 1e-3, 200)\n"
+                    "  --source-ramp-steps=N ramp inlet drive 0->full over N steps (gentle startup; default 0=off)\n"
                     "  --cfl=C              adaptive dt: cap advective CFL at C (~0.5 for BJ+BDF2)\n"
                     "  --vtu-output=PREFIX --vtu-every=N   VTU/PVTU output\n"
                     "  --ic-perturb=F       interior IC perturbation (break symmetry)\n"
@@ -292,6 +295,7 @@ int main(int argc, char** argv)
     NSStepper<KeyType, RealType, TetTag> s{amr.domain(), SolverKind::CG, blockSize,
                                            maxIter, RealType(tolerance), rank, numRanks};
     s.Uinf          = RealType(inletU);
+    s.uinfBase      = RealType(inletU);   // unramped full-strength inlet speed (ramp target)
     s.pumpZeroIC    = !pumpUniformIC;   // default: start from rest
     s.icPerturbMag  = RealType(icPerturb);
     // DDT (matrix-free D M^-1 D^T): the corrector applies the literal D^T, so the
@@ -954,6 +958,18 @@ int main(int argc, char** argv)
             dtNew = std::max(dtNew, 0.95 * dt);     // shrink <=5%/step (BDF2)
             dtNew = std::max(dtNew, 1e-6 * dtInit); // floor: never collapse dt to ~0
             dt = dtNew;
+        }
+        // Gentle startup: ramp the inlet drive 0->full over sourceRampSteps. The flow
+        // is real but starting it from rest at full strength dumps the whole pressure
+        // head onto a near-singular interior node -> phi spike -> advection blowup.
+        // Ramping keeps the head (and phi/grad(phi)) small while it builds. Scales BOTH
+        // the inlet Dirichlet velocity AND the opening-flux source (which reads s.Uinf
+        // live), so the discrete flux balance (oScale) is preserved at every ramp level.
+        if (sourceRampSteps > 0)
+        {
+            RealType ramp = RealType(std::min(1.0, double(step) / double(sourceRampSteps)));
+            s.Uinf = s.uinfBase * ramp;
+            rescaleInletVelocityTarget<KeyType, RealType, TetTag>(s, ramp);
         }
         runNsStep<KeyType, RealType, TetTag>(s, RealType(dt), RealType(nu), RealType(rho));
         simTime += dt;

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -114,7 +114,7 @@ int main(int argc, char** argv)
     // earlier solved-field version. Pairs with the mass-conserving outlet + pumpDp=0.
     // --no-opening-flux-source disables it for A/B. Dirichlet lift ON (a correctness
     // fix); --no-dirichlet-lift disables for comparison.
-    bool        openingFluxSource = true;
+    bool        openingFluxSource = false;
     bool        dirichletLift     = true;
     // FIX B -- pressure-drop drive. >0 activates FIX B: prescribe p=pumpDp on the
     // inlet face, p=0 on the outlet face, velocities FREE at both, so the flux

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -108,10 +108,13 @@ int main(int argc, char** argv)
     int         blockSize  = 256;
     int         bucketSize = 64;
     RealType    icPerturb  = 0.0;
-    // FIX 1/2 through-flow toggles. Opening-flux source OFF by default so it can
-    // be A/B-ed safely (a prior naive surface-source attempt blew up). Dirichlet
-    // lift ON (a correctness fix); --no-dirichlet-lift disables for comparison.
-    bool        openingFluxSource = false;
+    // FIX 1/2 through-flow toggles. Opening-flux source ON by default: it is now the
+    // CORRECT through-flow fix -- it uses the PRESCRIBED (balanced) inlet/outlet
+    // opening flux, which cancels EXACTLY at step0, so it cannot blow up like the
+    // earlier solved-field version. Pairs with the mass-conserving outlet + pumpDp=0.
+    // --no-opening-flux-source disables it for A/B. Dirichlet lift ON (a correctness
+    // fix); --no-dirichlet-lift disables for comparison.
+    bool        openingFluxSource = true;
     bool        dirichletLift     = true;
     // FIX B -- pressure-drop drive. >0 activates FIX B: prescribe p=pumpDp on the
     // inlet face, p=0 on the outlet face, velocities FREE at both, so the flux
@@ -187,8 +190,9 @@ int main(int argc, char** argv)
                     "  --cfl=C              adaptive dt: cap advective CFL at C (~0.5 for BJ+BDF2)\n"
                     "  --vtu-output=PREFIX --vtu-every=N   VTU/PVTU output\n"
                     "  --ic-perturb=F       interior IC perturbation (break symmetry)\n"
-                    "  --opening-flux-source  add inlet+outlet boundary surface flux to the\n"
-                    "                       pressure RHS (FIX 1, off by default; A/B with --no-...)\n"
+                    "  --opening-flux-source  add prescribed inlet+outlet opening flux to the\n"
+                    "                       pressure RHS (FIX 1, ON by default; correct through-flow\n"
+                    "                       fix, needs mass-conserving outlet; --no-... for A/B)\n"
                     "  --no-dirichlet-lift  disable the velocity-diffusion Dirichlet lift (FIX 2,\n"
                     "                       on by default)\n";
             }
@@ -313,7 +317,12 @@ int main(int argc, char** argv)
     s.useBdf2 = useBdf2;
     s.useRhieChow = useRhieChow;
     s.useVMSStab  = useVMSStab;   // Nalu VMS pressure stabilization (tet-only)
-    s.useOpeningFluxSource = openingFluxSource;   // FIX 1 (off by default)
+    // Correct through-flow config: mass-conserving outlet + opening-flux-source ON
+    // + pumpDp=0 (FIX B off). The prescribed inlet/outlet opening flux balances
+    // exactly (sum=0 at step0), so the single-pin Neumann pressure solve is
+    // compatible and through-flow develops. The source REQUIRES the mass-conserving
+    // outlet (so outletU>0 and the outlet term is nonzero); see the guard below.
+    s.useOpeningFluxSource = openingFluxSource;   // FIX 1 (on by default; correct fix)
     s.useDirichletLift     = dirichletLift;       // FIX 2 (on by default)
     s.pumpDp               = RealType(pumpDp);    // FIX B: pressure-drop drive (>0 active)
     s.rhieChowTau = rhieTau;   // <=0 -> kernel falls back to dt/rho
@@ -339,6 +348,20 @@ int main(int argc, char** argv)
     // default, forces Q_out=Q_in) or do-nothing (free velocity + whole-face p=0,
     // diagnostic only -- does not self-drive the passage).
     s.outletDoNothing = (outletMode != "mass-conserving");
+
+    // The opening-flux source REQUIRES the mass-conserving outlet: only then is
+    // outletU>0, so the prescribed outlet term (+Q_out) balances the inlet term
+    // (-Q_in). A do-nothing outlet leaves outletU<=0 -> outlet term ~0 -> one-sided
+    // imbalance -> the single-pin Neumann pressure solve goes incompatible -> blowup.
+    // Disable the source (with a warning) rather than blow up.
+    if (s.useOpeningFluxSource && s.outletDoNothing)
+    {
+        if (rank == 0)
+            std::cerr << "WARNING: --opening-flux-source needs the mass-conserving outlet "
+                         "(outletU>0 to balance the inlet flux); --outlet=do-nothing leaves it "
+                         "unbalanced. Disabling the opening-flux source.\n";
+        s.useOpeningFluxSource = false;
+    }
 
     // Prescribed inlet volume flux Q_in = inletU * areaIn, captured at function
     // scope so the per-step through-flow diagnostic can compare it to the measured
@@ -627,9 +650,10 @@ int main(int argc, char** argv)
         if (areaIn > 1e-30) perNodeAreaVec(inletSS, h_inAx, h_inAy, h_inAz);
 
         // FIX 1: push the per-node OUTWARD inlet area-vectors to the device so the
-        // opening-flux source can add ( u . areaVec ) at each inlet node. Same owner-
-        // complete field used for the inward normals above; outlet area-vecs are
-        // uploaded separately below. Only needed when the source is enabled.
+        // opening-flux source can add ( Uprescribed . areaVec ) at each inlet node.
+        // Same owner-complete field used for the inward normals above; outlet area-vecs
+        // are uploaded separately below. Gated on openingFluxSource (ON by default), so
+        // this fires by default; --no-opening-flux-source skips it.
         if (openingFluxSource && areaIn > 1e-30)
         {
             const size_t nNodes = amr.domain().getNodeCount();

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -113,6 +113,12 @@ int main(int argc, char** argv)
     // lift ON (a correctness fix); --no-dirichlet-lift disables for comparison.
     bool        openingFluxSource = false;
     bool        dirichletLift     = true;
+    // FIX B -- pressure-drop drive. >0 activates FIX B: prescribe p=pumpDp on the
+    // inlet face, p=0 on the outlet face, velocities FREE at both, so the flux
+    // EMERGES from the interior pressure gradient (SCS-captured -> visible). Two
+    // pressure-Dirichlet faces -> nonsingular A -> startup-safe. <=0 (default)
+    // keeps the legacy mass-conserving velocity outlet byte-identical.
+    double      pumpDp = 0.0;
 
     for (int i = 1; i < argc; ++i)
     {
@@ -138,6 +144,7 @@ int main(int argc, char** argv)
         else if (a == "--inlet-flip-normal")         inletFlipNormal = true;     // flip if vectors come out outward
         else if (a == "--pump-uniform-ic")           pumpUniformIC = true;       // legacy free-stream IC (default: start from rest)
         else if (a.rfind("--inlet-velocity=", 0) == 0) inletU  = std::stod(a.substr(17));
+        else if (a.rfind("--pump-dp=", 0) == 0)        pumpDp  = std::stod(a.substr(10));   // FIX B: pressure-drop drive (inlet p=pumpDp, outlet p=0, free velocities)
         else if (a.rfind("--rho=", 0) == 0)          rho       = std::stod(a.substr(6));
         else if (a.rfind("--nu=", 0) == 0)         { nu = std::stod(a.substr(5)); reqRe = -1; }
         else if (a.rfind("--Re=", 0) == 0)           reqRe = std::stod(a.substr(5)); // nu set after L is known
@@ -166,6 +173,10 @@ int main(int argc, char** argv)
                     "                       pin, forces Q_out=Q_in) | do-nothing (whole-face p=0 + FREE\n"
                     "                       outlet velocity, diagnostic only -- does NOT drive through-flow)\n"
                     "  --inlet-velocity=V   inlet speed along x (default 0.5)\n"
+                    "  --pump-dp=V          FIX B pressure-drop drive: prescribe p=V on the inlet\n"
+                    "                       face, p=0 on the outlet face, velocities FREE at both.\n"
+                    "                       Flux emerges from the interior pressure gradient.\n"
+                    "                       V<=0 (default) keeps the mass-conserving velocity outlet.\n"
                     "  --no-inlet-pernode-normal  use one global inlet normal (default: per-node)\n"
                     "  --advection=NAME     skew (default) | upwind | barth-jespersen (--bj)\n"
                     "  --rho=V --nu=V       physical fluid properties (default water: rho=1000, nu=1e-6)\n"
@@ -210,6 +221,12 @@ int main(int argc, char** argv)
                   << "Mesh        = " << meshFile << "\n";
         if (bcMode == "cavity")
             std::cout << "BC          = lid-driven cavity (lid u = " << inletU << ")\n";
+        else if (pumpDp > 0.0)
+            std::cout << "Drive       = FIX B pressure drop  dP = " << pumpDp << "\n"
+                      << "Inlet  SS   = " << inletSS  << "  (pressure-Dirichlet p=" << pumpDp
+                      << ", FREE velocity)\n"
+                      << "Outlet SS   = " << outletSS << "  (pressure-Dirichlet p=0, FREE velocity)\n"
+                      << "Walls       = all other side-sets (no-slip)\n";
         else
             std::cout << "Inlet  SS   = " << inletSS  << "  (u = " << inletU << ")\n"
                       << "Outlet SS   = " << outletSS
@@ -298,7 +315,18 @@ int main(int argc, char** argv)
     s.useVMSStab  = useVMSStab;   // Nalu VMS pressure stabilization (tet-only)
     s.useOpeningFluxSource = openingFluxSource;   // FIX 1 (off by default)
     s.useDirichletLift     = dirichletLift;       // FIX 2 (on by default)
+    s.pumpDp               = RealType(pumpDp);    // FIX B: pressure-drop drive (>0 active)
     s.rhieChowTau = rhieTau;   // <=0 -> kernel falls back to dt/rho
+    // FIX B and FIX 1 are mutually exclusive drives: the pressure drop already
+    // creates the through-flow, and adding the opening-flux source on top double-
+    // counts the inlet flux (the FIX-1 blowup). Warn and disable FIX 1 if both set.
+    if (pumpDp > 0.0 && openingFluxSource)
+    {
+        if (rank == 0)
+            std::cerr << "WARNING: --pump-dp>0 (FIX B) and --opening-flux-source (FIX 1) "
+                         "are incompatible; disabling the opening-flux source.\n";
+        s.useOpeningFluxSource = false;
+    }
     // Cavity = lid-driven cavity (geometric BC, no side-sets) -- a controlled
     // tet-NS validation case with a known flow pattern. Pump = per-side-set
     // BC machinery (Dirichlet velocity lists + outlet pressure mask).
@@ -675,7 +703,9 @@ int main(int argc, char** argv)
         //    admits a flat-pressure tank-recirculation solution -> no through-flow.)
         //  - mass-conserving: velocity-Dirichlet outflow U_out=(U_in*A_in)/A_out
         //    along the outward normal + a single p=0 pin.
-        if (!s.outletDoNothing && areaOut > 1e-30)
+        // FIX B (pumpDp>0): the outlet velocity is FREE (driven by the p=0 Dirichlet),
+        // so keep outletU<=0 -> no velocity tag on the outlet.
+        if (s.pumpDp <= RealType(0) && !s.outletDoNothing && areaOut > 1e-30)
         {
             double Uout = (double(inletU) * areaIn) / areaOut;
             s.outletU    = RealType(Uout);


### PR DESCRIPTION
- **fix(pump): revive the pressure outlet (the REAL through-flow fix). outletU was set unconditionally -> always velocity-Dirichlet outlet -> both-ends-Dirichlet admits a flat-pressure tank-recirculation div=0 solution -> NO flow through the passage (confirmed: 1e-10 pressure solve gave identical flat-p, so it's structural not convergence -- AMG would NOT help). Gate outletU on !outletDoNothing so do-nothing (default) leaves outletU<=0 -> solver masks the WHOLE outlet face p=0 + frees outlet velocity (singlePin=false, solver:4080) -> inlet flux against fixed-p outlet FORCES the outlet->suction gradient -> through-flow. The dead --outlet flag now actually works**
- **fix(pump): default outlet back to MASS-CONSERVING (the correct design). Root cause found: the divergence operator only loops interior faces (sum(div)==0 always), so the pressure solve is NEVER told mass enters at the inlet -> a velocity-inlet + free pressure-outlet is UNPROJECTABLE -> no through-flow (flow dies at inlet, pressure parks in body). The code's own comment (solver:2295) flags this. My prior do-nothing default was backwards: the mass-conserving outlet (vel outflow removes Q + single pin) BALANCES the flux so the projection builds the inlet->outlet gradient that drives flow through the passage. The dead-flag gate stays so do-nothing is still selectable (needs a boundary-flux source term to be correct -- separate work)**
- **pump through-flow: (1) default to do-nothing outlet = whole-face p=0 + FREE outlet velocity (the channel-proven pairing that builds the inlet->outlet pressure head; both-ends-velocity-Dirichlet + single pin gave a flat-pressure dead-passage solution). (2) --inlet-flux-source (GUARDED, off): add the prescribed inlet flux as a boundary divergence source -- the exterior opening flux is in no interior SCS so it's never integrated (verified not a double-count); A/B it. (3) [through-flow] Q_in/Q_out/ratio diagnostic each step so we MEASURE through-flow (ratio->1) instead of eyeballing uMax. mass-conserving still selectable. cavity/channel/TGV unaffected**
- **pump: REMOVE the broken --inlet-flux-source (double-counted the inlet flux already registered via interior SCS scatter; full-opening-area x rho/dt -> instant blowup, ratio=garbage) and revert default to MASS-CONSERVING outlet. Verified high-confidence: the inlet flux is already in the divergence for a velocity-Dirichlet inlet, so the only correct inlet boundary source is ZERO. do-nothing (whole-face p=0 + free outlet) does NOT self-drive a small interior outlet -> ratio=0 (no through-flow); the prior do-nothing-default + comments were disproven by the A/B. mass-conserving (U_out=Uin*Ain/Aout + single pin) forces Q_out=Q_in by construction. Kept the [through-flow] Q diagnostic (correct + useful)**
- **pump through-flow REWORK (verified root cause): the reference flows through the pump with ANY scheme (bj/upwind) so the dead passage is OUR bug, not Re/scheme. TWO real defects fixed: FIX1 --opening-flux-source (GUARDED off): inlet/outlet OPENING faces are exterior, in no interior SCS, so the prescribed opening flux never reaches the pressure RHS -> pressure flat -> no through-flow. Add it as a COMPATIBLE surface integral (u.n)*A_share, SAME scale as interior scatter, NOT x rho/dt (RHS does it), net~0 -- verified NOT a double-count (telescoping interior pairs never touch the opening face). FIX2 --dirichlet-lift (default ON): velocity-diffusion col-zero had no Dirichlet lift -> inlet momentum never diffused inward -> jet died at inlet. Add b-=K[row,bdry]*uTarget. FIX3: replace TAUTOLOGICAL Q_out (relocked to prescribed outletU) with an INTERIOR cut-plane flux probe at 25/50/75% -- measures SOLVED through-flow, can't be faked. old line relabeled [bc-sanity]**
- **pump FIX B: pressure-drop drive via --pump-dp=VALUE (gated, off by default -> existing pump byte-identical). Root cause: the divergence operator integrates only INTERIOR SCS faces, so a VELOCITY prescribed on the interior inlet opening is invisible to the pressure solver (exterior opening face never integrated) + the corrector freezes velocity-Dirichlet nodes -> no through-flow (proven: interior-flux mid-cut=0). FIX B masks BOTH openings as pressure-Dirichlet (p=dP inlet, p=0 outlet), frees both velocities, seeds the dP head in d_p -> flow EMERGES from the interior gradient (SCS-captured, VISIBLE). Startup-safe: two Dirichlet faces make the matrix NONSINGULAR -> no compatibility condition -> no FIX-1 source-blowup. inlet velocity becomes an OUTPUT (tune dP to hit ~0.5 m/s). Keeps interior-flux probe to verify mid-cut goes nonzero**
- **pump FIX B phi-lift (the piece that makes dP actually drive flow). Bug: FIX B seeded a one-node dP spike + pinned the phi increment to 0 at both faces -> interior never relaxed into the inlet->outlet gradient -> dP didn't drive flow (identical tiny flow at dP=1000 vs 30000). FIX: pin the SOLVED pressure to the target via rhs=target-p^n at masked DOFs (clamp to constant, NOT additive -> steady+bounded), so the Poisson solve imposes dP->0 Dirichlet data + relaxes the spanning gradient; the already-live predictor grad(p^n) then drives through-flow. LOAD-BEARING: pump runs DDT matrix-free, so the lift goes in solvePressureDDT's boundary-pin lambda (not the K-path). All gated pumpDp>0; pumpDp<=0 byte-identical (cavity/channel/TGV untouched)**
