### PR TITLE
cstone

### DIFF
--- a/backend/distributed/unstructured/fem/mars_ns_channel_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_channel_solver.hpp
@@ -1,0 +1,9718 @@
+#pragma once
+//
+// CHANNEL FORK of mars_ns_solver.hpp (same pattern as mars_ns_pump_solver.hpp:
+// full copy, included only by mars_poiseuille_flow, shared solver untouched).
+//
+// Delta vs the shared solver: the balanced opening-flux source ported from the
+// pump fork. The interior SCS divergence scatter never integrates boundary
+// opening faces, so a prescribed velocity-inlet is invisible to the pressure
+// RHS -> no streamwise pressure gradient -> dead channel. The source adds the
+// PRESCRIBED inlet/outlet fluxes to divAccNode (after the interior scatter +
+// reverse-halo, before the RHS build), with the outlet rescaled each step
+// (oScale = -Qin/Qout, adjustPhi-style) so the net source is machine-zero.
+// Gated behind NSStepper::useOpeningFluxSource, default OFF.
+//
+// Incompressible Navier-Stokes Chorin projection solver, header-only.
+//
+// Extracted from mars_amr_ns_projection.cu so multiple drivers (cavity,
+// channel, TGV with periodic BCs) can share one solver. This is a verbatim
+// lossless extraction: the cavity/channel driver behavior is preserved
+// bit-for-bit. The Periodic BCKind, runNsStep split into sub-steps, and
+// removeMean integration land in follow-up commits.
+//
+// Per timestep (current monolithic runNsStep):
+//   1) PREDICTOR        (explicit advection + grad p, halo exchange)
+//   2) IMPLICIT DIFFUSION (3 CG/Hypre solves for u,v,w)
+//   3) PRESSURE POISSON   (K-path or DDT-path; pin removes constant mode)
+//   4) CORRECTOR        (project velocity, update pressure)
+//   5) DIVERGENCE DIAG  (per-step max |div u| for monitoring)
+//
+// BCKind: Cavity | Channel (the Periodic mode lands in a follow-up).
+//
+// Note on namespacing: kernels and helpers live at file scope (no enclosing
+// namespace) to preserve the original symbol names. Drivers that include
+// this header get the same global symbols they had pre-refactor.
+//
+
+#include "mars.hpp"
+#include "backend/distributed/unstructured/domain.hpp"
+#include "backend/distributed/unstructured/fem/mars_fem.hpp"
+#include "backend/distributed/unstructured/fem/mars_cvfem_assembler.hpp"
+#include "backend/distributed/unstructured/fem/mars_cvfem_utils.hpp"
+#include "backend/distributed/unstructured/fem/mars_element_traits.hpp"
+#include "backend/distributed/unstructured/fem/mars_cvfem_tet_area.hpp"
+#include "backend/distributed/unstructured/fem/mars_cvfem_tet_assembler.hpp"
+#include "backend/distributed/unstructured/fem/mars_sparsity_builder.hpp"
+#include "backend/distributed/unstructured/fem/mars_perf_counters.hpp"
+#include "backend/distributed/unstructured/fem/mars_sparse_matrix.hpp"
+#include "backend/distributed/unstructured/fem/mars_periodic_bc.hpp"
+#include "backend/distributed/unstructured/solvers/mars_cg_solver.hpp"
+#ifdef MARS_ENABLE_HYPRE
+#include "backend/distributed/unstructured/solvers/mars_hypre_pcg_solver.hpp"
+#include "backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp"
+#endif
+#include "backend/distributed/unstructured/amr/mars_amr.hpp"
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/reduce.h>
+#include <thrust/transform.h>
+#include <thrust/extrema.h>
+#include <thrust/fill.h>
+#include <thrust/system/cuda/execution_policy.h>
+
+#include <memory>
+#include <array>
+#include <mpi.h>
+#include <iomanip>
+#include <chrono>
+#include <cmath>
+#include <cassert>
+#include <limits>
+#include <algorithm>
+#include <vector>
+#include <string>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+using namespace mars;
+using namespace mars::fem;
+using namespace mars::amr;
+
+// Sync on lap so wall-clock reflects all-rank work, not rank-0's stragglers.
+// Also live-prints each phase on rank 0 so long setup phases on large meshes
+// (e.g. 15M-hex wing) show progress in real time instead of a silent block
+// before the final summary.
+struct PhaseTimer
+{
+    using clk = std::chrono::high_resolution_clock;
+    clk::time_point t0;
+    std::vector<std::pair<std::string, float>> phases;
+    bool sync;
+    int  liveRank = -1;       // rank that should print laps live (-1 = no live print)
+
+    explicit PhaseTimer(bool sync_ = true) : sync(sync_) { reset(); }
+    explicit PhaseTimer(bool sync_, int liveRank_) : sync(sync_), liveRank(liveRank_) { reset(); }
+
+    void reset()
+    {
+        if (sync) { cudaDeviceSynchronize(); MPI_Barrier(MPI_COMM_WORLD); }
+        t0 = clk::now();
+    }
+
+    void lap(const std::string& name)
+    {
+        if (sync) { cudaDeviceSynchronize(); MPI_Barrier(MPI_COMM_WORLD); }
+        auto t1 = clk::now();
+        float ms = std::chrono::duration<float, std::milli>(t1 - t0).count();
+        phases.emplace_back(name, ms);
+        t0 = t1;
+        int worldRank = 0;
+        if (liveRank >= 0)
+        {
+            MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+            if (worldRank == liveRank)
+            {
+                std::cout << "  [lap] " << std::left << std::setw(36) << name
+                          << std::right << std::fixed << std::setprecision(2)
+                          << std::setw(12) << ms << " ms\n" << std::flush;
+            }
+        }
+    }
+
+    void report(int rank, const std::string& header)
+    {
+        if (rank != 0) return;
+        std::cout << "  [" << header << "] phase breakdown:\n";
+        float total = 0;
+        for (auto& [n, ms] : phases) total += ms;
+        for (auto& [n, ms] : phases)
+        {
+            std::cout << "    " << std::left << std::setw(36) << n
+                      << std::right << std::fixed << std::setprecision(2)
+                      << std::setw(10) << ms << " ms ("
+                      << std::setw(5) << std::setprecision(1)
+                      << (100.0f * ms / std::max(total, 1e-3f)) << "%)\n";
+        }
+        std::cout << "    " << std::left << std::setw(36) << "TOTAL"
+                  << std::right << std::fixed << std::setprecision(2)
+                  << std::setw(10) << total << " ms\n";
+    }
+};
+
+// =============================================================================
+// BC infrastructure: per-component velocity Dirichlet flags + per-node target
+// values for the lid-driven cavity; pressure pin DOF id for the Poisson solve.
+// =============================================================================
+
+// Cavity BC: u=1 on top face (z=z_max), q=0 on the other 5 faces; v=w=0 on all
+// 6 faces. Sets a per-node boundary mask AND per-node target values for each
+// velocity component. The boundary mask is computed in DOF order (only owned
+// DOFs need it; ghosts inherit through halo exchange of velocity).
+//
+// We compute per-NODE target values so the predictor/corrector can simply
+// overwrite owned-boundary node slots; the implicit diffusion solve then
+// inherits the same values via the lift-off RHS.
+template<typename RealType>
+__global__ void markCavityBCKernel(const RealType* nodeX,
+                                   const RealType* nodeY,
+                                   const RealType* nodeZ,
+                                   const uint8_t* ownership,
+                                   const int* nodeToDof,
+                                   uint8_t* isBdryDof,        // size numOwnedDofs
+                                   RealType* uTarget,         // size nodeCount
+                                   RealType* vTarget,
+                                   RealType* wTarget,
+                                   size_t numNodes,
+                                   RealType xmin, RealType xmax,
+                                   RealType ymin, RealType ymax,
+                                   RealType zmin, RealType zmax,
+                                   RealType eps,
+                                   RealType lidU,
+                                   int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+
+    RealType x = nodeX[i], y = nodeY[i], z = nodeZ[i];
+    bool onBdry = (fabs(x - xmin) < eps || fabs(x - xmax) < eps ||
+                   fabs(y - ymin) < eps || fabs(y - ymax) < eps ||
+                   fabs(z - zmin) < eps || fabs(z - zmax) < eps);
+    bool onTop  = (fabs(z - zmax) < eps);
+    // Pure-Dirichlet for velocity: only set targets on the actual boundary.
+    // Interior nodes' targets are unused (overwritten by the solve).
+    if (onBdry)
+    {
+        uTarget[i] = onTop ? lidU : RealType(0);
+        vTarget[i] = RealType(0);
+        wTarget[i] = RealType(0);
+    }
+    else
+    {
+        // Initialize interior to 0 so the predictor/corrector overwrite logic
+        // doesn't read stale memory if the array happened to alias.
+        uTarget[i] = RealType(0);
+        vTarget[i] = RealType(0);
+        wTarget[i] = RealType(0);
+    }
+
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    isBdryDof[dof] = onBdry ? 1 : 0;
+}
+
+// Channel flow BC marker.
+//   Velocity:
+//     Inflow face (x = xmin):  Dirichlet u = Uinf, v = w = 0
+//     Outflow face (x = xmax): natural homogeneous-Neumann (do nothing — not
+//                              marked in isBdryDof)
+//     Tunnel walls (y=ymin/ymax, z=zmin/zmax): Dirichlet no-slip u = v = w = 0
+//   Pressure: handled separately by markChannelPressureBCKernel (Dirichlet
+//   p = 0 on the entire outflow face). The corner-pin used by the cavity
+//   setup is skipped in channel mode — pinning a single corner fights the
+//   natural inflow-to-outflow pressure gradient and a free null space lets
+//   y-z symmetric modes grow.
+template<typename RealType>
+__global__ void markChannelBCKernel(const RealType* nodeX,
+                                    const RealType* nodeY,
+                                    const RealType* nodeZ,
+                                    const uint8_t* ownership,
+                                    const int* nodeToDof,
+                                    uint8_t* isBdryDof,
+                                    RealType* uTarget,
+                                    RealType* vTarget,
+                                    RealType* wTarget,
+                                    size_t numNodes,
+                                    RealType xmin, RealType xmax,
+                                    RealType ymin, RealType ymax,
+                                    RealType zmin, RealType zmax,
+                                    RealType eps,
+                                    RealType Uinf,
+                                    int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+
+    RealType x = nodeX[i], y = nodeY[i], z = nodeZ[i];
+    bool onInflow = (fabs(x - xmin) < eps);
+    bool onWall   = (fabs(y - ymin) < eps || fabs(y - ymax) < eps ||
+                     fabs(z - zmin) < eps || fabs(z - zmax) < eps);
+    // Outflow (x=xmax) deliberately excluded from onBdry so the natural BC
+    // (zero-grad / weak Neumann) applies through the matrix.
+    bool onBdry = onInflow || onWall;
+
+    if (onBdry)
+    {
+        uTarget[i] = onInflow ? Uinf : RealType(0);
+        vTarget[i] = RealType(0);
+        wTarget[i] = RealType(0);
+    }
+    else
+    {
+        uTarget[i] = RealType(0);
+        vTarget[i] = RealType(0);
+        wTarget[i] = RealType(0);
+    }
+
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    isBdryDof[dof] = onBdry ? 1 : 0;
+}
+
+// Channel pressure BC marker. Flags every owned node on the outflow face
+// (x = xmax) as a pressure-Dirichlet DOF. The pressure-matrix rows for those
+// DOFs become identity (row=0, diag=1) and the pressure RHS rows are zeroed
+// (target value = 0) so phi[outflow] = 0 exactly. This replaces the
+// single-point pin used by cavity and removes the null space without
+// fighting the natural channel pressure gradient.
+template<typename RealType>
+__global__ void markChannelPressureBCKernel(const RealType* nodeX,
+                                            const uint8_t* ownership,
+                                            const int* nodeToDof,
+                                            uint8_t* isPressureBdryDof,
+                                            size_t numNodes,
+                                            RealType xmax,
+                                            RealType eps,
+                                            int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    bool onOutflow = fabs(nodeX[i] - xmax) < eps;
+    isPressureBdryDof[dof] = onOutflow ? 1 : 0;
+}
+
+// Mark the single pressure-pin DOF. A pure-Dirichlet velocity problem leaves
+// the pressure Poisson rank-deficient by one (constant mode). Pinning ONE node
+// removes the singularity at minimal cost; we pick the lowest-rank node closest
+// to (xmin, ymin, zmin) so the choice is deterministic across runs.
+//
+// Approach: each rank finds its own closest owned DOF to the corner, ties
+// broken by lowest local DOF id. A single MPI_MINLOC then chooses the global
+// winner (which rank holds the pin), and that rank flips the bit. Returns the
+// winning rank in pinRankOut (only meaningful on rank 0).
+template<typename RealType>
+__global__ void findPressurePinCandidateKernel(const RealType* nodeX,
+                                               const RealType* nodeY,
+                                               const RealType* nodeZ,
+                                               const uint8_t* ownership,
+                                               const int* nodeToDof,
+                                               RealType* d2PerDof,
+                                               int* dofIdPerDof,
+                                               size_t numNodes,
+                                               int numOwnedDofs,
+                                               RealType xPin, RealType yPin, RealType zPin)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    RealType dx = nodeX[i] - xPin;
+    RealType dy = nodeY[i] - yPin;
+    RealType dz = nodeZ[i] - zPin;
+    d2PerDof[dof]    = dx * dx + dy * dy + dz * dz;
+    dofIdPerDof[dof] = dof;
+}
+
+// Pressure pin: row=0, diag=1, RHS=0 on the chosen DOF (and only on the rank
+// that owns it). All other rows have natural Neumann (no row touched).
+template<typename RealType>
+__global__ void enforcePinRowMatrixKernel(int pinDof,
+                                          const int* rowPtr,
+                                          const int* colInd,
+                                          const int* diagPtr,
+                                          RealType* values)
+{
+    int t = blockIdx.x * blockDim.x + threadIdx.x;
+    if (t != 0) return;
+    if (pinDof < 0) return;
+    for (int j = rowPtr[pinDof]; j < rowPtr[pinDof + 1]; ++j)
+        values[j] = RealType(0);
+    int dp = diagPtr[pinDof];
+    if (dp >= 0) values[dp] = RealType(1);
+}
+
+// Pin enforcement that PRESERVES the diagonal magnitude: zero the row's
+// off-diagonals, keep A[pin,pin] at its assembled value (do NOT force it to
+// 1). The DDT operator has tiny diagonals (~0.04-0.14); forcing the pin row
+// to 1.0 makes it 10-25x its neighbors -- CG tolerates that spike, but
+// BoomerAMG's strength-of-connection coarsening degrades and Hypre setup
+// returns generic error 1. Keeping the native diagonal removes the spike so
+// AMG sees a uniformly-scaled SPD row. Pin value = 0, so RHS needs no lift.
+template<typename RealType>
+__global__ void enforcePinRowKeepDiagKernel(int pinDof,
+                                            const int* rowPtr,
+                                            const int* colInd,
+                                            const int* diagPtr,
+                                            RealType* values)
+{
+    int t = blockIdx.x * blockDim.x + threadIdx.x;
+    if (t != 0) return;
+    if (pinDof < 0) return;
+    int dp = diagPtr[pinDof];
+    for (int j = rowPtr[pinDof]; j < rowPtr[pinDof + 1]; ++j)
+        if (j != dp) values[j] = RealType(0);
+    // Leave values[dp] as assembled. If the diagonal is somehow absent or
+    // non-positive, fall back to 1 so the row stays well-posed.
+    if (dp < 0) return;
+    if (!(values[dp] > RealType(0))) values[dp] = RealType(1);
+}
+
+// Zero RHS at the pin (called every step before the pressure solve).
+template<typename RealType>
+__global__ void enforcePinRhsKernel(int pinDof, RealType* rhs)
+{
+    int t = blockIdx.x * blockDim.x + threadIdx.x;
+    if (t != 0) return;
+    if (pinDof >= 0) rhs[pinDof] = RealType(0);
+}
+
+// Symmetric pin: zero column pinDof in every owned row i != pinDof. The row
+// kernel (enforcePinRowMatrixKernel) zeroes the pin's row + sets its diagonal
+// to 1, but the original off-diagonal couplings A[i, pinDof] in OTHER rows
+// remain, leaving the matrix non-symmetric. Hypre BoomerAMG's coarsening
+// heuristic assumes near-symmetry and degrades on a one-sided pin (suspected
+// contributor to the cube16 DDT+Hypre divergence). Pin value = 0, so no RHS
+// lift is needed: we simply zero the column entries.
+//
+// One thread per owned row. Each row holds at most one column equal to pinDof
+// (CSR rows have unique columns), so a linear scan + direct write (no atomic)
+// is correct.
+template<typename RealType>
+__global__ void enforcePinColMatrixKernel(int pinDof,
+                                          const int* rowPtr,
+                                          const int* colInd,
+                                          RealType* values,
+                                          int numOwnedRows)
+{
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= numOwnedRows) return;
+    if (pinDof < 0) return;
+    if (row == pinDof) return;  // row kernel already handled this row
+    int rs = rowPtr[row];
+    int re = rowPtr[row + 1];
+    for (int j = rs; j < re; ++j)
+    {
+        if (colInd[j] == pinDof)
+        {
+            values[j] = RealType(0);
+            return;
+        }
+    }
+}
+
+// Multi-DOF symmetric Dirichlet (channel outflow, pump outlet). For every
+// owned non-Dirichlet row, zero every column whose dof is flagged in the
+// boundary mask. Pin value = 0, no RHS lift.
+template<typename RealType>
+__global__ void enforceBcColMatrixKernel(const uint8_t* isBoundaryDof,
+                                         const int* rowPtr,
+                                         const int* colInd,
+                                         RealType* values,
+                                         int numOwnedRows)
+{
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= numOwnedRows) return;
+    if (isBoundaryDof[row]) return;  // already an identity row
+    int rs = rowPtr[row];
+    int re = rowPtr[row + 1];
+    for (int j = rs; j < re; ++j)
+    {
+        int c = colInd[j];
+        if (c >= 0 && c < numOwnedRows && isBoundaryDof[c])
+            values[j] = RealType(0);
+    }
+}
+
+// Zero RHS at every Dirichlet-pressure DOF (channel outflow face). Each
+// thread handles one owned DOF.
+template<typename RealType>
+__global__ void enforcePressureBcRhsKernel(const uint8_t* isPressureBdryDof,
+                                           RealType* rhs,
+                                           int numDofs)
+{
+    int dof = blockIdx.x * blockDim.x + threadIdx.x;
+    if (dof >= numDofs) return;
+    if (isPressureBdryDof[dof]) rhs[dof] = RealType(0);
+}
+
+// Build a per-NODE pressure-Dirichlet mask from the existing per-DOF mask +
+// optional single-pin DOF. Each owned node maps its dof through the existing
+// boundary flag; ghost nodes get 0 (filled by halo exchange later).
+template<typename RealType>
+__global__ void buildPressureBdryNodeMaskKernel(const int* nodeToDof,
+                                                const uint8_t* ownership,
+                                                const uint8_t* isPressureBdryDof, // may be null
+                                                int pinDof,                       // -1 if no pin
+                                                uint8_t* isPressureBdryNode,
+                                                size_t numNodes,
+                                                int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    isPressureBdryNode[i] = 0;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    bool isPin  = (pinDof >= 0 && dof == pinDof);
+    bool isMask = (isPressureBdryDof != nullptr && isPressureBdryDof[dof] != 0);
+    isPressureBdryNode[i] = (isPin || isMask) ? uint8_t(1) : uint8_t(0);
+}
+
+// Symmetric column-zero for the assembled DDT CSR, using the per-NODE
+// pressure-Dirichlet mask (halo-exchanged so ghosts see the owner's flag).
+// For every owned row whose own node is NOT pressure-Dirichlet, scan its CSR
+// neighbors; for any neighbor (local DOF c) whose corresponding LOCAL NODE is
+// flagged Dirichlet, zero values[j]. This eliminates pin/mask couplings on
+// EVERY rank (including ghost-copies of the pin on non-owning ranks), which
+// is necessary for BoomerAMG to see a globally symmetric operator.
+//
+// Maps a column local DOF c back to a local node by walking the nodeToDof
+// inverse via a precomputed dofToNode array (passed in as dofToNode[c]).
+template<typename RealType>
+__global__ void enforceBcColMatrixKernelByNode(const uint8_t* isPressureBdryNode,
+                                               const int* nodeToDof,
+                                               const int* dofToNode,
+                                               int numTotalDofs,
+                                               const int* rowPtr,
+                                               const int* colInd,
+                                               RealType* values,
+                                               int numOwnedRows)
+{
+    int row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= numOwnedRows) return;
+    // Skip if THIS row is itself Dirichlet (already an identity row).
+    int rowNode = dofToNode[row];
+    if (rowNode >= 0 && isPressureBdryNode[rowNode]) return;
+    int rs = rowPtr[row];
+    int re = rowPtr[row + 1];
+    for (int j = rs; j < re; ++j)
+    {
+        int c = colInd[j];
+        if (c < 0 || c >= numTotalDofs) continue;
+        int cnode = dofToNode[c];
+        if (cnode >= 0 && isPressureBdryNode[cnode])
+            values[j] = RealType(0);
+    }
+}
+
+// Build the inverse map: dofToNode[d] = local node that has nodeToDof[node] = d.
+// One thread per node. Multiple nodes can never share a DOF (in non-periodic
+// modes), so this is a simple scatter.
+__global__ void buildDofToNodeKernel(const int* nodeToDof,
+                                     int* dofToNode,
+                                     int numTotalDofs,
+                                     size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    int dof = nodeToDof[i];
+    if (dof >= 0 && dof < numTotalDofs) dofToNode[dof] = static_cast<int>(i);
+}
+
+// Velocity Dirichlet: zero the rows of boundary DOFs and put 1 on the diagonal.
+// Applied ONCE to the (M/dt + nu K) matrix so all three components inherit the
+// same row structure. Per-component target values are pushed through the RHS.
+template<typename RealType>
+__global__ void enforceBcMatrixKernel(const uint8_t* isBoundaryDof,
+                                      const int* rowPtr,
+                                      const int* colInd,
+                                      const int* diagPtr,
+                                      RealType* values,
+                                      int numDofs)
+{
+    int dof = blockIdx.x * blockDim.x + threadIdx.x;
+    if (dof >= numDofs || !isBoundaryDof[dof]) return;
+    for (int j = rowPtr[dof]; j < rowPtr[dof + 1]; ++j)
+        values[j] = RealType(0);
+    int dp = diagPtr[dof];
+    if (dp >= 0) values[dp] = RealType(1);
+}
+
+// Zero the assembled-DDT pressure RHS at cross-rank slave DOFs. Under
+// owner-migration the slave's nodeToDof points at the master's ghost DOF
+// (>= numOwnedDofs), so the bound check below makes this a no-op for migrated
+// pairs; it stays only for the legacy same-rank send-list entries.
+template<typename RealType>
+__global__ void zeroDofAtCrossRankSlavesKernel(const int* d_sendOwnedSlaveNodeIds,
+                                               const int* d_nodeToDof,
+                                               int numSendIds,
+                                               int numOwnedDofs,
+                                               RealType* b)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numSendIds) return;
+    int node = d_sendOwnedSlaveNodeIds[i];
+    int dof  = d_nodeToDof[node];
+    if (dof >= 0 && dof < numOwnedDofs) b[dof] = RealType(0);
+}
+
+// Lift-off velocity Dirichlet on the RHS: rhs[dof] = qTarget[node(dof)] for
+// owned boundary nodes. Combined with the matrix BC above, this implements
+// q[boundary] = qTarget exactly.
+template<typename RealType>
+__global__ void enforceBcRhsFromTargetKernel(const uint8_t* isBoundaryDof,
+                                             const RealType* qTarget,
+                                             const int* nodeToDof,
+                                             const uint8_t* ownership,
+                                             RealType* rhs,
+                                             size_t numNodes,
+                                             int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    if (isBoundaryDof[dof]) rhs[dof] = qTarget[i];
+}
+
+// =============================================================================
+// Lumped mass: per-node + reverse-halo pattern (same as B.2/B.3/B.4). Single
+// element-volume scatter feeds both the diffusion matrix (added to its diag as
+// M/dt) and the per-step predictor/corrector normalization. V_node matches the
+// per-node scatter used by gradient/divergence so the projection step is
+// algebraically consistent across operators.
+// =============================================================================
+
+// Element-tag dispatch for the SCS (sub-control-surface) left/right node indices.
+// Hex uses d_hexLRSCV[24] (mars_cvfem_utils.hpp), tet uses d_tetLRSCV[12]
+// (mars_element_traits.hpp). Both are __constant__ int arrays laid out [L,R,...].
+template<typename ElementTag>
+__device__ __forceinline__ void scsLR(int ip, int& L, int& R)
+{
+    if constexpr (std::is_same_v<ElementTag, HexTag>) { L = d_hexLRSCV[ip * 2]; R = d_hexLRSCV[ip * 2 + 1]; }
+    else { L = d_tetLRSCV[ip * 2]; R = d_tetLRSCV[ip * 2 + 1]; }
+}
+
+// Host-side connectivity pointer gather. Returns NodesPerElem device pointers
+// from the connectivity tuple so launch sites can dispatch on element type
+// without spelling std::get<7> for tet (which has only 4 columns).
+template<typename ElementTag, typename KeyType, typename ConnTuple>
+inline std::array<const KeyType*, ElemTraits<ElementTag>::NodesPerElem> connPtrs(const ConnTuple& d_conn)
+{
+    std::array<const KeyType*, ElemTraits<ElementTag>::NodesPerElem> p{};
+    if constexpr (std::is_same_v<ElementTag, HexTag>) {
+        p = { std::get<0>(d_conn).data(), std::get<1>(d_conn).data(), std::get<2>(d_conn).data(), std::get<3>(d_conn).data(),
+              std::get<4>(d_conn).data(), std::get<5>(d_conn).data(), std::get<6>(d_conn).data(), std::get<7>(d_conn).data() };
+    } else {
+        p = { std::get<0>(d_conn).data(), std::get<1>(d_conn).data(), std::get<2>(d_conn).data(), std::get<3>(d_conn).data() };
+    }
+    return p;
+}
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+__global__ void computeLumpedMassPerNodeKernel(const KeyType* c0, const KeyType* c1,
+                                               const KeyType* c2, const KeyType* c3,
+                                               const KeyType* c4, const KeyType* c5,
+                                               const KeyType* c6, const KeyType* c7,
+                                               const RealType* nodeX,
+                                               const RealType* nodeY,
+                                               const RealType* nodeZ,
+                                               RealType* massNode,
+                                               size_t startElem,
+                                               size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numLocal) return;
+    size_t e = startElem + k;
+    constexpr int NPE = ElemTraits<ElementTag>::NodesPerElem;
+    const KeyType* cc[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+
+    RealType x[NPE], y[NPE], z[NPE];
+    for (int i = 0; i < NPE; ++i)
+    {
+        x[i] = nodeX[n[i]];
+        y[i] = nodeY[n[i]];
+        z[i] = nodeZ[n[i]];
+    }
+    // Scatter to all corners (owned + ghost). The dispatcher passes only the
+    // OWNED element range; ghost-slot contributions are then folded back to the
+    // true owner by reverseExchangeNodeHaloAdd. (For cross-rank periodic pairs,
+    // slave and master have DISTINCT SFC keys -- reverse-halo can't bridge them
+    // automatically; a periodic-pair MPI exchange is required after this step.)
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    {
+        RealType xmin = x[0], xmax = x[0], ymin = y[0], ymax = y[0], zmin = z[0], zmax = z[0];
+        for (int i = 1; i < 8; ++i)
+        {
+            if (x[i] < xmin) xmin = x[i]; if (x[i] > xmax) xmax = x[i];
+            if (y[i] < ymin) ymin = y[i]; if (y[i] > ymax) ymax = y[i];
+            if (z[i] < zmin) zmin = z[i]; if (z[i] > zmax) zmax = z[i];
+        }
+        RealType contrib = (xmax - xmin) * (ymax - ymin) * (zmax - zmin) * RealType(0.125);
+        for (int i = 0; i < 8; ++i) atomicAdd(&massNode[n[i]], contrib);
+    }
+    else
+    {
+        // Tet: true cell volume V = |det[e1 e2 e3]| / 6, split equally to 4 nodes.
+        RealType e1[3] = {x[1] - x[0], y[1] - y[0], z[1] - z[0]};
+        RealType e2[3] = {x[2] - x[0], y[2] - y[0], z[2] - z[0]};
+        RealType e3[3] = {x[3] - x[0], y[3] - y[0], z[3] - z[0]};
+        RealType det = e1[0] * (e2[1] * e3[2] - e2[2] * e3[1])
+                     - e1[1] * (e2[0] * e3[2] - e2[2] * e3[0])
+                     + e1[2] * (e2[0] * e3[1] - e2[1] * e3[0]);
+        RealType V = fabs(det) / RealType(6);
+        RealType contrib = V / RealType(4);
+        for (int i = 0; i < 4; ++i) atomicAdd(&massNode[n[i]], contrib);
+    }
+}
+
+// Owned-node mass slots -> per-DOF mass array (post reverse halo). atomicAdd
+// because multiple nodes may map to the same DOF under periodic collapse
+// (slave + master both index the master DOF); plain assignment would race.
+template<typename RealType>
+__global__ void gatherOwnedNodeMassToDofKernel(const RealType* massNode,
+                                               const int* nodeToDof,
+                                               const uint8_t* ownership,
+                                               RealType* massDof,
+                                               size_t numNodes,
+                                               int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    atomicAdd(&massDof[dof], massNode[i]);
+}
+
+// Add M[i]/dt onto the diagonal of (nu K). Runs once at setup, before BC enforce.
+template<typename RealType>
+__global__ void addLumpedMassDiagonalKernel(const RealType* mass,
+                                            const int* diagPtr,
+                                            RealType invDt,
+                                            RealType* values,
+                                            int numOwnedDofs)
+{
+    int dof = blockIdx.x * blockDim.x + threadIdx.x;
+    if (dof >= numOwnedDofs) return;
+    int dp = diagPtr[dof];
+    if (dp >= 0) values[dp] += mass[dof] * invDt;
+}
+
+// O(1)-per-row diagonal extraction using the precomputed d_diagPtr indirection.
+// Cached at setup once (after BC enforcement + optional MARS_DDT_DIAG_SHIFT)
+// and reused as the Jacobi preconditioner in solvePressureDDT every CG iter.
+// Floor by 1e-30 so the 1/diag step in jacobiPrecondKernel cannot divide by
+// zero on a (pathological) empty/zero-diag row.
+template<typename RealType>
+__global__ void extractDiagByDiagPtrKernel(const int* diagPtr,
+                                           const RealType* values,
+                                           RealType* diag,
+                                           int numOwnedDofs)
+{
+    int dof = blockIdx.x * blockDim.x + threadIdx.x;
+    if (dof >= numOwnedDofs) return;
+    int dp = diagPtr[dof];
+    RealType d = (dp >= 0) ? values[dp] : RealType(0);
+    // Defensive: a non-positive diagonal would break Jacobi. Floor to keep CG
+    // robust without changing the SpMV (we only divide r by this).
+    if (!(d > RealType(1e-30))) d = RealType(1);
+    diag[dof] = d;
+}
+
+// Matrix-free Jacobi diagonal for the tet D M^-1 D^T pressure operator.
+// The assembled DDT matrix (and extractDiagByDiagPtrKernel above) is hex-only,
+// so tet has no diagonal to precondition with -> CG stalls. This builds the
+// diagonal directly from the same SCS area vectors and node lumped mass the
+// matrix-free applyDDTPerNode uses.
+//
+// Derivation (verified against the 3 operator steps): set phi = e_i and keep
+// each face's own self-term. For SCS face f=(L,R) with area A_f, applyDivT
+// scatters dp=0.5*(p_L-p_R) * A_f to BOTH endpoints (same sign), normalize
+// scales by 1/M, and computeDivergence forms 0.5*(g_L+g_R).A_f. The result:
+// each incident face contributes  +0.25 * |A_f|^2 * (1/M_L + 1/M_R)  to the
+// diagonal at i (sign^2 = 1, so strictly positive -> SPD-safe Jacobi). The
+// per-face value is symmetric in L,R, so both endpoints receive the same
+// contribution. Cross-face coupling (two distinct incident faces) is dropped;
+// harmless for a preconditioner (only needs to be a good positive scaling).
+//
+// Mass MUST come from massNode (NODE-indexed, halo-filled) not the DOF-indexed
+// d_mass: the neighbor endpoint can be a ghost with no DOF slot.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+__global__ void computeTetDDTDiagonalKernel(const KeyType* c0, const KeyType* c1,
+                                            const KeyType* c2, const KeyType* c3,
+                                            const KeyType* c4, const KeyType* c5,
+                                            const KeyType* c6, const KeyType* c7,
+                                            const RealType* areaVecX,
+                                            const RealType* areaVecY,
+                                            const RealType* areaVecZ,
+                                            const RealType* massNode,
+                                            RealType* diagAccNode,
+                                            size_t startElem,
+                                            size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numLocal) return;
+    size_t e = startElem + k;
+    constexpr int NPE = ElemTraits<ElementTag>::NodesPerElem;
+    constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+    const KeyType* cc[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+
+    #pragma unroll
+    for (int ip = 0; ip < NSCS; ++ip)
+    {
+        int nodeL, nodeR; scsLR<ElementTag>(ip, nodeL, nodeR);
+        KeyType iL = n[nodeL];
+        KeyType iR = n[nodeR];
+
+        size_t off = e * NSCS + ip;
+        RealType ax = areaVecX[off], ay = areaVecY[off], az = areaVecZ[off];
+        RealType A2 = ax*ax + ay*ay + az*az;
+
+        RealType mL = massNode[iL], mR = massNode[iR];
+        RealType invSum = RealType(0);
+        if (mL > RealType(0)) invSum += RealType(1) / mL;
+        if (mR > RealType(0)) invSum += RealType(1) / mR;
+        RealType c = RealType(0.25) * A2 * invSum;
+
+        atomicAdd(&diagAccNode[iL], c);
+        atomicAdd(&diagAccNode[iR], c);
+    }
+}
+
+// Fold owned-node diagonal accumulators into the per-DOF diagonal, flooring
+// non-positive entries (mirrors extractDiagByDiagPtrKernel's robustness).
+template<typename RealType>
+__global__ void gatherTetDDTDiagToDofKernel(const RealType* diagAccNode,
+                                            const int* nodeToDof,
+                                            const uint8_t* ownership,
+                                            RealType* diagDof,
+                                            size_t numNodes,
+                                            int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    atomicAdd(&diagDof[dof], diagAccNode[i]);
+}
+
+// Clipped Jacobi preconditioner: z[i] = r[i] / max(diag[dof(i)], epsClip)
+// for owned nodes, 0 elsewhere. The clip floor is essential on wing-type
+// meshes: high-aspect-ratio boundary-layer cells produce DDT diagonals
+// down to ~4.6e-5 while interior diag ~12.3, a 5-orders-of-magnitude spread.
+// Pure 1/diag would amplify residuals at the tiny-diag rows by ~250000x
+// every iter, biasing the search direction and breaking pAp>0. The clip
+// caps amplification at 1/epsClip while leaving the well-scaled bulk of
+// the operator preconditioned correctly. epsClip=0 disables the clip
+// (recovers the vanilla Jacobi).
+template<typename RealType>
+__global__ void jacobiPrecondNodeKernel(const RealType* r,
+                                        const RealType* diag,
+                                        const int* nodeToDof,
+                                        const uint8_t* ownership,
+                                        RealType epsClip,
+                                        RealType* z,
+                                        size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) { z[i] = RealType(0); return; }
+    int dof = nodeToDof[i];
+    if (dof < 0) { z[i] = RealType(0); return; }
+    RealType d = diag[dof];
+    if (d < epsClip) d = epsClip;
+    z[i] = r[i] / d;
+}
+
+// =============================================================================
+// Advection scatter: per-node + reverse-halo. Computes net out-flux at each
+// owned node for each velocity component q in {u, v, w}. Reused for all
+// three predictor components by passing different q arrays.
+//
+// Three forms are available, selected at runtime via the `useSkewSymmetric` flag:
+//
+//   MARS_NS_ADV_UPWIND (default for cavity/channel; useSkewSymmetric=false):
+//     q_face = q[iL] if mdot > 0 else q[iR]   (1st-order upwind)
+//     flux   = mdot * q_face
+//     Stable for any Re including high-Re, but injects/extracts KE proportional
+//     to |mdot|. Fine when boundary dissipation (Dirichlet walls) absorbs it;
+//     fatal for periodic NS because there is no wall to absorb the energy.
+//
+//   MARS_NS_ADV_SKEW (recommended for periodic; useSkewSymmetric=true):
+//     Verstappen-Veldman discrete skew-symmetric form:
+//       N_skew(u,q)_i = 1/2 (N_div + N_con)_i  =  N_div_i - 1/2 q_i (div u)_i
+//     On an SCS-face flux scatter this collapses to the "3:1 stencil":
+//       L gets  -0.25 * mdot * (3 q[L] + q[R])
+//       R gets  +0.25 * mdot * (q[L] + 3 q[R])
+//     Property: (N_skew q, q)_M = 0 exactly for ANY velocity field u (even
+//     when div u != 0). Discrete kinetic energy is conserved by advection.
+//     This is the canonical Nek5000 / Verstappen / Sandia-Nalu form.
+//     Energy conservation is a SPATIAL property; works with any time
+//     integrator (forward Euler still has O(dt) time-truncation drift).
+//
+//   MARS_NS_ADV_BJ (2nd-order Barth-Jespersen limited upwind; tet-only):
+//     Like upwind, but the upwind node value is linearly reconstructed to the
+//     face with a limited node gradient:
+//       up      = (mdot>0) ? L : R
+//       q_face  = q[up] + phi[up] * grad_q[up] . (M - x_up)
+//     M is the SCS-edge midpoint, so (M - x_up) = +-0.5*(xR - xL). phi in [0,1]
+//     is the Barth-Jespersen limiter that keeps q_face monotone (no new
+//     extrema vs the edge-neighbor min/max). phi=0 collapses to 1st-order
+//     upwind; phi=1 is the unlimited 2nd-order reconstruction. This matches
+//     the mesh developers' legacy advection. Gradient and phi are computed in
+//     runPredictorStep and halo-exchanged before this kernel runs.
+//
+// advMode selects the form at runtime: 0=skew, 1=upwind, 2=Barth-Jespersen.
+// Sign convention matches the legacy upwind path: net flux out of L, into R.
+// =============================================================================
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+__global__ void explicitAdvectionFluxScatterPerNodeKernel(const KeyType* c0, const KeyType* c1,
+                                                          const KeyType* c2, const KeyType* c3,
+                                                          const KeyType* c4, const KeyType* c5,
+                                                          const KeyType* c6, const KeyType* c7,
+                                                          const RealType* vx,
+                                                          const RealType* vy,
+                                                          const RealType* vz,
+                                                          const RealType* q,
+                                                          const RealType* areaVecX,
+                                                          const RealType* areaVecY,
+                                                          const RealType* areaVecZ,
+                                                          RealType* dqdtNode,
+                                                          size_t startElem,
+                                                          size_t numLocal,
+                                                          int advMode,
+                                                          // Barth-Jespersen inputs (advMode==2 only). For the convected
+                                                          // component q: limiter phi[node] in [0,1] and node gradient
+                                                          // grad_q. nodeX/Y/Z give the edge midpoint for reconstruction.
+                                                          // All nullptr / unread for skew and plain upwind.
+                                                          const RealType* phiQ,
+                                                          const RealType* gradQx,
+                                                          const RealType* gradQy,
+                                                          const RealType* gradQz,
+                                                          const RealType* nodeX,
+                                                          const RealType* nodeY,
+                                                          const RealType* nodeZ)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numLocal) return;
+    size_t e = startElem + k;
+    constexpr int NPE = ElemTraits<ElementTag>::NodesPerElem;
+    constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+    const KeyType* cc[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+
+    #pragma unroll
+    for (int ip = 0; ip < NSCS; ++ip)
+    {
+        int nodeL, nodeR; scsLR<ElementTag>(ip, nodeL, nodeR);
+        KeyType iL = n[nodeL];
+        KeyType iR = n[nodeR];
+
+        RealType vfx = RealType(0.5) * (vx[iL] + vx[iR]);
+        RealType vfy = RealType(0.5) * (vy[iL] + vy[iR]);
+        RealType vfz = RealType(0.5) * (vz[iL] + vz[iR]);
+
+        size_t off = e * NSCS + ip;
+        RealType mdot = vfx * areaVecX[off] + vfy * areaVecY[off] + vfz * areaVecZ[off];
+
+        if (advMode == 0)
+        {
+            // Verstappen-Veldman discrete skew-symmetric advection.
+            //
+            // Decomposition:
+            //   N_skew(u,q) = 1/2 [ div(u q)  +  (u . grad) q ]
+            //              = div(u q) - 1/2 q (div u)
+            //
+            // Per face f between (L, R), with mdot outflow-positive at L:
+            //   divergence flux: L <- -mdot*0.5*(q_L + q_R) ; R <- +mdot*0.5*(q_L + q_R)
+            //   per-node -1/2 q (div u): at L it adds -1/2 q_L * mdot
+            //                            at R it adds +1/2 q_R * mdot
+            // Sum per face:
+            //   L:  -0.5 * mdot * (2 q_L + q_R)
+            //   R:  +0.5 * mdot * (q_L + 2 q_R)
+            //
+            // Discrete property: sum_i q_i (dq/dt)_i = 0 for ANY u, even when
+            // div u != 0. Discrete KE is conserved by advection. Forward-Euler
+            // still has O(dt) time-truncation drift, but no exponential
+            // injection. Spatial property -- works with any time integrator.
+            RealType qL = q[iL];
+            RealType qR = q[iR];
+            atomicAdd(&dqdtNode[iL], -RealType(0.5) * mdot * (RealType(2) * qL + qR));
+            atomicAdd(&dqdtNode[iR], +RealType(0.5) * mdot * (qL + RealType(2) * qR));
+        }
+        else if (advMode == 1)
+        {
+            // 1st-order upwind (standard CVFEM, used by cavity/channel).
+            RealType q_face = (mdot > RealType(0)) ? q[iL] : q[iR];
+            RealType flux   = mdot * q_face;
+            atomicAdd(&dqdtNode[iL], -flux);
+            atomicAdd(&dqdtNode[iR], +flux);
+        }
+        else
+        {
+            // 2nd-order Barth-Jespersen limited upwind.
+            // Reconstruct the upwind node value to the SCS-edge midpoint M and
+            // limit the slope with the precomputed per-node phi. Midpoint
+            // reconstruction (r = M - x_up = +-0.5*(xR-xL)) is a defensible
+            // 2nd-order CVFEM target that needs only node coords; the full
+            // dual-quad-centroid IP is a later refinement.
+            KeyType up = (mdot > RealType(0)) ? iL : iR;
+            RealType mx = RealType(0.5) * (nodeX[iL] + nodeX[iR]);
+            RealType my = RealType(0.5) * (nodeY[iL] + nodeY[iR]);
+            RealType mz = RealType(0.5) * (nodeZ[iL] + nodeZ[iR]);
+            RealType rx = mx - nodeX[up];
+            RealType ry = my - nodeY[up];
+            RealType rz = mz - nodeZ[up];
+            RealType recon = gradQx[up] * rx + gradQy[up] * ry + gradQz[up] * rz;
+            RealType q_face = q[up] + phiQ[up] * recon;
+            RealType flux   = mdot * q_face;
+            atomicAdd(&dqdtNode[iL], -flux);
+            atomicAdd(&dqdtNode[iR], +flux);
+        }
+    }
+}
+
+// =============================================================================
+// Gradient scatter (B.4 pattern): three components in a single pass per call.
+// For each SCS face f with midpoint pressure p_f = 0.5*(p[iL]+p[iR]) and area
+// vector A_f pointing L->R: +p_f*A_f to L, -p_f*A_f to R. Three separate
+// buffers because CUDA has no native 3-vector atomicAdd.
+// =============================================================================
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+__global__ void computeGradientPerNodeKernel(const KeyType* c0, const KeyType* c1,
+                                             const KeyType* c2, const KeyType* c3,
+                                             const KeyType* c4, const KeyType* c5,
+                                             const KeyType* c6, const KeyType* c7,
+                                             const RealType* p,
+                                             const RealType* areaVecX,
+                                             const RealType* areaVecY,
+                                             const RealType* areaVecZ,
+                                             RealType* gxAccNode,
+                                             RealType* gyAccNode,
+                                             RealType* gzAccNode,
+                                             size_t startElem,
+                                             size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numLocal) return;
+    size_t e = startElem + k;
+    constexpr int NPE = ElemTraits<ElementTag>::NodesPerElem;
+    constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+    const KeyType* cc[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+
+    #pragma unroll
+    for (int ip = 0; ip < NSCS; ++ip)
+    {
+        int nodeL, nodeR; scsLR<ElementTag>(ip, nodeL, nodeR);
+        KeyType iL = n[nodeL];
+        KeyType iR = n[nodeR];
+        RealType pf = RealType(0.5) * (p[iL] + p[iR]);
+
+        size_t off = e * NSCS + ip;
+        RealType cx = pf * areaVecX[off];
+        RealType cy = pf * areaVecY[off];
+        RealType cz = pf * areaVecZ[off];
+
+        atomicAdd(&gxAccNode[iL], +cx);
+        atomicAdd(&gyAccNode[iL], +cy);
+        atomicAdd(&gzAccNode[iL], +cz);
+        atomicAdd(&gxAccNode[iR], -cx);
+        atomicAdd(&gyAccNode[iR], -cy);
+        atomicAdd(&gzAccNode[iR], -cz);
+    }
+}
+
+// =============================================================================
+// Barth-Jespersen limiter support kernels (used only when advScheme==
+// BarthJespersen). Defined here, ABOVE runPredictorStep, so the predictor can
+// launch them without a forward reference.
+//
+// CUDA has no native atomicMin/Max on double, so we do the standard atomicCAS
+// loop on the 64-bit pattern. Monotone bit order of IEEE-754 doubles is NOT
+// preserved across sign, so we compare the decoded double each iteration rather
+// than comparing the raw bits. This is a limiter (not exactness-critical), but
+// the CAS loop is exact anyway.
+// =============================================================================
+template<typename RealType>
+__device__ __forceinline__ void atomicMinDouble(RealType* addr, RealType val)
+{
+    unsigned long long* a = reinterpret_cast<unsigned long long*>(addr);
+    unsigned long long  old = *a, assumed;
+    do {
+        double cur = __longlong_as_double(static_cast<long long>(old));
+        if (cur <= double(val)) break;               // already <= val, done
+        assumed = old;
+        old = atomicCAS(a, assumed,
+                        static_cast<unsigned long long>(__double_as_longlong(double(val))));
+    } while (assumed != old);
+}
+
+template<typename RealType>
+__device__ __forceinline__ void atomicMaxDouble(RealType* addr, RealType val)
+{
+    unsigned long long* a = reinterpret_cast<unsigned long long*>(addr);
+    unsigned long long  old = *a, assumed;
+    do {
+        double cur = __longlong_as_double(static_cast<long long>(old));
+        if (cur >= double(val)) break;               // already >= val, done
+        assumed = old;
+        old = atomicCAS(a, assumed,
+                        static_cast<unsigned long long>(__double_as_longlong(double(val))));
+    } while (assumed != old);
+}
+
+// Seed qmin = qmax = q at every node before the neighbor min/max scatter, so a
+// node with no scattered neighbor (shouldn't happen on a valid mesh, but is
+// safe) still bounds itself.
+template<typename RealType>
+__global__ void bjSeedMinMaxKernel(const RealType* q, RealType* qmin, RealType* qmax, size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    qmin[i] = q[i];
+    qmax[i] = q[i];
+}
+
+// Neighbor min/max over edge-connected nodes. For each SCS edge (iL,iR) push
+// the neighbor's value into this node's running min/max. After this scatter
+// qmin[i]/qmax[i] hold min/max of q over {i} U {edge neighbors of i} that are
+// reachable from this rank's OWNED elements.
+//
+// Halo: run over OWNED elements only; an owned boundary node's off-rank
+// neighbors are completed by reverseExchangeNodeHaloMin/Max in the caller (a
+// MIN/MAX fold -- the SUM-based reverse fold would corrupt min/max), then a
+// forward exchangeNodeHalo publishes the complete owner bounds to ghosts.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+__global__ void bjNeighborMinMaxScatterKernel(const KeyType* c0, const KeyType* c1,
+                                              const KeyType* c2, const KeyType* c3,
+                                              const KeyType* c4, const KeyType* c5,
+                                              const KeyType* c6, const KeyType* c7,
+                                              const RealType* q,
+                                              RealType* qmin, RealType* qmax,
+                                              size_t startElem, size_t numElems)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numElems) return;
+    size_t e = startElem + k;
+    constexpr int NPE = ElemTraits<ElementTag>::NodesPerElem;
+    constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+    const KeyType* cc[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+
+    #pragma unroll
+    for (int ip = 0; ip < NSCS; ++ip)
+    {
+        int nodeL, nodeR; scsLR<ElementTag>(ip, nodeL, nodeR);
+        KeyType iL = n[nodeL];
+        KeyType iR = n[nodeR];
+        RealType qL = q[iL];
+        RealType qR = q[iR];
+        atomicMinDouble<RealType>(&qmin[iL], qR);
+        atomicMaxDouble<RealType>(&qmax[iL], qR);
+        atomicMinDouble<RealType>(&qmin[iR], qL);
+        atomicMaxDouble<RealType>(&qmax[iR], qL);
+    }
+}
+
+// Barth-Jespersen limiter phi per node. For each face incident to a node, the
+// reconstruction predicts a face delta Delta = grad_q[i] . (M - x_i). phi_face
+// caps the slope so q[i]+phi*Delta does not exceed the neighbor bounds:
+//   Delta > eps : phi = min(1, (qmax-q)/Delta)
+//   Delta < -eps: phi = min(1, (qmin-q)/Delta)
+//   else        : phi = 1
+// phi[i] is the MIN of phi_face over all faces incident to i. Seed phi=1
+// (bjSeedPhi) then atomicMin each face's phi into both endpoints.
+template<typename RealType>
+__global__ void bjSeedPhiKernel(RealType* phi, size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    phi[i] = RealType(1);
+}
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+__global__ void bjLimiterScatterKernel(const KeyType* c0, const KeyType* c1,
+                                       const KeyType* c2, const KeyType* c3,
+                                       const KeyType* c4, const KeyType* c5,
+                                       const KeyType* c6, const KeyType* c7,
+                                       const RealType* q,
+                                       const RealType* qmin, const RealType* qmax,
+                                       const RealType* gradQx,
+                                       const RealType* gradQy,
+                                       const RealType* gradQz,
+                                       const RealType* nodeX,
+                                       const RealType* nodeY,
+                                       const RealType* nodeZ,
+                                       RealType* phi,
+                                       size_t startElem, size_t numElems)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numElems) return;
+    size_t e = startElem + k;
+    constexpr int NPE = ElemTraits<ElementTag>::NodesPerElem;
+    constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+    const KeyType* cc[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+
+    const RealType eps = RealType(1e-12);
+
+    #pragma unroll
+    for (int ip = 0; ip < NSCS; ++ip)
+    {
+        int nodeL, nodeR; scsLR<ElementTag>(ip, nodeL, nodeR);
+        KeyType iL = n[nodeL];
+        KeyType iR = n[nodeR];
+
+        RealType mx = RealType(0.5) * (nodeX[iL] + nodeX[iR]);
+        RealType my = RealType(0.5) * (nodeY[iL] + nodeY[iR]);
+        RealType mz = RealType(0.5) * (nodeZ[iL] + nodeZ[iR]);
+
+        // phi_face seen from each endpoint of this edge.
+        #pragma unroll
+        for (int side = 0; side < 2; ++side)
+        {
+            KeyType i = (side == 0) ? iL : iR;
+            RealType rx = mx - nodeX[i];
+            RealType ry = my - nodeY[i];
+            RealType rz = mz - nodeZ[i];
+            RealType delta = gradQx[i] * rx + gradQy[i] * ry + gradQz[i] * rz;
+            RealType phi_face;
+            if (delta > eps)
+                phi_face = fmin(RealType(1), (qmax[i] - q[i]) / delta);
+            else if (delta < -eps)
+                phi_face = fmin(RealType(1), (qmin[i] - q[i]) / delta);
+            else
+                phi_face = RealType(1);
+            // Clamp to [0,1]: (qmax-q) is >=0 and (qmin-q) is <=0 by
+            // construction, so the ratio is >=0; the fmin caps at 1. Guard the
+            // floor anyway against roundoff that could make qmax<q by an ulp.
+            phi_face = fmax(RealType(0), phi_face);
+            atomicMinDouble<RealType>(&phi[i], phi_face);
+        }
+    }
+}
+
+// Path A: literal transpose of the divergence scatter, so that the Chorin
+// projection identity D u^{n+1} = D u** - (dt/rho) D D^T phi cancels exactly.
+//
+// The divergence kernel writes:
+//   divAcc[L] += +0.5 * A_f . (u[L] + u[R])
+//   divAcc[R] += -0.5 * A_f . (u[L] + u[R])
+// Block-transposing the per-face 2x2 contribution gives:
+//   gradAcc[L] += +0.5 * A_f * (p[L] - p[R])
+//   gradAcc[R] += +0.5 * A_f * (p[L] - p[R])   (same sign as L, NOT opposite)
+// That same-sign scatter of dp=0.5*(p[L]-p[R]) is what distinguishes this from
+// computeGradientPerNodeKernel, which uses (p[L]+p[R]) with opposite signs and
+// is the gradient one would get from independent integration by parts.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+__global__ void applyDivTransposePerNodeKernel(const KeyType* c0, const KeyType* c1,
+                                                const KeyType* c2, const KeyType* c3,
+                                                const KeyType* c4, const KeyType* c5,
+                                                const KeyType* c6, const KeyType* c7,
+                                                const RealType* p,
+                                                const RealType* areaVecX,
+                                                const RealType* areaVecY,
+                                                const RealType* areaVecZ,
+                                                RealType* gxAccNode,
+                                                RealType* gyAccNode,
+                                                RealType* gzAccNode,
+                                                size_t startElem,
+                                                size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numLocal) return;
+    size_t e = startElem + k;
+    constexpr int NPE = ElemTraits<ElementTag>::NodesPerElem;
+    constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+    const KeyType* cc[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+
+    #pragma unroll
+    for (int ip = 0; ip < NSCS; ++ip)
+    {
+        int nodeL, nodeR; scsLR<ElementTag>(ip, nodeL, nodeR);
+        KeyType iL = n[nodeL];
+        KeyType iR = n[nodeR];
+        RealType dp = RealType(0.5) * (p[iL] - p[iR]);
+
+        size_t off = e * NSCS + ip;
+        RealType cx = dp * areaVecX[off];
+        RealType cy = dp * areaVecY[off];
+        RealType cz = dp * areaVecZ[off];
+
+        atomicAdd(&gxAccNode[iL], cx);
+        atomicAdd(&gyAccNode[iL], cy);
+        atomicAdd(&gzAccNode[iL], cz);
+        atomicAdd(&gxAccNode[iR], cx);
+        atomicAdd(&gyAccNode[iR], cy);
+        atomicAdd(&gzAccNode[iR], cz);
+    }
+}
+
+// NOTE: this kernel is currently UNUSED. Per-element assembly of A = D M^-1 D^T
+// is fundamentally insufficient because the per-node M^-1 step in
+// applyDDTPerNode couples ANY pair of SCS faces (f, g) that share an
+// intermediate node i -- regardless of which element they belong to. A
+// per-element kernel only sees its OWN 12 faces, so the cross-element
+// face-pair contributions to A[r, c] (where r is in element e, c in element
+// e', and the pair shares an intermediate node) are silently dropped.
+// Validated on 1 rank: assembled-CG converges to a different solution than
+// matrix-free CG (which is bit-for-bit correct against the reference).
+//
+// Correct assembly would require a node-driven kernel that gathers the
+// node-to-element-to-face adjacency, then enumerates (g, f) pairs per
+// node across all touching elements. Left for later (see TGV_HANDOFF.md);
+// production path is matrix-free CG.
+//
+// The pair-double-sum derivation is kept below for reference. With
+// sigma_h(n) = +1 if n==L_h, -1 if n==R_h:
+//   A[r,c] = 0.25 * sum_{face pair (g,f)} sigma_g(r) sigma_f(c) (A_g . A_f) *
+//            sum_{i in {L_g,R_g} INTERSECT {L_f,R_f}} (1/V[i])
+//
+// Per-element implementation: enumerate the 8 nodes; for each node i with
+// the 3 SCS faces incident on it, enumerate ordered pairs (g, f) of incident
+// faces. The pair contributes to A[r, c] for the 2x2 grid (r in {L_g, R_g},
+// c in {L_f, R_f}) scaled by 1/V[i]. ONLY captures within-element pairs --
+// cross-element pairs sharing an intermediate i across element boundaries
+// are NOT captured.
+template<typename KeyType, typename RealType>
+__global__ void assembleDDTPerElementKernel(const KeyType* c0, const KeyType* c1,
+                                            const KeyType* c2, const KeyType* c3,
+                                            const KeyType* c4, const KeyType* c5,
+                                            const KeyType* c6, const KeyType* c7,
+                                            const RealType* areaVecX,
+                                            const RealType* areaVecY,
+                                            const RealType* areaVecZ,
+                                            const int* nodeToDof,
+                                            const uint8_t* ownership,
+                                            const RealType* lumpedMassNode, // per NODE (incl ghosts)
+                                            const int* rowPtr,
+                                            const int* colInd,
+                                            int numOwnedDofs,
+                                            RealType* values,
+                                            size_t startElem,
+                                            size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numLocal) return;
+    size_t e = startElem + k;
+    KeyType n[8] = {c0[e], c1[e], c2[e], c3[e], c4[e], c5[e], c6[e], c7[e]};
+
+    // Per-node incidence: each hex corner touches 3 SCS faces (see d_hexLRSCV).
+    // Indices into the 12-face local table. Listed in (face_idx, sign) pairs
+    // where sign is sigma_face(node) = +1 if node is L, -1 if node is R.
+    // Reading off d_hexLRSCV:
+    //   0:(0,1), 1:(1,2), 2:(2,3), 3:(0,3),
+    //   4:(4,5), 5:(5,6), 6:(6,7), 7:(4,7),
+    //   8:(0,4), 9:(1,5), 10:(2,6), 11:(3,7)
+    constexpr int nodeFaces[8][3] = { {0,3,8},  {0,1,9},  {1,2,10}, {2,3,11},
+                                       {4,7,8},  {4,5,9},  {5,6,10}, {6,7,11} };
+
+    // Cache the 12 area vectors locally so the inner double-loop reuses them.
+    RealType Ax[12], Ay[12], Az[12];
+    #pragma unroll
+    for (int ip = 0; ip < 12; ++ip)
+    {
+        size_t off = e * 12 + ip;
+        Ax[ip] = areaVecX[off];
+        Ay[ip] = areaVecY[off];
+        Az[ip] = areaVecZ[off];
+    }
+
+    // Iterate intermediate node i in {0..7}; the 1/V[i] factor multiplies the
+    // pair contribution. V is read from per-NODE lumped mass (halo-correct).
+    #pragma unroll
+    for (int iLocal = 0; iLocal < 8; ++iLocal)
+    {
+        KeyType iGlob = n[iLocal];
+        RealType vi = lumpedMassNode[iGlob];
+        if (!(vi > RealType(0))) continue;
+        RealType invVi = RealType(1) / vi;
+
+        // For each ordered pair (g, f) of faces both incident to node i:
+        //   - g contributes to rows r in {L_g, R_g}
+        //   - f contributes to cols c in {L_f, R_f}
+        // 3*3 = 9 face pairs per intermediate node, 8 nodes -> 72 pairs total
+        // per element. Each pair writes a 2x2 block (4 atomic adds), giving
+        // 288 atomic adds per element, vs the previous 96 (12 faces * 8).
+        #pragma unroll
+        for (int gi = 0; gi < 3; ++gi)
+        {
+            int gFace = nodeFaces[iLocal][gi];
+            int gL = d_hexLRSCV[gFace * 2];
+            int gR = d_hexLRSCV[gFace * 2 + 1];
+            RealType agx = Ax[gFace], agy = Ay[gFace], agz = Az[gFace];
+
+            #pragma unroll
+            for (int fi = 0; fi < 3; ++fi)
+            {
+                int fFace = nodeFaces[iLocal][fi];
+                int fL = d_hexLRSCV[fFace * 2];
+                int fR = d_hexLRSCV[fFace * 2 + 1];
+                RealType afx = Ax[fFace], afy = Ay[fFace], afz = Az[fFace];
+
+                RealType dot   = agx*afx + agy*afy + agz*afz;
+                RealType scale = RealType(0.25) * dot * invVi;
+
+                // 2x2 block: rows = {L_g, R_g}, cols = {L_f, R_f}.
+                // sigma_g(L_g) = +1, sigma_g(R_g) = -1.
+                int   rIdx[2] = {gL, gR};
+                int   cIdx[2] = {fL, fR};
+                RealType sigR[2] = {RealType(+1), RealType(-1)};
+                RealType sigC[2] = {RealType(+1), RealType(-1)};
+
+                #pragma unroll
+                for (int rr = 0; rr < 2; ++rr)
+                {
+                    KeyType nodeR = n[rIdx[rr]];
+                    if (ownership[nodeR] != 1) continue;
+                    int dofR = nodeToDof[nodeR];
+                    if (dofR < 0 || dofR >= numOwnedDofs) continue;
+                    int rs = rowPtr[dofR];
+                    int re = rowPtr[dofR + 1];
+
+                    #pragma unroll
+                    for (int cc = 0; cc < 2; ++cc)
+                    {
+                        KeyType nodeC = n[cIdx[cc]];
+                        int dofC = nodeToDof[nodeC];
+                        if (dofC < 0) continue;
+                        RealType v = sigR[rr] * sigC[cc] * scale;
+                        fem::atomicAddSparseEntry(values, colInd, rs, re, dofC, v);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Node-driven assembly of A = D M^-1 D^T into a CSR matrix sharing K's
+// 27-NNZ full-element sparsity. Replicates matrix-free applyDDTPerNode
+// EXACTLY, including cross-element face-pair contributions through the
+// per-node M^-1 step.
+//
+// One CUDA thread per OWNED node i. For each i, we gather ALL SCS faces
+// incident to i across every element that touches i (via the node->element
+// CSR adjacency map d_nodeToElementOffsets/d_nodeToElementList). For each
+// touching element e, we find which local corner of e is node i (search
+// the 8 connectivity entries), then look up the 3 incident SCS faces of
+// e at that corner and append each as a face record (other_node, area,
+// sigma) to a per-thread list.
+//
+// Then we double-loop over the ordered (g, f) pairs of incident faces and
+// contribute
+//   delta_A[i, c] = 0.25 * sigma_g(i) * sigma_f(c) * (A_g . A_f) / V[i]
+// for c in {i, other_f}. Row "other_g" is NOT written here -- it is owned
+// by another node thread, which will fill that row from its own
+// perspective. Each owned row is therefore written by exactly one thread.
+//
+// This is exactly the analytical expansion of the matrix-free chain
+// D^T (scatter), M^-1 (per-node divide), D (scatter) applied to a unit
+// vector e_c -- so the assembled matrix is bit-identical to the operator.
+//
+// Hex8 specific: max 8 elements per corner node * 3 SCS faces per element
+// per corner = 24 faces in the worst case. We store them in a fixed-size
+// register array (MAX_FACES = 32 for safety; nodes with more incidents --
+// e.g., from non-conformal AMR -- would need a fallback, but plain hex
+// meshes never exceed 24).
+template<typename KeyType, typename RealType>
+__global__ void assembleDDTPerNodeKernel(const KeyType* c0, const KeyType* c1,
+                                         const KeyType* c2, const KeyType* c3,
+                                         const KeyType* c4, const KeyType* c5,
+                                         const KeyType* c6, const KeyType* c7,
+                                         const RealType* areaVecX,
+                                         const RealType* areaVecY,
+                                         const RealType* areaVecZ,
+                                         const KeyType* nodeToElemOffsets,
+                                         const KeyType* nodeToElemList,
+                                         const int* nodeToDof,
+                                         const uint8_t* ownership,
+                                         const RealType* lumpedMassNode,
+                                         const int* rowPtr,
+                                         const int* colInd,
+                                         int numOwnedDofs,
+                                         RealType* values,
+                                         size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dofI = nodeToDof[i];
+    if (dofI < 0 || dofI >= numOwnedDofs) return;
+
+    RealType vi = lumpedMassNode[i];
+    if (!(vi > RealType(0))) return;
+    RealType invVi = RealType(1) / vi;
+
+    // Per-node incidence: which 3 of the 12 local SCS faces touch each
+    // local corner.
+    constexpr int nodeFaces[8][3] = { {0,3,8},  {0,1,9},  {1,2,10}, {2,3,11},
+                                       {4,7,8},  {4,5,9},  {5,6,10}, {6,7,11} };
+
+    constexpr int MAX_FACES = 32;
+    int      incCount = 0;
+    KeyType  incOtherNode[MAX_FACES];
+    int      incOtherDof[MAX_FACES];
+    RealType incAx[MAX_FACES], incAy[MAX_FACES], incAz[MAX_FACES];
+    int8_t   incSigma[MAX_FACES];
+
+    KeyType eStart = nodeToElemOffsets[i];
+    KeyType eEnd   = nodeToElemOffsets[i + 1];
+    for (KeyType ep = eStart; ep < eEnd; ++ep)
+    {
+        KeyType e = nodeToElemList[ep];
+        KeyType en[8] = {c0[e], c1[e], c2[e], c3[e], c4[e], c5[e], c6[e], c7[e]};
+        int iLocal = -1;
+        #pragma unroll
+        for (int k = 0; k < 8; ++k) if (en[k] == (KeyType)i) iLocal = k;
+        if (iLocal < 0) continue;
+
+        #pragma unroll
+        for (int gi = 0; gi < 3; ++gi)
+        {
+            if (incCount >= MAX_FACES) break;
+            int gFace = nodeFaces[iLocal][gi];
+            int gL_local = d_hexLRSCV[gFace * 2];
+            int gR_local = d_hexLRSCV[gFace * 2 + 1];
+            int sigma = (iLocal == gL_local) ? +1 : -1;
+            int otherLocal = (iLocal == gL_local) ? gR_local : gL_local;
+            KeyType otherNode = en[otherLocal];
+            size_t off = e * 12 + gFace;
+
+            incOtherNode[incCount] = otherNode;
+            incOtherDof[incCount]  = nodeToDof[otherNode];
+            incAx[incCount]        = areaVecX[off];
+            incAy[incCount]        = areaVecY[off];
+            incAz[incCount]        = areaVecZ[off];
+            incSigma[incCount]     = int8_t(sigma);
+            incCount++;
+        }
+    }
+
+    // Row r=i is owned by THIS thread; write that row directly.
+    int rs_i = rowPtr[dofI];
+    int re_i = rowPtr[dofI + 1];
+
+    // Double-loop over face pairs (g, f) at intermediate node i.
+    // The 2x2 contribution to A is at rows r in {i, other_g}, cols c in
+    // {i, other_f} with signs sigma_g(r) * sigma_f(c).
+    //   sigma_g(i)        = sg_i        sigma_g(other_g) = -sg_i
+    //   sigma_f(i)        = sf_i        sigma_f(other_f) = -sf_i
+    // We must write all four cells because no other node's thread will
+    // ever visit this pair at intermediate i (other_g's thread iterates
+    // pairs at intermediate other_g, not at i). Writes to "other" rows
+    // gate on ownership[other_g] == 1.
+    for (int g = 0; g < incCount; ++g)
+    {
+        RealType agx = incAx[g], agy = incAy[g], agz = incAz[g];
+        int sg_i = incSigma[g];
+        KeyType otherG_node = incOtherNode[g];
+        // Look up row info for other_g if owned.
+        int otherG_dof = -1;
+        int rs_og = 0, re_og = 0;
+        if (ownership[otherG_node] == 1)
+        {
+            otherG_dof = nodeToDof[otherG_node];
+            if (otherG_dof >= 0 && otherG_dof < numOwnedDofs)
+            {
+                rs_og = rowPtr[otherG_dof];
+                re_og = rowPtr[otherG_dof + 1];
+            }
+            else otherG_dof = -1;
+        }
+
+        for (int f = 0; f < incCount; ++f)
+        {
+            RealType dot   = agx * incAx[f] + agy * incAy[f] + agz * incAz[f];
+            RealType scale = RealType(0.25) * dot * invVi;
+            int sf_i = incSigma[f];
+            int otherF_dof = incOtherDof[f];
+            RealType base = RealType(sg_i) * RealType(sf_i) * scale;
+            // (r=i,         c=i):         + base
+            // (r=i,         c=other_f):   - base   (sigma_f(other_f)=-sf_i)
+            // (r=other_g,   c=i):         - base   (sigma_g(other_g)=-sg_i)
+            // (r=other_g,   c=other_f):   + base
+            fem::atomicAddSparseEntry(values, colInd, rs_i, re_i, dofI,  base);
+            if (otherF_dof >= 0)
+                fem::atomicAddSparseEntry(values, colInd, rs_i, re_i, otherF_dof, -base);
+            if (otherG_dof >= 0)
+            {
+                fem::atomicAddSparseEntry(values, colInd, rs_og, re_og, dofI, -base);
+                if (otherF_dof >= 0)
+                    fem::atomicAddSparseEntry(values, colInd, rs_og, re_og, otherF_dof, base);
+            }
+        }
+    }
+}
+
+// Divide accumulator by V; write to per-node output (kept node-indexed for the
+// predictor/corrector apply, which iterates over nodes).
+template<typename RealType>
+__global__ void normalizeGradientPerNodeKernel(const RealType* gxAccNode,
+                                               const RealType* gyAccNode,
+                                               const RealType* gzAccNode,
+                                               const RealType* lumpedMassNode,  // per-NODE, sized nodeCount (halo-synced)
+                                               const int* /*nodeToDof*/,        // kept for ABI; unused
+                                               const uint8_t* ownership,
+                                               RealType* gx,
+                                               RealType* gy,
+                                               RealType* gz,
+                                               size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) { gx[i] = gy[i] = gz[i] = RealType(0); return; }
+    // Index per-NODE mass directly: works for cross-rank periodic slaves
+    // whose nodeToDof was redirected to a ghost DOF (out of d_mass bounds).
+    RealType m = lumpedMassNode[i];
+    if (m == RealType(0)) { gx[i] = gy[i] = gz[i] = RealType(0); return; }
+    RealType invV = RealType(1) / m;
+    gx[i] = gxAccNode[i] * invV;
+    gy[i] = gyAccNode[i] * invV;
+    gz[i] = gzAccNode[i] * invV;
+}
+
+// =============================================================================
+// Divergence scatter (B.3 pattern): integrates SCS-face fluxes
+// v_f . A_f into the L slot, -v_f . A_f into the R slot. Used in step 3 to
+// build the pressure-Poisson RHS: b = (rho/dt) * div(u**) * V * sign? Below
+// we keep the scatter in the un-normalized accumulator form because the RHS
+// for the Poisson system is the integrated source f*V_i (lumped), which is
+// exactly what the un-normalized accumulator already is when multiplied by
+// the constant (rho/dt). Skipping the normalize-then-multiply-by-V cancels out.
+// =============================================================================
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+__global__ void computeDivergencePerNodeKernel(const KeyType* c0, const KeyType* c1,
+                                               const KeyType* c2, const KeyType* c3,
+                                               const KeyType* c4, const KeyType* c5,
+                                               const KeyType* c6, const KeyType* c7,
+                                               const RealType* vx,
+                                               const RealType* vy,
+                                               const RealType* vz,
+                                               const RealType* areaVecX,
+                                               const RealType* areaVecY,
+                                               const RealType* areaVecZ,
+                                               RealType* divAccNode,
+                                               size_t startElem,
+                                               size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numLocal) return;
+    size_t e = startElem + k;
+    constexpr int NPE = ElemTraits<ElementTag>::NodesPerElem;
+    constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+    const KeyType* cc[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+
+    #pragma unroll
+    for (int ip = 0; ip < NSCS; ++ip)
+    {
+        int nodeL, nodeR; scsLR<ElementTag>(ip, nodeL, nodeR);
+        KeyType iL = n[nodeL];
+        KeyType iR = n[nodeR];
+
+        RealType vfx = RealType(0.5) * (vx[iL] + vx[iR]);
+        RealType vfy = RealType(0.5) * (vy[iL] + vy[iR]);
+        RealType vfz = RealType(0.5) * (vz[iL] + vz[iR]);
+
+        size_t off = e * NSCS + ip;
+        RealType flow = vfx * areaVecX[off] + vfy * areaVecY[off] + vfz * areaVecZ[off];
+
+        atomicAdd(&divAccNode[iL], +flow);
+        atomicAdd(&divAccNode[iR], -flow);
+    }
+}
+
+// =============================================================================
+// Rhie-Chow corrected divergence kernel for periodic Q1-Q1 CVFEM. Same as
+// computeDivergencePerNodeKernel but adds the Rhie-Chow pressure-velocity
+// coupling correction at each SCS face:
+//
+//   mdot_RC = avg(u) . A - tau * (p_R - p_L) * |A|^2 / (A . dx)
+//                        + tau * avg(grad_p) . A
+//
+// The middle term is the "compact" face-gradient stencil; the third is the
+// "smooth" nodal-gradient average. Their difference IS the Rhie-Chow
+// stabilization that suppresses pressure-velocity decoupling on co-located
+// grids. The formula matches Nalu-Wind's MdotEdgeAlg and OpenFOAM's PISO
+// pEqn.flux() construction.
+//
+// tau ~ dt/rho for explicit Chorin; for more accurate variants, use the
+// inverse momentum-matrix diagonal 1/A_diag (the SIMPLE/PISO weight).
+// =============================================================================
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+__global__ void computeDivergenceRhieChowKernel(const KeyType* c0, const KeyType* c1,
+                                                const KeyType* c2, const KeyType* c3,
+                                                const KeyType* c4, const KeyType* c5,
+                                                const KeyType* c6, const KeyType* c7,
+                                                const RealType* vx,
+                                                const RealType* vy,
+                                                const RealType* vz,
+                                                const RealType* p,
+                                                const RealType* gradPx,
+                                                const RealType* gradPy,
+                                                const RealType* gradPz,
+                                                const RealType* nodeX,
+                                                const RealType* nodeY,
+                                                const RealType* nodeZ,
+                                                const RealType* areaVecX,
+                                                const RealType* areaVecY,
+                                                const RealType* areaVecZ,
+                                                RealType tauRC,
+                                                RealType* divAccNode,
+                                                size_t startElem,
+                                                size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numLocal) return;
+    size_t e = startElem + k;
+    constexpr int NPE = ElemTraits<ElementTag>::NodesPerElem;
+    constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+    const KeyType* cc[8] = {c0, c1, c2, c3, c4, c5, c6, c7};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+
+    #pragma unroll
+    for (int ip = 0; ip < NSCS; ++ip)
+    {
+        int nodeL, nodeR; scsLR<ElementTag>(ip, nodeL, nodeR);
+        KeyType iL = n[nodeL];
+        KeyType iR = n[nodeR];
+
+        // Standard average face velocity.
+        RealType vfx = RealType(0.5) * (vx[iL] + vx[iR]);
+        RealType vfy = RealType(0.5) * (vy[iL] + vy[iR]);
+        RealType vfz = RealType(0.5) * (vz[iL] + vz[iR]);
+
+        size_t off = e * NSCS + ip;
+        RealType Ax = areaVecX[off];
+        RealType Ay = areaVecY[off];
+        RealType Az = areaVecZ[off];
+
+        RealType flow = vfx * Ax + vfy * Ay + vfz * Az;
+
+        // Node-pair geometry: dx = position(R) - position(L)
+        RealType dx = nodeX[iR] - nodeX[iL];
+        RealType dy = nodeY[iR] - nodeY[iL];
+        RealType dz = nodeZ[iR] - nodeZ[iL];
+
+        RealType asq  = Ax * Ax + Ay * Ay + Az * Az;
+        RealType axdx = Ax * dx + Ay * dy + Az * dz;
+
+        // CHORIN Rhie-Chow: compact-pressure-gradient term ONLY.
+        //
+        // In a Chorin projection, the predictor `u** = u^n + dt*adv - dt*grad(p^n)/rho`
+        // has already subtracted the smooth nodal grad(p^n) from velocity, so
+        // div(u**) already implicitly includes the smooth-gradient pressure
+        // contribution. The Nalu/OpenFOAM RC formula `-compact + smooth` is
+        // appropriate for SIMPLE/PISO loops where the predicted velocity
+        // u* = HbyA does NOT yet contain grad p. Applying that form to a
+        // post-predictor u** double-counts the smooth contribution and
+        // produces catastrophic divergence (verified empirically).
+        //
+        // The Code_Saturne `arak`-only form and the OpenFOAM `phi = phiHbyA
+        // - pEqn.flux()` pattern both use the compact term alone:
+        //
+        //   mdot_RC = avg(u**)*A - tau * (p_R - p_L) * |A|^2 / (A.dx)
+        //
+        // This subtracts only the compact-vs-smooth DISCREPANCY (which is
+        // exactly the checkerboard-mode amplitude when p oscillates by sign
+        // at adjacent nodes), leaving smooth pressure fields unaffected.
+        if (fabs(axdx) > RealType(1e-30))
+        {
+            RealType compact = tauRC * (p[iR] - p[iL]) * asq / axdx;
+            flow += -compact;
+        }
+        (void)gradPx; (void)gradPy; (void)gradPz;  // preserved for future variants
+
+        atomicAdd(&divAccNode[iL], +flow);
+        atomicAdd(&divAccNode[iR], -flow);
+    }
+}
+
+// Normalized divergence (V_i^{-1} * sum), per node. Used for the div_max
+// diagnostic only -- the Poisson RHS uses the un-normalized accumulator.
+template<typename RealType>
+__global__ void normalizeDivergencePerNodeKernel(const RealType* divAccNode,
+                                                 const RealType* lumpedMassNode,  // per-NODE, sized nodeCount
+                                                 const int* /*nodeToDof*/,
+                                                 const uint8_t* ownership,
+                                                 RealType* divU,
+                                                 size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) { divU[i] = RealType(0); return; }
+    RealType m = lumpedMassNode[i];
+    if (m == RealType(0)) { divU[i] = RealType(0); return; }
+    divU[i] = divAccNode[i] / m;
+}
+
+// =============================================================================
+// Predictor / corrector apply kernels.
+// =============================================================================
+
+// Predictor: q* = q^n + dt * dqdtNode / V - dt * (1/rho) * gradPnq on interior;
+// on boundary, snap to qTarget (so the implicit RHS lifts it without drift).
+// dqdtNode contains the per-node UN-normalized flux sum from the advection
+// scatter; we divide by V here (no separate normalize step). gradPnq is the
+// per-node gradient component (already V-normalized by the gradient kernel).
+template<typename RealType>
+__global__ void applyPredictorPerNodeKernel(RealType* qStar,
+                                            const RealType* qN,
+                                            const RealType* dqdtNode,
+                                            const RealType* gradPnq,
+                                            const RealType* lumpedMass,
+                                            const RealType* /*lumpedMassNode*/,  // unused; kept for ABI
+                                            const RealType* qTarget,
+                                            const uint8_t* isBdryDof,
+                                            const int* nodeToDof,
+                                            const uint8_t* ownership,
+                                            RealType dt,
+                                            RealType invRho,
+                                            RealType bodyForce,
+                                            size_t numNodes,
+                                            int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+
+    if (isBdryDof[dof])
+    {
+        qStar[i] = qTarget[i];
+        return;
+    }
+    RealType V = lumpedMass[dof];
+    // BDF1: u* = u^n + dt*(-adv/V - invRho*grad p + invRho*f) (interior only)
+    qStar[i] = qN[i] + dt * dqdtNode[i] / V
+                    - dt * invRho * gradPnq[i]
+                    + dt * invRho * bodyForce;
+}
+
+// BDF2 + EXT2 predictor: 3-point backward time derivative + Adams-Bashforth-
+// style extrapolation 2 N(u^n) - N(u^(n-1)) for advection.
+//   u* = (4/3) u^n - (1/3) u^(n-1)
+//        + (2 dt / 3) * [ (2 N_n - N_nm1)/V - invRho * grad p^n ]
+// Implements the Karniadakis-Israeli-Orszag stencil also used by deal.II
+// step-35, MFEM-Navier, and NekRS.
+template<typename RealType>
+__global__ void applyPredictorBdf2PerNodeKernel(RealType* qStar,
+                                                const RealType* qN,
+                                                const RealType* qNm1,
+                                                const RealType* dqdtNode_n,
+                                                const RealType* dqdtNode_nm1,
+                                                const RealType* gradPnq,
+                                                const RealType* lumpedMass,
+                                                const RealType* qTarget,
+                                                const uint8_t* isBdryDof,
+                                                const int* nodeToDof,
+                                                const uint8_t* ownership,
+                                                RealType dt,
+                                                RealType invRho,
+                                                RealType bodyForce,
+                                                size_t numNodes,
+                                                int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    if (isBdryDof[dof])
+    {
+        qStar[i] = qTarget[i];
+        return;
+    }
+    RealType V       = lumpedMass[dof];
+    RealType adv_ext = RealType(2) * dqdtNode_n[i] - dqdtNode_nm1[i];
+    RealType coef    = RealType(2) * dt / RealType(3);
+    // BDF2 + EXT2 with body-force source: KIO stencil + coef*invRho*f.
+    qStar[i] = (RealType(4) / RealType(3)) * qN[i]
+             - (RealType(1) / RealType(3)) * qNm1[i]
+             + coef * (adv_ext / V - invRho * gradPnq[i] + invRho * bodyForce);
+}
+
+// Corrector: q^{n+1} = q** - (dt/rho) (grad phi)_q on interior; snap to
+// qTarget on boundary (Dirichlet velocity unchanged by the corrector since
+// grad(phi).n = 0 is enforced on impermeable walls -- here we just lock it).
+template<typename RealType>
+__global__ void applyCorrectorPerNodeKernel(RealType* q,
+                                            const RealType* qStarStar,
+                                            const RealType* gradPhiq,
+                                            const RealType* qTarget,
+                                            const uint8_t* isBdryDof,
+                                            const int* nodeToDof,
+                                            const uint8_t* ownership,
+                                            RealType dt,
+                                            RealType invRho,
+                                            size_t numNodes,
+                                            int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0) return;
+
+    // Cross-rank periodic slave under owner-migration: nodeToDof[slave] points
+    // to master's GHOST dof (>= numOwnedDofs). The slave node IS owned but the
+    // dof is on another rank. Without this branch, q[slave] never receives the
+    // corrector update -> s.d_u[slave] stays at u^n, projection identity leaks
+    // at every cross-rank periodic seam node, and PROJ-P3 stays ~0.5 on
+    // multi-rank (single-rank has no cross-rank slaves so this branch is dead).
+    // BDF flag lookup needs dof < numOwnedDofs; cross-rank slaves are never
+    // Dirichlet under owner-migration (master DOF carries the BDF flag), so
+    // skip BDF check. gradPhiq[i] here is the broadcast master gradient (the
+    // else-branch corrector broadcasts gradPhi master->slave before this
+    // kernel runs), so the subtraction is the correct one.
+    if (dof >= numOwnedDofs)
+    {
+        q[i] = qStarStar[i] - dt * invRho * gradPhiq[i];
+        return;
+    }
+
+    if (isBdryDof[dof])
+    {
+        q[i] = qTarget[i];
+        return;
+    }
+    q[i] = qStarStar[i] - dt * invRho * gradPhiq[i];
+}
+
+// Pressure update: p^{n+1} = p^n + phi on owned nodes (Chorin incremental).
+// Ghosts are refreshed by an explicit halo exchange afterward.
+template<typename RealType>
+__global__ void updatePressureKernel(RealType* p,
+                                     const RealType* phi,
+                                     const int* nodeToDof,
+                                     const uint8_t* ownership,
+                                     size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0) return;
+    p[i] += phi[i];
+}
+
+// =============================================================================
+// RHS builders for the implicit solves.
+// =============================================================================
+
+// Velocity implicit RHS: b[dof] = (M[dof]/dt) * qStar[node(dof)] on owned
+// nodes. Same shape as mars_amr_advdiff's buildRhsFromTimeNKernel; called
+// three times (one per component) with the appropriate qStar.
+template<typename RealType>
+__global__ void buildVelocityImplicitRhsKernel(const RealType* qStar,
+                                               const int* nodeToDof,
+                                               const uint8_t* ownership,
+                                               const RealType* mass,
+                                               RealType invDt,
+                                               RealType* rhs,
+                                               size_t numNodes,
+                                               int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    // dof can be >= numOwnedDofs when periodic DOF collapse redirected a
+    // cross-rank slave onto the master's ghost DOF on this rank. The master
+    // rank assembles the matching b[master_owned] from its periodic-image
+    // halo elements, so skipping here is correct (no contribution lost).
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    rhs[dof] = mass[dof] * invDt * qStar[i];
+}
+
+// Pressure RHS from the un-normalized divergence accumulator: the per-node
+// scatter sum IS the integrated flux (no extra /V).
+//
+// Sign convention: CvfemHexAssembler::assembleFull's K is the discrete operator
+// for -Laplacian (see mars_amr_poisson / mars_cvfem_poisson: "Solve -Δu = f").
+// The continuous projection equation is +Lap(phi) = (rho/dt) div(u**), so the
+// discrete system is K phi = -(rho/dt) * div(u**)_lumped. divAccNode[i] is the
+// lumped integral V_i * div(u**)_i, so rhs[dof] = -coef * divAccNode[i].
+template<typename RealType>
+__global__ void buildPressureRhsKernel(const RealType* divAccNode,
+                                       const int* nodeToDof,
+                                       const uint8_t* ownership,
+                                       RealType coef,        // = rho / dt
+                                       RealType* rhs,
+                                       size_t numNodes,
+                                       int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    rhs[dof] = -coef * divAccNode[i];
+}
+
+// DOF-indexed solver output -> per-node array. Reused for all velocity solves
+// and the pressure solve.
+template<typename RealType>
+// dofBound (optional): if >0, only scatter from sol[dof] when dof < dofBound.
+// The reduced-DOF pressure path passes sol sized numOwnedDofs but loops over ALL
+// nodes incl. ghosts, whose nodeToDof >= numOwnedDofs -> sol[dof] would be an
+// out-of-bounds read (Warp Illegal Address). Bounding to numOwnedDofs leaves
+// ghost node slots untouched; the caller's exchangeNodeHalo fills them from the
+// owners. dofBound==0 (default) = old behavior (velocity path passes a
+// numTotalDofs-sized sol, so ghost dofs ARE valid and intended).
+__global__ void scatterDofToNodeKernel(const RealType* sol,
+                                       const int* nodeToDof,
+                                       RealType* nodeOut,
+                                       size_t numNodes,
+                                       int dofBound = 0)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    int dof = nodeToDof[i];
+    if (dof >= 0 && (dofBound == 0 || dof < dofBound)) nodeOut[i] = sol[dof];
+}
+
+// =============================================================================
+// Solver kind + Stepper state. All persistent state lives here -- the per-step
+// function reads / writes the device vectors in this struct and never allocates
+// in the hot path (modulo per-call temporaries for the implicit solves).
+// =============================================================================
+
+enum class SolverKind { CG, Hypre };
+
+// Krylov method hint for solveOneComponent. PCG is the default for velocity
+// (Avel) and K-path pressure (Apre). GMRES is required for the DDT pressure
+// operator (D M^-1 D^T), which is SPSD with a constant null space and is
+// rejected by Hypre PCG (error 1). Only consulted when s.solverKind == Hypre;
+// the in-house CG path ignores it.
+//
+// Env MARS_HYPRE_KRYLOV=pcg|gmres (DEBUG ONLY) overrides the caller's hint.
+enum class KrylovHint { PCG, GMRES };
+
+// Phase E: matrix-free pressure-Poisson choice.
+//   K   -> existing CVFEM stiffness matrix K phi = -(rho/dt) D u**  (Galerkin
+//          Laplacian; not discretely D D^T, so D u^{n+1} only decays slowly).
+//   DDT -> matrix-free (D M^{-1} D^T) phi = (rho/dt) D u** ; gives exact
+//          projection D u^{n+1} = 0 by construction because the corrector's
+//          (1/rho) D^T phi cancels D u** algebraically through that operator.
+// PressureSolveKind:
+//   K   = (default, stable) solve K*phi = rhs with assembled stiffness from
+//         assembleFull. Produces a stable, well-behaved cavity solve but
+//         div_max decays slowly toward zero because K is the continuous
+//         Laplacian discretization, not the discrete D D^T conjugate of
+//         this code's divergence operator.
+//   DDT = Matrix-free Galerkin Laplacian A = D M^{-1} D^T. The corrector's
+//         grad operator uses M^{-1} D^T to make the projection algebraically
+//         exact: div(u^{n+1}) = roundoff every step. ~3-4x slower per CG iter
+//         vs K-path; iteration count similar on uniform meshes (~50-200 on
+//         cube16). Production preconditioning (multigrid or Hypre on assembled
+//         D D^T) is a separate work item.
+enum class PressureSolveKind { K, DDT };
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag> struct NSStepper;
+
+// Forward declaration so the setup-time MARS_DDT_PROBE_DIFF diagnostic can
+// call applyDDTPerNode (defined later in this file). applyPeriodic default
+// lives HERE (on the forward decl) -- repeating it on the definition below is a
+// C++ redefinition-of-default-argument error. applyPeriodic=false drops every
+// periodic leg, leaving a bare self-adjoint element op + cstone halo (the
+// reduced P^T A P matvec); default true keeps all existing callers identical.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void applyDDTPerNode(NSStepper<KeyType, RealType, ElementTag>& s,
+                     cstone::DeviceVector<RealType>& phi,
+                     cstone::DeviceVector<RealType>& outAcc,
+                     cstone::DeviceVector<RealType>& gxAcc,
+                     cstone::DeviceVector<RealType>& gyAcc,
+                     cstone::DeviceVector<RealType>& gzAcc,
+                     bool applyPeriodic = true,
+                     bool reducedPeriodicFold = false);
+
+template<typename KeyType, typename RealType, typename ElementTag>
+struct NSStepper
+{
+    using DomainT = ElementDomain<ElementTag, RealType, KeyType, cstone::GpuTag>;
+
+    DomainT& domain;
+    SolverKind solverKind;
+    int blockSize;
+    int maxIter;
+    RealType tolerance;
+    int rank;
+    int numRanks;
+    PressureSolveKind pressureSolve = PressureSolveKind::K;
+    // Path A (div^T gradient) was attempted but is unstable: the CVFEM stiffness
+    // matrix K assembled by assembleFull discretizes the continuous Laplacian,
+    // not D D^T from this scatter pattern. So phi solved against K is not the
+    // phi that D^T would cancel divergence with -> projection diverges.
+    // Default is the SCS gradient (legacy); the div^T path stays available
+    // under --experimental-divT for future Path B (Rhie-Chow) work.
+    bool useLegacyGradient = true;
+
+    size_t nodeCount    = 0;
+    size_t elementCount = 0;
+    int numOwnedDofs    = 0;
+    int numTotalDofs    = 0;
+    int nnz             = 0;
+
+    // DOF mapping + lumped mass + BC mask (per-OWNED-DOF for the mask).
+    cstone::DeviceVector<int>     d_node_to_dof;
+    cstone::DeviceVector<RealType> d_mass;       // per OWNED DOF
+    cstone::DeviceVector<RealType> d_massNode;   // per NODE (owned + ghosts halo-exchanged); read by DDT assembler
+    cstone::DeviceVector<uint8_t>  d_isBdryDof;
+    // Pressure BC: in cavity mode, use a single corner pin (pressurePinDof).
+    // In channel mode, use a Dirichlet mask (d_isPressureBdryDof) over the
+    // entire outflow face. Exactly one mechanism is active per run.
+    int pressurePinDof = -1;   // owned-DOF id on the owning rank; -1 elsewhere (or in channel mode)
+    int pressurePinRank = 0;   // global rank that owns the pin
+    cstone::DeviceVector<uint8_t> d_isPressureBdryDof;   // size numOwnedDofs; only used in channel mode
+    // Per-NODE pressure-Dirichlet mask (size nodeCount, halo-exchanged so
+    // ghost slots see the owner's flag). Includes the single corner pin
+    // (cavity) AND every outflow-face DOF (channel/pump). Used by symmetric
+    // column-zeroing on the assembled DDT CSR so non-owning ranks also zero
+    // out their ghost-copy columns; without this, the cavity pin was only
+    // enforced symmetrically on rank 0 and the channel mask only on each
+    // owner, leaving the global matrix asymmetric and AMG misbehaving.
+    cstone::DeviceVector<uint8_t> d_isPressureBdryNode;
+    // Per-NODE velocity-Dirichlet mask (size nodeCount, halo-exchanged so ghost
+    // slots see the owner's flag). Mirrors d_isPressureBdryNode but driven by
+    // the velocity BC predicate (d_isBdryDof). Used by symmetric column-zero
+    // on d_valuesVel for Channel/Pump -- without it the velocity matrix is
+    // row-cleared but not column-cleared, breaking SPD with many ~125k
+    // Dirichlet DOFs + 5-OOM diag spread on anisotropic BL cells flips pAp
+    // sign and breaks cstone CG (cg_iter_uvw=FAIL on any non-trivial RHS).
+    cstone::DeviceVector<uint8_t> d_isBdryNode;
+    // Inverse of nodeToDof: dofToNode[dof] = local-node-index. Size numTotalDofs
+    // (= nodeCount). Used by symmetric col-zero kernel to map a column local
+    // DOF back to its local node, so the per-NODE mask can be consulted.
+    cstone::DeviceVector<int> d_dofToNode;
+
+    // Per-node velocity targets for the cavity BC. Boundary nodes hold the
+    // prescribed value (u=1 on top, 0 elsewhere); interior nodes hold 0 (unused).
+    cstone::DeviceVector<RealType> d_uTarget, d_vTarget, d_wTarget;
+
+    // Geometry: SCS area vectors per (element, face). Same source used by the
+    // implicit assembler, the advection scatter, the gradient, the divergence.
+    cstone::DeviceVector<RealType> d_areaVec_x;
+    cstone::DeviceVector<RealType> d_areaVec_y;
+    cstone::DeviceVector<RealType> d_areaVec_z;
+
+    // Two CSR matrices: velocity (M/dt + nu K) with Dirichlet velocity BC;
+    // pressure (K) with pure Neumann + a single-DOF pin. Share rowPtr/colInd/
+    // diagPtr (full 27-NNZ Laplacian sparsity required by assembleFull);
+    // values are stored separately.
+    cstone::DeviceVector<int> d_rowPtr;
+    cstone::DeviceVector<int> d_colInd;
+    cstone::DeviceVector<int> d_diagPtr;
+    cstone::DeviceVector<RealType> d_valuesVel;
+    cstone::DeviceVector<RealType> d_valuesPre;
+    // Assembled D M^-1 D^T uses its OWN reduced (7-NNZ) sparsity that exactly
+    // matches the SCS-face graph the assembler writes to. Sharing K's 27-NNZ
+    // sparsity left ~20 explicit-zero entries per row that confused Hypre
+    // BoomerAMG's coarsening (the stored zeros made the graph denser than the
+    // operator). Separate CSR avoids that. Diagnosed via parallel research
+    // agents during Phase E Stage 4 debug.
+    cstone::DeviceVector<int> d_rowPtrDDT;
+    cstone::DeviceVector<int> d_colIndDDT;
+    cstone::DeviceVector<int> d_diagPtrDDT;
+    int nnzDDT = 0;
+    cstone::DeviceVector<RealType> d_valuesDDT;
+    // Cached diagonal of the BC-modified DDT operator (size numOwnedDofs),
+    // used as the Jacobi preconditioner by solvePressureDDT. Extracted once
+    // at setup after BC enforcement + optional shift.
+    cstone::DeviceVector<RealType> d_diagDDT;
+    // Floor for the clipped Jacobi preconditioner: z = r / max(diag, eps).
+    // Default is 1e-3 * max(diag), computed at the setup-time cache build.
+    // Env MARS_DDT_JACOBI_CLIP_FRAC overrides the 1e-3 fraction.
+    RealType diagDDTEpsClip = RealType(0);
+
+    // Owned-row SparseMatrix wrappers consumed by CG/Hypre.
+    using Matrix = SparseMatrix<int, RealType, cstone::GpuTag>;
+    Matrix Avel;
+    Matrix Apre;
+    Matrix AddT;
+
+    // Per-node solution fields. Sized nodeCount; ghost slots refreshed by
+    // exchangeNodeHalo after each update.
+    cstone::DeviceVector<RealType> d_u, d_v, d_w;            // velocity
+    cstone::DeviceVector<RealType> d_uStar, d_vStar, d_wStar;        // after predictor
+    cstone::DeviceVector<RealType> d_uStarStar, d_vStarStar, d_wStarStar;  // after diffusion
+    cstone::DeviceVector<RealType> d_p;                       // pressure (n)
+    cstone::DeviceVector<RealType> d_phi;                     // pressure correction
+    // Stash of normalized div(u**) per node, captured during the pressure
+    // solve, reused by the rotational pressure correction: p = p + phi - nu*div(u**).
+    // Sized lazily in runPressureSolveStep.
+    cstone::DeviceVector<RealType> d_divUStar;
+    bool rotationalPressureCorrection = false;
+    RealType nuCached = 0;  // remember nu so runCorrectorStep can apply -nu*div(u*)
+    // Advection form selector. The flux kernel branches on advScheme:
+    //   Skew   = Verstappen central skew-symmetric (discrete KE conservation;
+    //            needed for periodic NS where no wall dissipation exists).
+    //   Upwind = 1st-order upwind (stable at any Re; cavity/channel default).
+    //   BarthJespersen = 2nd-order upwind with a node gradient reconstruction
+    //            limited by Barth-Jespersen, matching the mesh developers'
+    //            legacy advection. Tet-only path built in this file.
+    enum class AdvScheme { Skew, Upwind, BarthJespersen };
+    AdvScheme advScheme = AdvScheme::Skew;
+    cstone::DeviceVector<RealType> d_gradPx, d_gradPy, d_gradPz;
+    cstone::DeviceVector<RealType> d_gradPhix, d_gradPhiy, d_gradPhiz;
+
+    // Barth-Jespersen state (allocated lazily in runPredictorStep only when
+    // advScheme==BarthJespersen; non-BJ runs never touch these). Per-component
+    // node velocity gradients grad(u), grad(v), grad(w), each (1/V_i) sum_f
+    // q_face*A_f, then halo-exchanged. Limiter phi and neighbor min/max are
+    // recomputed per component into the scratch buffers below.
+    cstone::DeviceVector<RealType> d_gradUx, d_gradUy, d_gradUz;
+    cstone::DeviceVector<RealType> d_gradVx, d_gradVy, d_gradVz;
+    cstone::DeviceVector<RealType> d_gradWx, d_gradWy, d_gradWz;
+    // Per-component scratch reused across the 3 momentum components: neighbor
+    // min/max over edge-connected nodes (seed = node's own value) and the
+    // Barth-Jespersen limiter phi in [0,1]. Sized nodeCount, halo-exchanged.
+    cstone::DeviceVector<RealType> d_bjQmin, d_bjQmax, d_bjPhi;
+
+    // BDF2 / EXT2 (Karniadakis-Israeli-Orszag 1991) history.
+    // ----------------------------------------------------------
+    // Standard Chorin is first-order in time + forward-Euler explicit on
+    // advection. For periodic NS this is unstable: every "fix" we tried
+    // (Bochev-Dohrmann, Rhie-Chow, broadcasts, skew-symmetric stencil)
+    // converges to the same ~step 100 blowup. The fundamental limit is
+    // the time integrator. BDF2/EXT2 is what NekRS, MFEM-Navier, and
+    // deal.II step-35 all use.
+    //
+    // Formula (per-component scalar, kinematic pressure):
+    //   predictor (step n+1, n>=1):
+    //     u* = (4/3) u^n  -  (1/3) u^(n-1)
+    //          - (2 dt / 3) * [ N_ext + grad(p^n)/rho ]
+    //     N_ext = 2 N(u^n) - N(u^(n-1))    // EXT2 extrapolation
+    //   diffusion:  (3 M / (2 dt) + nu K) u** = (3 M / (2 dt)) u*
+    //   pressure:   K phi = (3 rho / (2 dt)) div(u**)
+    //   corrector:  u^(n+1) = u** - (2 dt / (3 rho)) grad(phi)
+    //               p^(n+1) = p^n + phi    (incremental Chorin)
+    //
+    // Step 0 (bootstrap): no u^(n-1) yet -> fall back to BDF1 (the
+    // existing Chorin formulas). At step 1, switch to BDF2 with the
+    // u^0 stored as u^(n-1).
+    bool useBdf2 = true;
+    int  bdfStep = 0;     // 0 = use BDF1 (no history yet); >=1 = use BDF2
+    // Velocity history (u at step n-1). Sized lazily by setupNSStepper.
+    cstone::DeviceVector<RealType> d_u_nm1, d_v_nm1, d_w_nm1;
+    // Advection accumulator history: N(u^n) and N(u^(n-1)) per node.
+    // Promoted from step-local scratch to persistent so EXT2 can reuse.
+    // Sized lazily by setupNSStepper.
+    cstone::DeviceVector<RealType> d_advU_n,   d_advV_n,   d_advW_n;
+    cstone::DeviceVector<RealType> d_advU_nm1, d_advV_nm1, d_advW_nm1;
+    // Second velocity matrix for BDF2 (coefficient 3M/(2dt) + nu K).
+    // Built once at setup alongside the BDF1 matrix; used from step 1 on.
+    cstone::DeviceVector<RealType> d_valuesVel_bdf2;
+    Matrix Avel_bdf2;
+
+    // Per-step diagnostics
+    int lastPressureIters = 0;
+    RealType lastPressR0    = 0;  // initial absolute residual |r0| of the pressure CG this step
+    RealType lastPressResid = 0;  // final relative residual |r|/|r0| at the pressure CG's exit
+    int lastUIters = 0, lastVIters = 0, lastWIters = 0;
+    RealType lastDivMax     = 0;  // |div(u^{n+1})| max -- post-corrector, PLAIN nodal operator
+    RealType lastDivRms     = 0;  // |div(u^{n+1})| RMS over interior owned DOFs; less ring-sensitive
+    RealType lastDivMaxPre  = 0;  // |div(u**)|    max -- pre-corrector (= b magnitude / V scaled)
+    RealType lastDivRC      = 0;  // |div_RC(u^{n+1})| max -- the operator RC actually zeros (only set when useRhieChow)
+    RealType lastGradPRms   = 0;  // RMS of grad(p^n) magnitude  -- predictor input
+    RealType lastGradPhiRms = 0;  // RMS of grad(phi)  magnitude -- corrector input
+
+    // Hypre-specific persistent state (only filled when solverKind == Hypre).
+    int64_t globalRowStart = 0;
+    int64_t globalRowEnd = 0;
+    int64_t numInteriorGlobal = 0;
+#ifdef MARS_ENABLE_HYPRE
+    thrust::device_vector<HYPRE_BigInt> d_localToGlobalDof;
+#endif
+
+    // Cached bbox for BC marking (constant on a fixed mesh).
+    RealType xmin = 0, xmax = 1, ymin = 0, ymax = 1, zmin = 0, zmax = 1;
+    RealType bboxEps = 0;
+    RealType lidU = 1;
+
+    // BC configuration. Cavity: Dirichlet u=lidU on top face, u=0 on others.
+    // Channel: Dirichlet u=Uinf on x=xmin inflow, u=v=w=0 on y/z walls,
+    // natural (Neumann) on x=xmax outflow.
+    // Pump: per-side-set Dirichlet driven by Exodus side-sets. walls=no-slip
+    //   (u=v=w=0), in=Uinf, out=Dirichlet p=0, other named side-sets get
+    //   full Dirichlet u=Uinf (extra Dirichlet walls; true slip BCs are
+    //   a follow-up). Side-set local-node lists must be populated before
+    //   setupNSStepper(). NSStepper does not allocate or free them.
+    // Periodic: triply periodic box. No Dirichlet on velocity. Pressure
+    // null-space removed by global-mean subtraction every step. Requires
+    // periodicMap to be set before setupNSStepper().
+    enum class BCKind { Cavity, Channel, Pump, Periodic };
+    BCKind bcKind = BCKind::Cavity;
+    RealType Uinf = 1;   // channel/pump inflow speed; reuses lidU value via CLI
+    // Inlet velocity direction (unit vector). Default +x for legacy channel/pump.
+    // The pump driver sets this to the INWARD normal of the inlet side-set so
+    // the prescribed Uinf is applied normal to the opening, not along a global
+    // axis. Inlet velocity = Uinf * (inletDirX, inletDirY, inletDirZ).
+    RealType inletDirX = 1, inletDirY = 0, inletDirZ = 0;
+    // Mass-conserving outlet (pump). When outletU > 0, the Pump outlet nodes are
+    // tagged as a velocity-Dirichlet OUTFLOW with velocity outletU along the
+    // OUTWARD normal (outletDir), sized so the outlet flux removes the inlet
+    // flux -> balances net through-flux so the projection is well-posed (a
+    // velocity-inlet + pressure-only outlet leaves an unprojectable mode). The
+    // outlet still gets p=0 for the pressure null-space. outletU<=0 keeps the
+    // legacy natural-Neumann outflow.
+    RealType outletU = -1;
+    RealType outletDirX = 1, outletDirY = 0, outletDirZ = 0;
+    bool outletDoNothing = true;  // do-nothing outlet (free velocity + p=0 face); false = mass-conserving velocity outlet
+
+    // Constant streamwise (and orthogonal) momentum body force, added in the
+    // predictor as +dt*f/rho (BDF1) and +(2dt/3)*f/rho (BDF2). Defaults to 0
+    // to match Nalu-Wind / NekRS / MFEM-Navier convention (no force unless the
+    // user opts in via CLI). Used for full-Dirichlet flows where a
+    // uniform IC + full-Dirichlet BC has no transient otherwise; for cavity
+    // the lid shears the flow and the body force stays 0. Activates per
+    // component via --body-force-x|y|z=<val>.
+    RealType bodyForceX = 0;
+    RealType bodyForceY = 0;
+    RealType bodyForceZ = 0;
+
+    // Balanced opening-flux source (pump-fork port; CHANNEL FORK ONLY). The
+    // driver fills the per-node OUTWARD opening area-vectors and the PRESCRIBED
+    // inlet/outlet velocities; runPressureSolveStep adds v.aVec to divAccNode
+    // after the interior scatter, with the outlet rescaled (oScale = -Qin/Qout)
+    // so the net source is exactly zero. Prescribed values, never the solved
+    // field: the solved u** is ~0 at the outlet at step 0 -> one-sided source
+    // -> blowup. Default OFF.
+    bool useOpeningFluxSource = false;
+    RealType openInletVel[3]  = {0, 0, 0};
+    RealType openOutletVel[3] = {0, 0, 0};
+    cstone::DeviceVector<RealType> d_openInAreaX, d_openInAreaY, d_openInAreaZ;
+    cstone::DeviceVector<RealType> d_openOutAreaX, d_openOutAreaY, d_openOutAreaZ;
+    // IC velocity perturbation amplitude as a fraction of Uinf. Adds a small
+    // deterministic per-node perturbation to (v, w) interior at t=0 so the
+    // body force / advection has something to amplify. Without this on a
+    // uniform-IC + full-Dirichlet domain, the system is a discrete
+    // steady state and no flow develops -- exactly matches NekRS userdat2 /
+    // Nalu-Wind ABLForcingMomentum boot pattern. Default 0 (opt-in via
+    // --ic-perturb=<eps>). Standard NekRS value is ~1e-3.
+    RealType icPerturbMag = 0;
+
+    // Pump-mode side-set local-node lists. Each vector holds owned-or-ghost
+    // LOCAL node indices (size_t) that the driver mapped from global Exodus
+    // node IDs via cstone's d_localToGlobalNodeMap_. Populated only when
+    // bcKind == Pump. Names match the Exodus mesh side-set names.
+    std::vector<int> wallNodes;     // no-slip
+    std::vector<int> inletNodes;    // u = Uinf
+    std::vector<int> outletNodes;   // Dirichlet p = 0
+    std::vector<int> extraNodes;    // top/bottom/side/sym -- u = Uinf (full Dirichlet shortcut)
+
+    // Optional. When bcKind == Periodic, must point to a built PeriodicMap.
+    // Owned by the driver; NSStepper does not allocate or free it. The map
+    // must be rebuilt by the driver after any AMR step (coords/node count
+    // change) before the next runNsStep call.
+    const PeriodicMap<KeyType, RealType>* periodicMap = nullptr;
+
+    // Bochev-Dohrmann polynomial pressure projection stabilization.
+    // Equal-order CG-FEM (Q1-Q1 here) does NOT satisfy the LBB / inf-sup
+    // condition: the discrete pressure space admits spurious checkerboard
+    // modes that the discrete gradient cannot detect. In domains with
+    // Dirichlet pressure boundaries those modes are pinned by the BC; in
+    // *periodic* domains they have no anchor and grow exponentially via the
+    // grad(p) feedback in the predictor. Bochev & Dohrmann (2006, SISC) add
+    // a consistent element-local stabilization term S = tau (q - Pi q, p - Pi p)
+    // where Pi is the L2 projection onto element constants (P0 on Q1). For
+    // Q1 hexes with lumped mass V_e/8 per corner, S^e_ij = tau (M^e_ij - V_e/64)
+    // -- a small, symmetric element matrix added to the pressure system. This
+    // controls the pressure null-space without artificially increasing the
+    // velocity dissipation. tau = h^2 / (4 mu) is the canonical choice; we
+    // expose it as a knob via stabPressureTau (set <= 0 to auto-pick).
+    bool stabBochevDohrmann = false;
+    RealType stabPressureTau = -1;
+    // Rhie-Chow pressure-velocity coupling on the divergence operator.
+    // The textbook CVFEM/co-located-FV stabilization (Nalu-Wind, OpenFOAM,
+    // Fluent all use it). For Q1-Q1 on periodic boundaries this is the
+    // correct fix for the inf-sup pathology; alternative FEM stabilizations
+    // (Bochev-Dohrmann, PSPG, Codina) are FEM-canonical answers to the same
+    // question but don't fit a face-flux discretization.
+    bool useRhieChow      = false;
+    RealType rhieChowTau  = -1;   // <=0 => auto-pick = dt/rho
+
+    // Ownership map every kernel uses. Always the domain's cached map -- we no
+    // longer demote periodic slaves (see setupNSStepper). Kept as a single
+    // accessor so all kernels bind through one place.
+    const cstone::DeviceVector<uint8_t>& ownershipMap() const {
+        return domain.getNodeOwnershipMap();
+    }
+};
+
+// =============================================================================
+// Helpers for the two-matrix Laplacian assembly. Both matrices want the same
+// CVFEM Laplacian K (gamma=1), assembled by CvfemHexAssembler::assembleFull
+// with zeroed advection inputs. We assemble K once into a temporary buffer,
+// then copy it into d_valuesVel (and add M/dt + enforce velocity BC) and into
+// d_valuesPre (and enforce single-pin BC) so the two matrices end up with
+// different values but the same row/column structure.
+// =============================================================================
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void assembleLaplacian(NSStepper<KeyType, RealType, ElementTag>& s,
+                       const cstone::DeviceVector<int>& /*unused*/,
+                       cstone::DeviceVector<RealType>& d_valuesOut,
+                       CvfemKernelVariant kernelVariant)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const auto& d_conn          = s.domain.getElementToNodeConnectivity();
+    const auto& d_x = s.domain.getNodeX();
+    const auto& d_y = s.domain.getNodeY();
+    const auto& d_z = s.domain.getNodeZ();
+
+    const uint8_t* effectiveOwnership = d_nodeOwnership.data();
+
+    using MatrixT = CSRMatrix<RealType>;
+    MatrixT* d_matrix;
+    cudaMalloc(&d_matrix, sizeof(MatrixT));
+    // numRows = numTotalDofs (matrix is sized for owned + ghost rows so ghost
+    // column indices are addressable). numOwnedRows = numOwnedDofs tells the
+    // kernel which rows are actually solved + halo-exchanged; scatters into
+    // rows >= numOwnedRows would be silent leaks (e.g. periodic slave redirected
+    // to a cross-rank master ghost).
+    MatrixT h_matrix{s.d_rowPtr.data(), s.d_colInd.data(), d_valuesOut.data(), s.d_diagPtr.data(),
+                     s.numTotalDofs, s.nnz, s.numOwnedDofs};
+    cudaMemcpy(d_matrix, &h_matrix, sizeof(MatrixT), cudaMemcpyHostToDevice);
+
+    // gamma=1 -> pure Laplacian; all advection inputs zero so assembler doesn't
+    // accumulate an advective contribution. RHS unused.
+    cstone::DeviceVector<RealType> d_gamma(s.nodeCount, RealType(1));
+    cstone::DeviceVector<RealType> d_phi(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> d_beta(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> d_gphi_x(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> d_gphi_y(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> d_gphi_z(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> d_mdot_zero(s.elementCount * ElemTraits<ElementTag>::ScsPerElem, RealType(0));
+    cstone::DeviceVector<RealType> d_rhs_unused(s.numTotalDofs, RealType(0));
+
+    thrust::fill(thrust::device_pointer_cast(d_valuesOut.data()),
+                 thrust::device_pointer_cast(d_valuesOut.data() + s.nnz),
+                 RealType(0));
+
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    {
+        typename CvfemHexAssembler<KeyType, RealType>::Config config;
+        config.blockSize = s.blockSize;
+        config.variant   = kernelVariant;
+
+        CvfemHexAssembler<KeyType, RealType>::assembleFull(
+            std::get<0>(d_conn).data(), std::get<1>(d_conn).data(), std::get<2>(d_conn).data(),
+            std::get<3>(d_conn).data(), std::get<4>(d_conn).data(), std::get<5>(d_conn).data(),
+            std::get<6>(d_conn).data(), std::get<7>(d_conn).data(), s.elementCount,
+            d_x.data(), d_y.data(), d_z.data(),
+            d_gamma.data(), d_phi.data(), d_beta.data(),
+            d_gphi_x.data(), d_gphi_y.data(), d_gphi_z.data(),
+            d_mdot_zero.data(), s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+            s.d_node_to_dof.data(), effectiveOwnership, d_matrix, d_rhs_unused.data(), config);
+    }
+    else
+    {
+        typename CvfemTetAssembler<KeyType, RealType>::Config tetConfig;
+        tetConfig.blockSize = s.blockSize;
+
+        CvfemTetAssembler<KeyType, RealType>::assembleFull(
+            std::get<0>(d_conn).data(), std::get<1>(d_conn).data(),
+            std::get<2>(d_conn).data(), std::get<3>(d_conn).data(), s.elementCount,
+            d_x.data(), d_y.data(), d_z.data(),
+            d_gamma.data(), d_phi.data(), d_beta.data(),
+            d_gphi_x.data(), d_gphi_y.data(), d_gphi_z.data(),
+            d_mdot_zero.data(),
+            s.d_node_to_dof.data(), effectiveOwnership, d_matrix, d_rhs_unused.data(), tetConfig);
+    }
+    cudaDeviceSynchronize();
+    cudaFree(d_matrix);
+}
+
+// Wrap a CSR (rowPtr/colInd/values) into a SparseMatrix and copy into A.
+// numCols = numTotalDofs so ghost columns are addressable; numRows = owned only.
+template<typename RealType>
+void wrapIntoSparseMatrix(SparseMatrix<int, RealType, cstone::GpuTag>& A,
+                          int numOwnedDofs, int numTotalDofs, int nnz,
+                          const int* d_rowPtr, const int* d_colInd, const RealType* d_values)
+{
+    A.allocate(numOwnedDofs, numTotalDofs, nnz);
+    cudaMemcpy(A.rowOffsetsPtr(), d_rowPtr, (numOwnedDofs + 1) * sizeof(int), cudaMemcpyDeviceToDevice);
+    cudaMemcpy(A.colIndicesPtr(), d_colInd, nnz * sizeof(int),                cudaMemcpyDeviceToDevice);
+    cudaMemcpy(A.valuesPtr(),     d_values, nnz * sizeof(RealType),           cudaMemcpyDeviceToDevice);
+}
+
+// =============================================================================
+// Bochev-Dohrmann polynomial pressure projection stabilization for Q1 hexes.
+// Adds, per element, the symmetric 8x8 matrix
+//   S^e_ij = tau * V_e * (delta_ij/8 - 1/64)
+// to the (already-assembled) pressure matrix. This is the lumped-mass form
+// of the BD stabilizer with Pi(q) = element-mean. The matrix is symmetric,
+// has row sum zero (consistent: kills constant-pressure mode), positive
+// semidefinite, and adds element-local control of the discrete pressure
+// null-space that equal-order CG-FEM cannot otherwise see.
+//
+// tau has units of [pressure] / [pressure-Poisson]. For (M/dt + nu*K) the
+// natural choice is tau = h^2 / (4 * nu * rho); the agent docs use this
+// scaling. We pass `tau` already-computed by the caller.
+//
+// The scatter pattern mirrors CvfemHexAssembler::assembleFull: each (i,j)
+// pair of element corners writes to either the diagonal slot (if i and j
+// reduce to the same DOF after periodic collapse) or finds the column
+// position by binary search and atomicAdds there.
+// =============================================================================
+
+template<typename KeyType, typename RealType>
+__global__ void assembleBDStabilizationKernel(const KeyType* c0, const KeyType* c1,
+                                              const KeyType* c2, const KeyType* c3,
+                                              const KeyType* c4, const KeyType* c5,
+                                              const KeyType* c6, const KeyType* c7,
+                                              const RealType* nodeX,
+                                              const RealType* nodeY,
+                                              const RealType* nodeZ,
+                                              size_t numElements,
+                                              const int* nodeToDof,
+                                              const uint8_t* ownership,
+                                              RealType tau,
+                                              const int* rowPtr,
+                                              const int* colInd,
+                                              const int* diagPtr,
+                                              RealType* values)
+{
+    size_t e = blockIdx.x * blockDim.x + threadIdx.x;
+    if (e >= numElements) return;
+
+    KeyType n[8] = {c0[e], c1[e], c2[e], c3[e], c4[e], c5[e], c6[e], c7[e]};
+
+    // Element volume via box approximation: V_e ~ |x7-x0| * |y7-y0| * |z7-z0|.
+    // For a uniform hex mesh this is exact; for distorted hexes it's the
+    // determinant of the trilinear Jacobian at the element center, an O(1)
+    // approximation that suffices for a stabilization parameter.
+    RealType V_e;
+    {
+        RealType x0 = nodeX[n[0]], x6 = nodeX[n[6]];
+        RealType y0 = nodeY[n[0]], y6 = nodeY[n[6]];
+        RealType z0 = nodeZ[n[0]], z6 = nodeZ[n[6]];
+        V_e = fabs((x6 - x0) * (y6 - y0) * (z6 - z0));
+    }
+    RealType diagCoef = tau * V_e * (RealType(1) / RealType(8) - RealType(1) / RealType(64));
+    RealType offCoef  = tau * V_e * (-RealType(1) / RealType(64));
+
+    int dofs[8];
+    uint8_t own[8];
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) { dofs[i] = nodeToDof[n[i]]; own[i] = ownership[n[i]]; }
+
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        if (own[i] != 1) continue;
+        int row_dof = dofs[i];
+        if (row_dof < 0) continue;
+        int row_start = rowPtr[row_dof];
+        int row_end   = rowPtr[row_dof + 1];
+        int diag_pos  = diagPtr[row_dof];
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            int col_dof = dofs[j];
+            if (col_dof < 0) continue;
+            RealType v = (i == j) ? diagCoef : offCoef;
+
+            if (col_dof == row_dof) {
+                atomicAdd(&values[diag_pos], v);
+            } else {
+                int lo = row_start, hi = row_end - 1;
+                while (lo <= hi) {
+                    int mid = (lo + hi) >> 1;
+                    int col = colInd[mid];
+                    if (col == col_dof) { atomicAdd(&values[mid], v); break; }
+                    else if (col < col_dof) lo = mid + 1;
+                    else                    hi = mid - 1;
+                }
+            }
+        }
+    }
+}
+
+// Helper: add BD stabilization to the pressure matrix s.d_valuesPre.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void addBochevDohrmannStab(NSStepper<KeyType, RealType, ElementTag>& s, RealType tau)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const auto& d_conn          = s.domain.getElementToNodeConnectivity();
+    const auto& d_x = s.domain.getNodeX();
+    const auto& d_y = s.domain.getNodeY();
+    const auto& d_z = s.domain.getNodeZ();
+
+    size_t nElem = s.elementCount;
+    int blockSize = s.blockSize;
+    int grid = int((nElem + blockSize - 1) / blockSize);
+    if (grid <= 0) return;
+
+    // BD stabilization is a Q1-hex-specific 8x8 scatter (std::get<7>, 8 corners).
+    // Tet pressure stabilization is a separate follow-up; guard so the tet
+    // instantiation never touches the 8-column connectivity.
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    {
+        assembleBDStabilizationKernel<KeyType, RealType><<<grid, blockSize>>>(
+            std::get<0>(d_conn).data(), std::get<1>(d_conn).data(),
+            std::get<2>(d_conn).data(), std::get<3>(d_conn).data(),
+            std::get<4>(d_conn).data(), std::get<5>(d_conn).data(),
+            std::get<6>(d_conn).data(), std::get<7>(d_conn).data(),
+            d_x.data(), d_y.data(), d_z.data(),
+            nElem, s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            tau,
+            s.d_rowPtr.data(), s.d_colInd.data(), s.d_diagPtr.data(),
+            s.d_valuesPre.data());
+        cudaDeviceSynchronize();
+    }
+}
+
+// =============================================================================
+// Setup: builds DOF mapping, sparsity, two matrices, lumped mass, BC mask,
+// pressure pin, area vectors. Runs ONCE before the time loop.
+// =============================================================================
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
+                    RealType nu,
+                    RealType dt,
+                    CvfemKernelVariant kernelVariant)
+{
+    // Live-print each setup lap on rank 0; the final report still summarizes.
+    PhaseTimer pt(/*sync=*/true, /*liveRank=*/0);
+
+    s.nodeCount    = s.domain.getNodeCount();
+    s.elementCount = s.domain.getElementCount();
+
+    // Optional one-shot diagnostic: count halo elements per rank and how many
+    // touch the periodic-min faces. Confirms cstone delivers periodic-image
+    // halo elements (verified yes on cube16/4-rank: 1238 halo elements touch
+    // min-faces). Set MARS_PERIODIC_HALO_DBG=1 to enable.
+    // Hex-only: the lambda spells std::get<7> and a fixed n[8]; a runtime
+    // `if` would still INSTANTIATE that on the 4-tuple tet domain. if constexpr
+    // keeps it out of the tet compile entirely.
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    if (std::getenv("MARS_PERIODIC_HALO_DBG") != nullptr)
+    {
+        size_t startE  = s.domain.startIndex();
+        size_t endE    = s.domain.endIndex();
+        size_t numOwn  = endE - startE;
+        size_t numHalo = s.elementCount > numOwn ? s.elementCount - numOwn : 0;
+
+        // Local bbox + Allreduce to get global box (s.xmin etc. not yet set).
+        const auto& d_cn = s.domain.getElementToNodeConnectivity();
+        const auto& d_x  = s.domain.getNodeX();
+        const auto& d_y  = s.domain.getNodeY();
+        const auto& d_z  = s.domain.getNodeZ();
+        RealType lxmin = thrust::reduce(thrust::device, d_x.data(), d_x.data() + s.nodeCount, RealType(1e30),  thrust::minimum<RealType>());
+        RealType lxmax = thrust::reduce(thrust::device, d_x.data(), d_x.data() + s.nodeCount, RealType(-1e30), thrust::maximum<RealType>());
+        RealType lymin = thrust::reduce(thrust::device, d_y.data(), d_y.data() + s.nodeCount, RealType(1e30),  thrust::minimum<RealType>());
+        RealType lymax = thrust::reduce(thrust::device, d_y.data(), d_y.data() + s.nodeCount, RealType(-1e30), thrust::maximum<RealType>());
+        RealType lzmin = thrust::reduce(thrust::device, d_z.data(), d_z.data() + s.nodeCount, RealType(1e30),  thrust::minimum<RealType>());
+        RealType lzmax = thrust::reduce(thrust::device, d_z.data(), d_z.data() + s.nodeCount, RealType(-1e30), thrust::maximum<RealType>());
+        RealType xmin, xmax, ymin, ymax, zmin, zmax;
+        MPI_Datatype mpiType = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
+        MPI_Allreduce(&lxmin, &xmin, 1, mpiType, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(&lxmax, &xmax, 1, mpiType, MPI_MAX, MPI_COMM_WORLD);
+        MPI_Allreduce(&lymin, &ymin, 1, mpiType, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(&lymax, &ymax, 1, mpiType, MPI_MAX, MPI_COMM_WORLD);
+        MPI_Allreduce(&lzmin, &zmin, 1, mpiType, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(&lzmax, &zmax, 1, mpiType, MPI_MAX, MPI_COMM_WORLD);
+        RealType eps  = RealType(1e-3) * std::max({xmax - xmin, ymax - ymin, zmax - zmin});
+
+        long long localOnMin = 0;
+        if (numHalo > 0)
+        {
+            localOnMin = thrust::count_if(
+                thrust::device,
+                thrust::counting_iterator<size_t>(0),
+                thrust::counting_iterator<size_t>(s.elementCount),
+                [startE, endE,
+                 c0 = std::get<0>(d_cn).data(), c1 = std::get<1>(d_cn).data(),
+                 c2 = std::get<2>(d_cn).data(), c3 = std::get<3>(d_cn).data(),
+                 c4 = std::get<4>(d_cn).data(), c5 = std::get<5>(d_cn).data(),
+                 c6 = std::get<6>(d_cn).data(), c7 = std::get<7>(d_cn).data(),
+                 x = d_x.data(), y = d_y.data(), z = d_z.data(),
+                 xmin, ymin, zmin, eps]
+                __device__ (size_t e) -> bool {
+                    if (e >= startE && e < endE) return false;
+                    KeyType n[8] = {c0[e], c1[e], c2[e], c3[e],
+                                    c4[e], c5[e], c6[e], c7[e]};
+                    for (int i = 0; i < 8; ++i)
+                    {
+                        if (fabs(double(x[n[i]] - xmin)) < double(eps) ||
+                            fabs(double(y[n[i]] - ymin)) < double(eps) ||
+                            fabs(double(z[n[i]] - zmin)) < double(eps))
+                            return true;
+                    }
+                    return false;
+                });
+        }
+
+        long long lOwn  = (long long)numOwn;
+        long long lHalo = (long long)numHalo;
+        long long gOwn = 0, gHalo = 0, gOnMin = 0;
+        MPI_Reduce(&lOwn,       &gOwn,   1, MPI_LONG_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+        MPI_Reduce(&lHalo,      &gHalo,  1, MPI_LONG_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+        MPI_Reduce(&localOnMin, &gOnMin, 1, MPI_LONG_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+        if (s.rank == 0)
+        {
+            std::cout << "[DBG halo] sum owned=" << gOwn
+                      << " sum halo=" << gHalo
+                      << " sum halo-on-min-face=" << gOnMin
+                      << "  (rank0 own=" << lOwn << " halo=" << lHalo
+                      << " onMin=" << localOnMin << ")\n";
+        }
+    }
+
+    // Ownership: normally the domain's cached map. For PERIODIC multi-rank we
+    // Periodic slaves are NOT demoted. MARS's multi-rank matrix-assembly
+    // invariant requires every owned DOF to receive all its element stiffness
+    // locally (the assembler loops over cstone's halo-extended element set and
+    // scatters owned rows only -- no cross-rank matrix coupling). With the
+    // periodic cstone Box, the periodic-image element + master node arrive in
+    // each rank's halo, so a periodic master's owned row is filled on its
+    // owner rank exactly as for an interior node. Slaves keep ownership=1 and
+    // the DOF collapse below identifies slave_dof with the (now locally
+    // present, owned-or-halo) master_dof. Demoting slaves broke this invariant
+    // (under-filled master rows -> velocity CG NaN), so we use the domain's
+    // ownership map unchanged.
+    const auto& d_nodeOwnership = s.domain.getNodeOwnershipMap();
+
+    const auto& d_conn          = s.domain.getElementToNodeConnectivity();
+    s.domain.cacheNodeCoordinates();
+    const auto& d_x = s.domain.getNodeX();
+    const auto& d_y = s.domain.getNodeY();
+    const auto& d_z = s.domain.getNodeZ();
+    pt.lap("lazy domain prep");
+
+    // DOF mapping: owned -> [0, numOwnedDofs); ghost -> [numOwnedDofs, nodeCount).
+    s.d_node_to_dof.resize(s.nodeCount);
+    s.numOwnedDofs = buildDofMappingGpu<KeyType>(d_nodeOwnership.data(), s.d_node_to_dof.data(), s.nodeCount);
+    s.numTotalDofs = static_cast<int>(s.nodeCount);
+
+    // PERIODIC DOF COLLAPSE: a slave node shares its master's DOF index, then
+    // we COMPACT the DOF numbering so there are no orphan rows. After this:
+    //   - nodeToDof[slave] = nodeToDof[master]  (only for LOCAL-OWNED masters)
+    //   - all surviving DOF indices are dense in [0, nLive)
+    //   - s.numOwnedDofs = nLive
+    //
+    // MULTI-RANK: we ONLY collapse a slave onto its master when the master is
+    // locally OWNED (own==1). Then the merged DOF is a real owned row on this
+    // rank and the assembler fills it from the local halo-extended element set.
+    //
+    // When the master is a REMOTE node (present only as a periodic-halo ghost
+    // here, own!=1), we do NOT collapse: the slave keeps its own owned DOF.
+    // The slave and the remote master are the same periodic point but each
+    // rank owns its own copy's row -- exactly how cstone treats any shared
+    // node. cstone's periodic element halo fills each owned row locally, and
+    // exchangeNodeHalo keeps the slave's value synced to the master's owner.
+    // Collapsing across ranks would point the slave at a ghost DOF (out of the
+    // owned range) and orphan its row -> velocity CG NaN (the bug we hit).
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.periodicMap)
+    {
+        const int* d_partner = s.periodicMap->d_periodicPartner.data();
+        const uint8_t* d_own = d_nodeOwnership.data();
+        int* d_n2d           = s.d_node_to_dof.data();
+        size_t nNodes        = s.nodeCount;
+        int numOwned         = s.numOwnedDofs;
+
+        // Pass 1: redirect EVERY owned slave -> its master's DOF (owner-migration),
+        // for both same-rank and cross-rank pairs. For a same-rank pair the master
+        // is locally owned. For a cross-rank pair the master is a periodic-image
+        // ghost delivered by cstone's halo, so the redirect points the slave at a
+        // GHOST DOF (>= numOwned); the Pass-2 compaction (gated dof<numOwned) then
+        // drops the slave's own owned row, collapsing the pair to ONE global DOF.
+        cstone::DeviceVector<int> d_oldDof(s.d_node_to_dof);
+        thrust::for_each(thrust::device,
+                         thrust::counting_iterator<size_t>(0),
+                         thrust::counting_iterator<size_t>(nNodes),
+                         [d_partner, d_old = d_oldDof.data(), d_n2d, d_own]
+                         __device__ (size_t i) {
+                             int master = d_partner[i];
+                             if (master < 0 || d_own[i] != 1) return;
+                             // TRUE cross-rank collapse (owner-migration): redirect
+                             // EVERY owned slave onto its master's DOF, regardless of
+                             // whether the master is owned (same-rank) or a periodic-
+                             // image GHOST (cross-rank). For a same-rank pair d_old[master]
+                             // is the master's owned dof (< numOwned). For a cross-rank
+                             // pair the master is a local ghost (delivered by cstone's
+                             // periodic-image halo) and d_old[master] is a GHOST dof
+                             // (>= numOwned), so the compaction below (Pass 2 gates
+                             // dof<numOwned) drops the slave's OWN owned row -> the pair
+                             // becomes ONE global DOF. No orphan: the slave node is now a
+                             // ghost-valued node reading the master's value via halo; its
+                             // stiffness is re-assembled on the master-owner rank from the
+                             // SAME periodic-image element. This eliminates the cross-rank
+                             // emulation (no post-solve broadcast, no per-matvec pair-sum).
+                             d_n2d[i] = d_old[master];
+                         });
+        cudaDeviceSynchronize();
+
+        // Pass 2: mark live DOFs.
+        cstone::DeviceVector<int> d_isLive(numOwned, 0);
+        thrust::for_each(thrust::device,
+                         thrust::counting_iterator<size_t>(0),
+                         thrust::counting_iterator<size_t>(nNodes),
+                         [d_n2d, d_live = d_isLive.data(), numOwned,
+                          d_own = d_nodeOwnership.data()] __device__ (size_t i) {
+                             if (d_own[i] != 1) return;
+                             int dof = d_n2d[i];
+                             if (dof >= 0 && dof < numOwned) d_live[dof] = 1;
+                         });
+        cudaDeviceSynchronize();
+
+        // Pass 3: compact map: compact[old_dof] = prefix-sum of d_isLive.
+        cstone::DeviceVector<int> d_compact(numOwned, -1);
+        thrust::exclusive_scan(thrust::device, d_isLive.begin(), d_isLive.end(),
+                               d_compact.begin());
+        // For orphan DOFs we leave compact = scan value but they will be
+        // unreachable from nodeToDof, so it doesn't matter. Mark them -1
+        // explicitly for safety so any stale lookup is detected.
+        thrust::transform(thrust::device,
+                          d_isLive.begin(), d_isLive.end(),
+                          d_compact.begin(), d_compact.begin(),
+                          [] __device__ (int live, int idx) {
+                              return live ? idx : -1;
+                          });
+        cudaDeviceSynchronize();
+
+        int nLive = int(thrust::reduce(thrust::device,
+                                        d_isLive.begin(), d_isLive.end(), 0));
+
+        // Pass 4: rewrite nodeToDof through the compact map.
+        // - Owned nodes whose dof is in [0, numOwned): apply compact[].
+        // - Owned slaves whose Pass-1 redirect put them at a ghost dof
+        //   (>= numOwned, cross-rank periodic case): skip; the ghost dof is
+        //   already in the post-compact ghost range [nLive, numTotalDofs)
+        //   semantically because d_n2d ghost slots don't get renumbered and
+        //   cstone halo exchange writes the ghost dof slot from the master
+        //   owner's owned-dof slot (which IS in [0, nLive_remote) on the
+        //   master rank). This works because we never reorder the ghost-dof
+        //   slots themselves -- only the owned slots compact.
+        thrust::for_each(thrust::device,
+                         thrust::counting_iterator<size_t>(0),
+                         thrust::counting_iterator<size_t>(nNodes),
+                         [d_n2d, d_comp = d_compact.data(), numOwned,
+                          d_own = d_nodeOwnership.data()] __device__ (size_t i) {
+                             int dof = d_n2d[i];
+                             if (dof >= 0 && dof < numOwned && d_own[i] == 1)
+                                 d_n2d[i] = d_comp[dof];
+                         });
+        cudaDeviceSynchronize();
+
+        s.numOwnedDofs = nLive;
+        {
+            // Per-rank print: cross-rank slaves only show on the slave-owner rank,
+            // not rank 0. Keep all ranks visible to verify Pass-1 redirect coverage.
+            int nOrphan = numOwned - nLive;
+            std::cout << "  [rank " << s.rank << "] periodic DOF collapse: "
+                      << nOrphan << " slave DOFs collapsed -> "
+                      << nLive << " active equations (was " << numOwned << ")\n";
+        }
+    }
+    pt.lap("DOF mapping");
+
+    // DIAGNOSTIC: owned-node partition health. Sum of per-rank owned DOFs across
+    // ranks MUST equal the global unique-DOF count -- if it is LARGER, some nodes
+    // are doubly-owned (counted on >1 rank), which double-counts them in the CG
+    // inner products and corrupts the projection (multi-rank div != single-rank).
+    {
+        long long localOwned = s.numOwnedDofs;
+        long long sumOwned = 0, maxOwned = 0;
+        MPI_Allreduce(&localOwned, &sumOwned, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&localOwned, &maxOwned, 1, MPI_LONG_LONG, MPI_MAX, MPI_COMM_WORLD);
+        if (s.rank == 0)
+            std::cout << "  [owned-node check] sum(numOwnedDofs over ranks)=" << sumOwned
+                      << "  (this should EQUAL the global unique node/DOF count; "
+                      << "larger => doubly-owned boundary nodes)\n";
+    }
+
+    // FULL 27-NNZ sparsity (same pattern used by both matrices). Building once
+    // means the velocity and pressure matrices share row/col/diag pointers.
+    s.d_rowPtr.resize(s.numTotalDofs + 1);
+    s.d_diagPtr.resize(s.numTotalDofs);
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    {
+        s.nnz = CvfemSparsityBuilder<KeyType>::buildFullSparsity(
+            std::get<0>(d_conn).data(), std::get<1>(d_conn).data(), std::get<2>(d_conn).data(),
+            std::get<3>(d_conn).data(), std::get<4>(d_conn).data(), std::get<5>(d_conn).data(),
+            std::get<6>(d_conn).data(), std::get<7>(d_conn).data(), s.elementCount,
+            s.d_node_to_dof.data(), s.numTotalDofs,
+            s.d_rowPtr.data(), nullptr, nullptr, 0);
+        s.d_colInd.resize(s.nnz);
+        CvfemSparsityBuilder<KeyType>::buildFullSparsity(
+            std::get<0>(d_conn).data(), std::get<1>(d_conn).data(), std::get<2>(d_conn).data(),
+            std::get<3>(d_conn).data(), std::get<4>(d_conn).data(), std::get<5>(d_conn).data(),
+            std::get<6>(d_conn).data(), std::get<7>(d_conn).data(), s.elementCount,
+            s.d_node_to_dof.data(), s.numTotalDofs,
+            s.d_rowPtr.data(), s.d_colInd.data(), s.d_diagPtr.data(), 0);
+    }
+    else
+    {
+        s.nnz = CvfemTetSparsityBuilder<KeyType>::buildFullSparsity(
+            std::get<0>(d_conn).data(), std::get<1>(d_conn).data(),
+            std::get<2>(d_conn).data(), std::get<3>(d_conn).data(), s.elementCount,
+            s.d_node_to_dof.data(), s.numTotalDofs,
+            s.d_rowPtr.data(), nullptr, nullptr, 0);
+        s.d_colInd.resize(s.nnz);
+        CvfemTetSparsityBuilder<KeyType>::buildFullSparsity(
+            std::get<0>(d_conn).data(), std::get<1>(d_conn).data(),
+            std::get<2>(d_conn).data(), std::get<3>(d_conn).data(), s.elementCount,
+            s.d_node_to_dof.data(), s.numTotalDofs,
+            s.d_rowPtr.data(), s.d_colInd.data(), s.d_diagPtr.data(), 0);
+    }
+    s.d_valuesVel.resize(s.nnz);
+    s.d_valuesPre.resize(s.nnz);
+    pt.lap("sparsity build");
+
+    // Area vectors (single source of truth for face geometry across operators).
+    s.d_areaVec_x.resize(s.elementCount * ElemTraits<ElementTag>::ScsPerElem);
+    s.d_areaVec_y.resize(s.elementCount * ElemTraits<ElementTag>::ScsPerElem);
+    s.d_areaVec_z.resize(s.elementCount * ElemTraits<ElementTag>::ScsPerElem);
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    {
+        precomputeAreaVectorsGpu<KeyType, RealType>(
+            std::get<0>(d_conn).data(), std::get<1>(d_conn).data(), std::get<2>(d_conn).data(),
+            std::get<3>(d_conn).data(), std::get<4>(d_conn).data(), std::get<5>(d_conn).data(),
+            std::get<6>(d_conn).data(), std::get<7>(d_conn).data(), s.elementCount,
+            d_x.data(), d_y.data(), d_z.data(),
+            s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data());
+    }
+    else
+    {
+        precomputeTetAreaVectorsGpu<KeyType, RealType>(
+            std::get<0>(d_conn).data(), std::get<1>(d_conn).data(),
+            std::get<2>(d_conn).data(), std::get<3>(d_conn).data(), s.elementCount,
+            d_x.data(), d_y.data(), d_z.data(),
+            s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data());
+    }
+    pt.lap("area vectors");
+
+    // MARS_PERIODIC_AREAVEC_PROBE: H1 falsifier. Per-element Stokes closure
+    // (sum of 12 SCS face area-vectors must be 0 over a closed CV). Scan OWNED
+    // and HALO element ranges separately; if a periodic-image halo element on
+    // the receiving rank has a sign-flipped face from a misordered SCS-table
+    // wrap, halo_max >> owned_max. One-shot at setup, rank-uniform gate.
+    // Hex-only (tet uses a different table); Periodic-only; pump path skipped.
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+        && s.periodicMap != nullptr
+        && std::getenv("MARS_PERIODIC_AREAVEC_PROBE") != nullptr)
+    {
+        constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+        const size_t startE = s.domain.startIndex();
+        const size_t endE   = s.domain.endIndex();
+        const size_t numOwn = endE - startE;
+        const size_t nElem  = s.elementCount;
+        const RealType* ax = s.d_areaVec_x.data();
+        const RealType* ay = s.d_areaVec_y.data();
+        const RealType* az = s.d_areaVec_z.data();
+        auto closureMagSq = [=] __device__ (size_t e) -> RealType {
+            RealType sx = 0, sy = 0, sz = 0;
+            const size_t base = e * NSCS;
+            for (int f = 0; f < NSCS; ++f) { sx += ax[base+f]; sy += ay[base+f]; sz += az[base+f]; }
+            return sx*sx + sy*sy + sz*sz;
+        };
+        RealType ownedMaxSq = thrust::transform_reduce(
+            thrust::device, thrust::counting_iterator<size_t>(startE),
+            thrust::counting_iterator<size_t>(endE), closureMagSq,
+            RealType(0), thrust::maximum<RealType>());
+        RealType haloMaxSq = RealType(0);
+        if (nElem > numOwn) {
+            RealType h1 = (startE > 0) ? thrust::transform_reduce(
+                thrust::device, thrust::counting_iterator<size_t>(0),
+                thrust::counting_iterator<size_t>(startE), closureMagSq,
+                RealType(0), thrust::maximum<RealType>()) : RealType(0);
+            RealType h2 = (nElem > endE) ? thrust::transform_reduce(
+                thrust::device, thrust::counting_iterator<size_t>(endE),
+                thrust::counting_iterator<size_t>(nElem), closureMagSq,
+                RealType(0), thrust::maximum<RealType>()) : RealType(0);
+            haloMaxSq = std::max(h1, h2);
+        }
+        RealType gOwn = 0, gHalo = 0;
+        MPI_Datatype mt = std::is_same<RealType,double>::value ? MPI_DOUBLE : MPI_FLOAT;
+        MPI_Allreduce(&ownedMaxSq, &gOwn,  1, mt, MPI_MAX, MPI_COMM_WORLD);
+        MPI_Allreduce(&haloMaxSq,  &gHalo, 1, mt, MPI_MAX, MPI_COMM_WORLD);
+        if (s.rank == 0) {
+            std::cout << "  [areavec-probe] sum-over-12-faces |.|_max  owned="
+                      << std::sqrt(gOwn) << "  halo=" << std::sqrt(gHalo)
+                      << "   (closure ~eps => H1 dead; halo>>owned => sign-flip on periodic-image)\n";
+        }
+    }
+
+    // MARS_PERIODIC_SEAMAX_PROBE: inter-element seam mirror-orientation falsifier.
+    // For triperiodic cube the seam at x=xmin (master side) and x=xmax (slave
+    // side) must have mirror-oriented SCS area vectors: master-side x-dominant
+    // SCS faces point +x (A.x>0), slave-side x-dominant SCS faces point -x
+    // (A.x<0). Sum the SIGNED A.x over x-dominant SCS faces of every owned hex
+    // whose bbox-touch is xmin (-> master accumulator) or xmax (-> slave
+    // accumulator). The intra-element closure check above is silent on this;
+    // this probe is the inter-element discriminator. Hex-only; Periodic-only;
+    // one-shot at setup; off by default; pump path never reaches.
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+        && s.periodicMap != nullptr
+        && std::getenv("MARS_PERIODIC_SEAMAX_PROBE") != nullptr)
+    {
+        constexpr int NSCS = ElemTraits<ElementTag>::ScsPerElem;
+        const size_t startE = s.domain.startIndex();
+        const size_t endE   = s.domain.endIndex();
+        const RealType* axp = s.d_areaVec_x.data();
+        const RealType* ayp = s.d_areaVec_y.data();
+        const RealType* azp = s.d_areaVec_z.data();
+        const RealType* xp  = d_x.data();
+        const KeyType* c0p = std::get<0>(d_conn).data(); const KeyType* c1p = std::get<1>(d_conn).data();
+        const KeyType* c2p = std::get<2>(d_conn).data(); const KeyType* c3p = std::get<3>(d_conn).data();
+        const KeyType* c4p = std::get<4>(d_conn).data(); const KeyType* c5p = std::get<5>(d_conn).data();
+        const KeyType* c6p = std::get<6>(d_conn).data(); const KeyType* c7p = std::get<7>(d_conn).data();
+        RealType lxmin = thrust::reduce(thrust::device, xp, xp + s.nodeCount, RealType( 1e30), thrust::minimum<RealType>());
+        RealType lxmax = thrust::reduce(thrust::device, xp, xp + s.nodeCount, RealType(-1e30), thrust::maximum<RealType>());
+        RealType xmin = 0, xmax = 0;
+        MPI_Datatype mt2 = std::is_same<RealType,double>::value ? MPI_DOUBLE : MPI_FLOAT;
+        MPI_Allreduce(&lxmin, &xmin, 1, mt2, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(&lxmax, &xmax, 1, mt2, MPI_MAX, MPI_COMM_WORLD);
+        const RealType seamEps = RealType(1e-4) * (xmax - xmin);
+        // Two separate scalar reductions (one per seam side) -- thrust can't
+        // deduce tuple-return-type from a __device__ lambda without
+        // proclaim_return_type, and two reductions is simpler.
+        auto sideAccPicker = [=] __device__ (size_t e, int wantSide) -> RealType {
+            KeyType n[8] = {c0p[e],c1p[e],c2p[e],c3p[e],c4p[e],c5p[e],c6p[e],c7p[e]};
+            RealType cmn = xp[n[0]], cmx = xp[n[0]];
+            for (int i = 1; i < 8; ++i) { RealType v = xp[n[i]]; if (v<cmn) cmn=v; if (v>cmx) cmx=v; }
+            int side = (cmn < xmin + seamEps) ? 1 : ((cmx > xmax - seamEps) ? 2 : 0);
+            if (side != wantSide) return RealType(0);
+            RealType acc = RealType(0);
+            const size_t base = e * NSCS;
+            for (int f = 0; f < NSCS; ++f) {
+                RealType X = axp[base+f], Y = ayp[base+f], Z = azp[base+f];
+                if (X*X > Y*Y + Z*Z) acc += X;
+            }
+            return acc;
+        };
+        auto pickMaster = [=] __device__ (size_t e) -> RealType { return sideAccPicker(e, 1); };
+        auto pickSlave  = [=] __device__ (size_t e) -> RealType { return sideAccPicker(e, 2); };
+        RealType locM = thrust::transform_reduce(thrust::device,
+                          thrust::counting_iterator<size_t>(startE),
+                          thrust::counting_iterator<size_t>(endE),
+                          pickMaster, RealType(0), thrust::plus<RealType>());
+        RealType locS = thrust::transform_reduce(thrust::device,
+                          thrust::counting_iterator<size_t>(startE),
+                          thrust::counting_iterator<size_t>(endE),
+                          pickSlave, RealType(0), thrust::plus<RealType>());
+        RealType lpair[2] = { locM, locS };
+        RealType gpair[2] = { RealType(0), RealType(0) };
+        MPI_Allreduce(lpair, gpair, 2, mt2, MPI_SUM, MPI_COMM_WORLD);
+        if (s.rank == 0) {
+            RealType M = gpair[0], S = gpair[1];
+            double ratio = (std::fabs((double)M) > 1e-30) ? double(S)/double(M) : 0.0;
+            std::cout << "  [seamax-probe] sum-x-dom-Ax  master(x=xmin)=" << M
+                      << "  slave(x=xmax)=" << S << "  ratio=S/M=" << ratio
+                      << "   (~ -1 => correct mirror; ~ +1 => SEAM SIGN FLIP)\n";
+        }
+    }
+    // Velocity matrix: nu * K assembled first (then we add M/dt and apply BC).
+    assembleLaplacian<KeyType, RealType, ElementTag>(s, s.d_node_to_dof, s.d_valuesVel, kernelVariant);
+    // The Laplacian above was assembled with gamma=1 -> raw K. Scale by nu for
+    // the diffusion matrix.
+    {
+        const RealType nuScale = nu;
+        RealType* valPtr = s.d_valuesVel.data();
+        thrust::for_each(thrust::device,
+                          thrust::counting_iterator<int>(0),
+                          thrust::counting_iterator<int>(s.nnz),
+                          [valPtr, nuScale] __device__ (int k) { valPtr[k] *= nuScale; });
+        cudaDeviceSynchronize();
+    }
+    pt.lap("assembly nu*K (velocity)");
+
+    // Cross-rank periodic seam: ship rank A's slave-row stiffness to the
+    // master-owner rank and accumulate into the master row. cstone delivers
+    // the periodic-image elements as halos, but the assembler's ownership
+    // gate skips them on the master-owner rank (the slave-image node is a
+    // ghost there). Without this MPI exchange the master row is missing
+    // ~70% of its off-diagonal stiffness. One-shot at setup. No-op when
+    // numRanks==1 or no cross-rank peers exist.
+    // Pressure matrix: same K (no nu scale). Assemble into d_valuesPre.
+    assembleLaplacian<KeyType, RealType, ElementTag>(s, s.d_node_to_dof, s.d_valuesPre, kernelVariant);
+    pt.lap("assembly K (pressure)");
+
+    // MARS_PERIODIC_FOLDCOUNT: telescoping check. Fold an all-ones field through the
+    // SAME maybePeriodicSum the physics uses. A telescoping fold deposits exactly
+    // group_size on every ultimate master and 0 on every slave, so the global sum
+    // over owned non-slave nodes MUST equal the total owned-node count. defect =
+    // global_master_sum - total_owned: 0 => telescopes; <0 => a seam node folded
+    // ZERO times (dropped); >0 => DOUBLE-folded. Build-time, env-gated, no physics.
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+        && s.periodicMap != nullptr
+        && std::getenv("MARS_PERIODIC_FOLDCOUNT") != nullptr)
+    {
+        cstone::DeviceVector<RealType> d_ones(s.nodeCount, RealType(1));
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_ones);
+        const uint8_t* ownPtr  = s.ownershipMap().data();
+        const int*     partPtr = s.periodicMap->d_periodicPartner.data();
+        const RealType* onesP  = d_ones.data();
+        double locSum = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+            [ownPtr, partPtr, onesP] __device__ (size_t i) -> double {
+                if (ownPtr[i] != 1 || partPtr[i] >= 0) return 0.0;  // slave folded away
+                return double(onesP[i]); }, 0.0, thrust::plus<double>());
+        double locMax = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+            [ownPtr, partPtr, onesP] __device__ (size_t i) -> double {
+                if (ownPtr[i] != 1 || partPtr[i] >= 0) return 0.0;
+                return double(onesP[i]); }, 0.0, thrust::maximum<double>());
+        long long locResid = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+            [ownPtr, partPtr, onesP] __device__ (size_t i) -> long long {
+                if (ownPtr[i] != 1 || partPtr[i] < 0) return 0LL;
+                return (onesP[i] != RealType(0)) ? 1LL : 0LL; }, 0LL, thrust::plus<long long>());
+        long long locOwned = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+            [ownPtr] __device__ (size_t i) -> long long { return (ownPtr[i] == 1) ? 1LL : 0LL; },
+            0LL, thrust::plus<long long>());
+        double gSum = 0, gMax = 0; long long gResid = 0, gOwned = 0;
+        MPI_Allreduce(&locSum, &gSum, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&locMax, &gMax, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+        MPI_Allreduce(&locResid, &gResid, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&locOwned, &gOwned, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        if (s.rank == 0)
+            std::cout << "[periodic-foldcount] global_master_sum=" << gSum
+                      << " expected(owned_nodes)=" << gOwned
+                      << " defect=" << (gSum - double(gOwned))
+                      << " max_master=" << gMax
+                      << " nonzero_slave_residual=" << gResid
+                      << "  (defect==0 && residual==0 => telescopes)\n";
+
+        // Over-fold breakdown: count owned non-slave masters whose accumulated
+        // value exceeds reasonable group_size thresholds. Triperiodic group
+        // sizes are 1 (interior), 2 (face), 4 (edge), 8 (corner). Anything
+        // above 8 is an over-fold. Counts and a dimensional split tell us
+        // which subset (face vs edge vs corner) is doubling.
+        const uint8_t* maskPtr = s.periodicMap->d_periodicMask.data();
+        long long lOver1=0, lOver2=0, lOver4=0, lOver8=0;
+        long long lG1=0, lG2=0, lG4=0, lG8=0;
+        auto countOver = [&](double thr) {
+            return thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+                [ownPtr, partPtr, onesP, thr] __device__ (size_t i) -> long long {
+                    if (ownPtr[i] != 1 || partPtr[i] >= 0) return 0LL;
+                    return (double(onesP[i]) > thr + 0.5) ? 1LL : 0LL;
+                }, 0LL, thrust::plus<long long>());
+        };
+        // Counts of owned-master nodes whose folded value EXCEEDS each threshold.
+        // Strict > so e.g. >1 catches a face master that double-summed (2 instead of 2... wait)
+        // -- triperiodic group sizes are 1/2/4/8 so a *correct* face master shows 2,
+        // edge master 4, corner master 8. We report counts ABOVE each canonical size.
+        lOver1 = countOver(1.0);   // >1 -> at least face-folded
+        lOver2 = countOver(2.0);   // >2 -> at least edge-folded
+        lOver4 = countOver(4.0);   // >4 -> at least corner-folded
+        lOver8 = countOver(8.0);   // >8 -> OVER-FOLDED, must be 0
+        // And exact group buckets (= per-mask popcount expectations):
+        auto countEq = [&](double tgt) {
+            return thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+                [ownPtr, partPtr, onesP, tgt] __device__ (size_t i) -> long long {
+                    if (ownPtr[i] != 1 || partPtr[i] >= 0) return 0LL;
+                    return (double(onesP[i]) > tgt - 0.5 && double(onesP[i]) < tgt + 0.5) ? 1LL : 0LL;
+                }, 0LL, thrust::plus<long long>());
+        };
+        lG1 = countEq(1.0);
+        lG2 = countEq(2.0);
+        lG4 = countEq(4.0);
+        lG8 = countEq(8.0);
+        long long gOver1=0,gOver2=0,gOver4=0,gOver8=0,gG1=0,gG2=0,gG4=0,gG8=0;
+        MPI_Allreduce(&lOver1, &gOver1, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&lOver2, &gOver2, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&lOver4, &gOver4, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&lOver8, &gOver8, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&lG1, &gG1, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&lG2, &gG2, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&lG4, &gG4, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&lG8, &gG8, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        if (s.rank == 0)
+            std::cout << "[periodic-foldcount] buckets eq{1,2,4,8}={"
+                      << gG1 << "," << gG2 << "," << gG4 << "," << gG8
+                      << "} over{1,2,4,8}={"
+                      << gOver1 << "," << gOver2 << "," << gOver4 << "," << gOver8
+                      << "}  (cube16 triperiodic expects eq1=interior,"
+                      << " eq2=#faces-2-folded, eq4=#edges-4-folded,"
+                      << " eq8=#corners-8-folded; over8==0 required)\n";
+        (void)maskPtr;
+    }
+
+    // Lumped mass (per-node + reverse-halo). Identical to B.2/B.3/B.4 pattern.
+    s.d_mass.resize(s.numOwnedDofs);
+    thrust::fill(thrust::device_pointer_cast(s.d_mass.data()),
+                 thrust::device_pointer_cast(s.d_mass.data() + s.numOwnedDofs),
+                 RealType(0));
+    // Persistent per-NODE lumped mass with halo-exchanged ghost values.
+    // Needed by the assembled-DDT preconditioner builder so face entries
+    // touching a ghost endpoint use the correct V_ghost (which lives on
+    // another rank). Without this, every assembled row that has a ghost
+    // neighbor is systematically wrong (entry magnitude ~halved), AMG sees
+    // an unbalanced operator, and DDT+Hypre diverges on cube16 step 1.
+    s.d_massNode.resize(s.nodeCount);
+    thrust::fill(thrust::device_pointer_cast(s.d_massNode.data()),
+                 thrust::device_pointer_cast(s.d_massNode.data() + s.nodeCount),
+                 RealType(0));
+    {
+        // OWNED-only per-element scatter + reverseExchangeNodeHaloAdd: standard
+        // pattern for cross-rank shared-FACE nodes. Periodic-pair cross-rank
+        // contributions are NOT routed this way (slave/master have distinct
+        // SFC keys, see domain.hpp comment around line 1607) -- a separate
+        // periodic-pair MPI exchange runs below.
+        size_t startElem = s.domain.startIndex();
+        size_t numLocal  = s.domain.localElementCount();
+        if (numLocal > 0)
+        {
+            int eBlocks = int((numLocal + s.blockSize - 1) / s.blockSize);
+            auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+            if constexpr (std::is_same_v<ElementTag, HexTag>)
+                computeLumpedMassPerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    cp[0], cp[1], cp[2], cp[3], cp[4], cp[5], cp[6], cp[7],
+                    d_x.data(), d_y.data(), d_z.data(),
+                    s.d_massNode.data(), startElem, numLocal);
+            else
+                computeLumpedMassPerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    cp[0], cp[1], cp[2], cp[3], nullptr, nullptr, nullptr, nullptr,
+                    d_x.data(), d_y.data(), d_z.data(),
+                    s.d_massNode.data(), startElem, numLocal);
+            cudaDeviceSynchronize();
+        }
+        s.domain.reverseExchangeNodeHaloAdd(s.d_massNode);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, s.d_massNode);
+        // Forward halo: ghost slots get owner-rank V values so DDT assembler
+        // can read s.d_massNode[ghostNode] and get the correct V.
+        s.domain.exchangeNodeHalo(s.d_massNode);
+        int nBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+        gatherOwnedNodeMassToDofKernel<RealType><<<nBlocks, s.blockSize>>>(
+            s.d_massNode.data(),
+            s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            s.d_mass.data(), s.nodeCount, s.numOwnedDofs);
+        cudaDeviceSynchronize();
+
+        // Periodic seam mass mirror (AFTER the DOF gather, never before).
+        // maybePeriodicSum folded each slave's mass onto its master and set
+        // d_massNode[slave]=0. That zero makes normalizeGradientPerNodeKernel hit
+        // m==0 and ZERO the gradient/divergence at every owned slave node -- so the
+        // reduced operator A's internal D drops the seam slave-side flux while the
+        // physical/probe D (which reads the live velocity at the slave) keeps it.
+        // A is then a self-consistent symmetric operator (CG solves it to 1e-11)
+        // but NOT the true periodic D M^-1 D^T: the corrector leaves u[slave]
+        // uncorrected and only ~half the divergence is removed (PROJ-P3 ~0.5).
+        // Mirror the combined mass back onto the slave so every per-NODE mass
+        // consumer (A's M^-1, the corrector's M^-1, the RHS divergence normalize,
+        // the DDT diagonal, the probe) sees the same non-zero seam mass and the
+        // seam faces come alive. Done AFTER gatherOwnedNodeMassToDofKernel so the
+        // per-DOF mass d_mass (built once here, never re-derived from
+        // d_massNode[slave] later) is NOT double-counted: the gather already summed
+        // master+slave geometric mass into the single collapsed DOF. For a
+        // cross-rank pair the master is a ghost the forward halo above filled, so
+        // the broadcast reads the right value there too.
+        if (s.periodicMap)
+        {
+            mars::fem::periodicBroadcastKernel<<<nBlocks, s.blockSize>>>(
+                s.periodicMap->d_periodicPartner.data(), s.nodeCount, s.d_massNode.data());
+            cudaDeviceSynchronize();
+            // Re-sync ghost slots: a cross-rank master-ghost slave just got the
+            // master value; keep ghost copies consistent for the assembler.
+            s.domain.exchangeNodeHalo(s.d_massNode);
+
+            // CROSS_RANK_SLAVE_MASS_ZERO_PROBE
+            // Count owned periodic slaves with partner==-1 (no local master)
+            // AND mass==0 after the broadcast: those are cross-rank slaves the
+            // mirror could not reach. One Allreduce, rank-0 prints a tuple.
+            // Hex+Periodic+env-gated -- tet/pump never reach this branch.
+            if constexpr (std::is_same_v<ElementTag, HexTag>) {
+                if (std::getenv("MARS_XRANK_SLAVE_MASS_PROBE") != nullptr) {
+                    const uint8_t* ownPtr   = d_nodeOwnership.data();
+                    const uint8_t* maskPtr  = s.periodicMap->d_periodicMask.data();
+                    const int*     partPtr  = s.periodicMap->d_periodicPartner.data();
+                    const RealType* mPtr    = s.d_massNode.data();
+                    const size_t nN = s.nodeCount;
+                    long long localZeroSlaves = thrust::transform_reduce(thrust::device,
+                        thrust::counting_iterator<size_t>(0),
+                        thrust::counting_iterator<size_t>(nN),
+                        [ownPtr, maskPtr, partPtr, mPtr] __device__ (size_t i) -> long long {
+                            if (ownPtr[i] != 1) return 0;
+                            if (maskPtr[i] == 0) return 0;
+                            if (partPtr[i] >= 0) return 0;
+                            return (double(mPtr[i]) < 1e-30) ? 1 : 0;
+                        }, (long long)0, thrust::plus<long long>());
+                    double localMaxMirroredMass = thrust::transform_reduce(thrust::device,
+                        thrust::counting_iterator<size_t>(0),
+                        thrust::counting_iterator<size_t>(nN),
+                        [ownPtr, maskPtr, partPtr, mPtr] __device__ (size_t i) -> double {
+                            if (ownPtr[i] != 1 || maskPtr[i] == 0 || partPtr[i] < 0) return 0.0;
+                            return double(mPtr[i]);
+                        }, 0.0, thrust::maximum<double>());
+                    long long localOwnedSlaves = thrust::transform_reduce(thrust::device,
+                        thrust::counting_iterator<size_t>(0),
+                        thrust::counting_iterator<size_t>(nN),
+                        [ownPtr, maskPtr] __device__ (size_t i) -> long long {
+                            return (ownPtr[i] == 1 && maskPtr[i] != 0) ? 1 : 0;
+                        }, (long long)0, thrust::plus<long long>());
+                    long long gZeroSlaves = 0, gOwnedSlaves = 0;
+                    double gMaxMirroredMass = 0.0;
+                    MPI_Allreduce(&localZeroSlaves, &gZeroSlaves, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+                    MPI_Allreduce(&localMaxMirroredMass, &gMaxMirroredMass, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+                    MPI_Allreduce(&localOwnedSlaves, &gOwnedSlaves, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+                    if (s.rank == 0) {
+                        std::cout << "  [XRANK-SLAVE-MASS] numCrossRankSlavesWithZeroMass="
+                                  << gZeroSlaves
+                                  << "  totalOwnedSlavesGlobal=" << gOwnedSlaves
+                                  << "  maxMassOnPartneredOwnedSlave=" << std::scientific
+                                  << std::setprecision(6) << gMaxMirroredMass << std::defaultfloat
+                                  << "\n";
+                    }
+                }
+            }
+        }
+
+        // DIAGNOSTIC: total control volume = sum of OWNED-node lumped mass over
+        // ALL ranks. This MUST equal the single-rank total (the domain volume) --
+        // it is rank-count-invariant. If multi-rank sum < single-rank, boundary
+        // nodes are MISSING off-rank element volume => their 1/V_i is too large
+        // => grad(p) and the corrector blow up there (seen as |gP|max ~ 1e4).
+        {
+            const uint8_t* ownPtr = d_nodeOwnership.data();
+            const RealType* mP    = s.d_massNode.data();
+            // Skip periodic-slave nodes: after the seam mass mirror they carry the
+            // SAME combined mass as their master, so counting both would double the
+            // seam volume and break the "= domain volume" invariant. The slave's
+            // mass is already represented in its master (and its DOF). partner>=0
+            // marks a slave.
+            const int* partnerP = s.periodicMap ? s.periodicMap->d_periodicPartner.data() : nullptr;
+            double localMass = thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0),
+                thrust::counting_iterator<size_t>(s.nodeCount),
+                [ownPtr, mP, partnerP] __device__ (size_t i) -> double {
+                    if (ownPtr[i] != 1) return 0.0;
+                    if (partnerP && partnerP[i] >= 0) return 0.0;  // slave -> counted via master
+                    return double(mP[i]);
+                }, 0.0, thrust::plus<double>());
+            double globalMass = 0;
+            MPI_Allreduce(&localMass, &globalMass, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+            if (s.rank == 0)
+                std::cout << "  [mass-sum check] sum(owned d_massNode over ranks)=" << std::scientific
+                          << std::setprecision(8) << globalMass << std::defaultfloat
+                          << "  (rank-count-INVARIANT = domain volume; if 4-rank < 1-rank, "
+                          << "boundary nodes miss off-rank volume)\n";
+        }
+    }
+    pt.lap("lumped mass");
+
+    // Optional: print min/max/mean of d_mass + count of slots at "full" mass
+    // (= V_e for the unit-mesh cube16 case) vs "half" mass. Distinguishes
+    // periodic-pair sums "actually happening" from "missing".
+    if (std::getenv("MARS_PERIODIC_HALO_DBG") != nullptr)
+    {
+        thrust::host_vector<RealType> h_mass(s.numOwnedDofs);
+        thrust::copy(thrust::device_pointer_cast(s.d_mass.data()),
+                     thrust::device_pointer_cast(s.d_mass.data() + s.numOwnedDofs),
+                     h_mass.begin());
+        double lmin = 1e30, lmax = -1e30, lsum = 0.0;
+        for (size_t i = 0; i < h_mass.size(); ++i) {
+            double v = double(h_mass[i]);
+            if (v < lmin) lmin = v;
+            if (v > lmax) lmax = v;
+            lsum += v;
+        }
+        double gmin, gmax, gsum;
+        long long lcount = (long long)h_mass.size(), gcount = 0;
+        MPI_Reduce(&lmin, &gmin, 1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+        MPI_Reduce(&lmax, &gmax, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+        MPI_Reduce(&lsum, &gsum, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+        MPI_Reduce(&lcount, &gcount, 1, MPI_LONG_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+        if (s.rank == 0) {
+            std::cout << "[DBG mass] global owned-DOF count=" << gcount
+                      << std::scientific << std::setprecision(6)
+                      << " min=" << gmin
+                      << " max=" << gmax
+                      << " sum=" << gsum
+                      << std::defaultfloat
+                      << " (expected for cube16/unit-box: sum=1.0; full V_e ~ 2.44e-4; half V_e ~ 1.22e-4)\n";
+        }
+    }
+
+    // Assemble the matrix-free DDT operator into a CSR matrix with the
+    // DEDICATED two-hop-through-shared-node sparsity. The operator
+    // A = D M^-1 D^T couples pairs (r,c) of nodes that share ANY face-endpoint
+    // i, INCLUDING the case where r and c live in different hex elements
+    // that share only the corner i. buildFullSparsity only emits intra-element
+    // pairs, so cross-element pairs that the assembler kernel writes get
+    // silently dropped by atomicAddSparseEntry's binary search. The dedicated
+    // buildDDTSparsity uses the same node->element CSR the assembler uses
+    // and emits exactly the pairs the assembler writes; verified bit-exact
+    // against applyDDTPerNode via MARS_DDT_PROBE_DIFF=1.
+    //
+    // Hex-only: buildDDTSparsity / assembleDDTPerNodeKernel spell std::get<7>
+    // and the fixed hex 8-corner / nodeFaces[8][3] incidence. The tet DDT
+    // operator is a separate follow-up; if constexpr keeps the whole block
+    // (sparsity, node-driven assembly, health check, diagonal shift) out of
+    // the tet compile entirely.
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    {
+    const auto& d_n2eOff_sparsity  = s.domain.getNodeToElementOffsets();
+    const auto& d_n2eList_sparsity = s.domain.getNodeToElementList();
+    s.d_rowPtrDDT.resize(s.numTotalDofs + 1);
+    s.d_diagPtrDDT.resize(s.numTotalDofs);
+    s.nnzDDT = CvfemSparsityBuilder<KeyType>::buildDDTSparsity(
+        std::get<0>(d_conn).data(), std::get<1>(d_conn).data(), std::get<2>(d_conn).data(),
+        std::get<3>(d_conn).data(), std::get<4>(d_conn).data(), std::get<5>(d_conn).data(),
+        std::get<6>(d_conn).data(), std::get<7>(d_conn).data(),
+        s.elementCount, s.nodeCount,
+        d_n2eOff_sparsity.data(), d_n2eList_sparsity.data(),
+        s.d_node_to_dof.data(), s.numTotalDofs,
+        s.d_rowPtrDDT.data(), nullptr, nullptr, 0);
+    s.d_colIndDDT.resize(s.nnzDDT);
+    CvfemSparsityBuilder<KeyType>::buildDDTSparsity(
+        std::get<0>(d_conn).data(), std::get<1>(d_conn).data(), std::get<2>(d_conn).data(),
+        std::get<3>(d_conn).data(), std::get<4>(d_conn).data(), std::get<5>(d_conn).data(),
+        std::get<6>(d_conn).data(), std::get<7>(d_conn).data(),
+        s.elementCount, s.nodeCount,
+        d_n2eOff_sparsity.data(), d_n2eList_sparsity.data(),
+        s.d_node_to_dof.data(), s.numTotalDofs,
+        s.d_rowPtrDDT.data(), s.d_colIndDDT.data(), s.d_diagPtrDDT.data(), 0);
+    s.d_valuesDDT.resize(s.nnzDDT);
+    thrust::fill(thrust::device_pointer_cast(s.d_valuesDDT.data()),
+                 thrust::device_pointer_cast(s.d_valuesDDT.data() + s.nnzDDT),
+                 RealType(0));
+    {
+        // Node-driven assembly: one thread per OWNED node i, gather all
+        // SCS faces incident to i via the node->element CSR (which spans
+        // local + halo elements), enumerate all face pairs (g, f), and
+        // contribute analytically. Captures cross-element face pairs that
+        // a per-element kernel would miss because of the per-node M^-1
+        // step in applyDDTPerNode (root cause documented above the kernel).
+        const auto& d_n2eOff  = s.domain.getNodeToElementOffsets();
+        const auto& d_n2eList = s.domain.getNodeToElementList();
+        if (s.nodeCount > 0)
+        {
+            int nBlocks = int((s.nodeCount + s.blockSize - 1) / s.blockSize);
+            assembleDDTPerNodeKernel<KeyType, RealType><<<nBlocks, s.blockSize>>>(
+                std::get<0>(d_conn).data(), std::get<1>(d_conn).data(),
+                std::get<2>(d_conn).data(), std::get<3>(d_conn).data(),
+                std::get<4>(d_conn).data(), std::get<5>(d_conn).data(),
+                std::get<6>(d_conn).data(), std::get<7>(d_conn).data(),
+                s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                d_n2eOff.data(), d_n2eList.data(),
+                s.d_node_to_dof.data(), d_nodeOwnership.data(),
+                s.d_massNode.data(),
+                s.d_rowPtrDDT.data(), s.d_colIndDDT.data(), s.numOwnedDofs,
+                s.d_valuesDDT.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+        }
+        // Post-assembly health check: every owned row must have a non-zero
+        // diagonal entry (Hypre BoomerAMG strength-of-connection asserts on
+        // |A[i,i]| > 0; missing or zero diag is a documented cause of
+        // HYPRE_ERROR_GENERIC on setup). Run on rank 0 only since this is
+        // a structural property -- all ranks should see the same answer for
+        // their own owned rows. (Print only if a defect is found.)
+        if (s.rank == 0)
+        {
+            std::vector<int> hRowPtr(s.numOwnedDofs + 1);
+            cudaMemcpy(hRowPtr.data(), s.d_rowPtrDDT.data(),
+                       (s.numOwnedDofs + 1) * sizeof(int), cudaMemcpyDeviceToHost);
+            std::vector<int> hColInd(hRowPtr[s.numOwnedDofs]);
+            std::vector<RealType> hVals(hRowPtr[s.numOwnedDofs]);
+            cudaMemcpy(hColInd.data(), s.d_colIndDDT.data(),
+                       hRowPtr[s.numOwnedDofs] * sizeof(int), cudaMemcpyDeviceToHost);
+            cudaMemcpy(hVals.data(), s.d_valuesDDT.data(),
+                       hRowPtr[s.numOwnedDofs] * sizeof(RealType), cudaMemcpyDeviceToHost);
+            int emptyRows = 0, missingDiag = 0, zeroDiag = 0, negDiag = 0;
+            int firstEmpty = -1, firstMissingDiag = -1;
+            RealType minDiag = 1e30, maxDiag = -1e30;
+            for (int r = 0; r < s.numOwnedDofs; ++r)
+            {
+                int rs = hRowPtr[r], re = hRowPtr[r + 1];
+                if (re == rs) { emptyRows++; if (firstEmpty<0) firstEmpty=r; continue; }
+                int diagIdx = -1;
+                for (int k = rs; k < re; ++k) if (hColInd[k] == r) { diagIdx = k; break; }
+                if (diagIdx < 0) {
+                    missingDiag++;
+                    if (firstMissingDiag<0) firstMissingDiag=r;
+                    continue;
+                }
+                RealType d = hVals[diagIdx];
+                if (d == RealType(0)) zeroDiag++;
+                else if (d < RealType(0)) negDiag++;
+                if (d < minDiag) minDiag = d;
+                if (d > maxDiag) maxDiag = d;
+            }
+            std::cout << "  [DDT-health] emptyRows=" << emptyRows
+                      << " missingDiag=" << missingDiag
+                      << " zeroDiag=" << zeroDiag
+                      << " negDiag=" << negDiag
+                      << " diag range=[" << minDiag << ", " << maxDiag << "]\n";
+            if (emptyRows > 0)
+                std::cout << "    first empty row: " << firstEmpty << "\n";
+            if (missingDiag > 0)
+                std::cout << "    first missing-diag row: " << firstMissingDiag << "\n";
+        }
+    }
+    pt.lap("assembly D M^-1 D^T (node-driven, 27-NNZ)");
+
+    // Optional diagonal shift on the DDT matrix: A := A + eps * I. Hypre PCG
+    // strictly requires SPD. D M^-1 D^T is SPSD (constant mode in nullspace);
+    // even with the pin BC, near-null modes survive in finite precision and
+    // trigger PCG's pAp <= 0 check, returning error 1. A small diagonal shift
+    // breaks the null mode (operator becomes A + eps*I with smallest eigenvalue
+    // >= eps > 0) at the cost of perturbing the projection slightly. Default
+    // 0 (no shift); set env MARS_DDT_DIAG_SHIFT=1e-10 to enable.
+    {
+        const char* shiftEnv = std::getenv("MARS_DDT_DIAG_SHIFT");
+        RealType eps = (shiftEnv) ? RealType(std::atof(shiftEnv)) : RealType(0);
+        if (eps > RealType(0))
+        {
+            int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+            const int* dpDdt = s.d_diagPtrDDT.data();
+            RealType* vDdt   = s.d_valuesDDT.data();
+            int n            = s.numOwnedDofs;
+            thrust::for_each(thrust::device,
+                thrust::counting_iterator<int>(0),
+                thrust::counting_iterator<int>(n),
+                [dpDdt, vDdt, eps] __device__ (int r) {
+                    vDdt[dpDdt[r]] += eps;
+                });
+            cudaDeviceSynchronize();
+            if (s.rank == 0)
+                std::cout << "  [DDT] diagonal shift A := A + "
+                          << std::scientific << eps << " * I (Hypre SPD regularization)\n"
+                          << std::defaultfloat;
+        }
+    }
+    } // end if constexpr hex (DDT operator block)
+
+    // Add M/dt to the velocity matrix diagonal -> (M/dt + nu K).
+    {
+        int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+        addLumpedMassDiagonalKernel<RealType><<<dofBlocks, s.blockSize>>>(
+            s.d_mass.data(), s.d_diagPtr.data(), RealType(1) / dt,
+            s.d_valuesVel.data(), s.numOwnedDofs);
+        cudaDeviceSynchronize();
+    }
+    pt.lap("add M/dt (velocity)");
+
+    // DIAGNOSTIC: velocity diffusion matrix (nu K + M/dt) INTERIOR-row consistency
+    // across ranks. K is a Laplacian -> its rows sum ~0, so each interior row of
+    // (nu K + M/dt) sums to ~ mass[row]/dt -- a PHYSICAL, rank-count-INVARIANT
+    // value. The matrix is assembled over OWNED+HALO elements; if a halo element
+    // is double-counted (or an owned row's stencil differs across ranks), the
+    // interior row-sum will DIFFER on 4 ranks vs 1 -> the diffusion solve injects
+    // a bulk perturbation every step (suspected cause of div(u*) 17x on 4 ranks).
+    // We report global max |rowsum - mass/dt| over interior owned rows: ~0 if
+    // assembly is rank-consistent, large if not.
+    {
+        // Compare the velocity-matrix DIAGONAL (nu K_diag + mass/dt) across ranks
+        // on a per-DOF basis. Uses d_diagPtr indirection -- the SAME proven-safe
+        // indexing as addLumpedMassDiagonalKernel above (diagPtr[dof], guarded
+        // dp>=0) -- so no rowPtr walk (that crashed: tet rowPtr layout is not a
+        // plain owned-row CSR here). We report max and SUM of the K-diagonal
+        // part (diag - mass/dt) over owned DOFs; both are rank-count-INVARIANT if
+        // the owned+halo assembly is consistent. A rank-VARYING sum => an owned
+        // row's stencil differs across ranks (suspected div(u*) 17x cause).
+        const int* dptr      = s.d_diagPtr.data();
+        const RealType* vv   = s.d_valuesVel.data();
+        const RealType* mass = s.d_mass.data();
+        RealType invdt = RealType(1) / dt;
+        double localKsum = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<int>(0),
+            thrust::counting_iterator<int>(s.numOwnedDofs),
+            [dptr, vv, mass, invdt] __device__ (int r) -> double {
+                int dp = dptr[r];
+                if (dp < 0) return 0.0;
+                return double(vv[dp] - mass[r] * invdt);   // nu*K diagonal part
+            }, 0.0, thrust::plus<double>());
+        RealType localKmax = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<int>(0),
+            thrust::counting_iterator<int>(s.numOwnedDofs),
+            [dptr, vv, mass, invdt] __device__ (int r) -> RealType {
+                int dp = dptr[r];
+                if (dp < 0) return RealType(0);
+                return fabs(vv[dp] - mass[r] * invdt);
+            }, RealType(0), thrust::maximum<RealType>());
+        auto mt = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+        double gKsum = 0; RealType gKmax = 0;
+        MPI_Allreduce(&localKsum, &gKsum, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&localKmax, &gKmax, 1, mt, MPI_MAX, MPI_COMM_WORLD);
+        if (s.rank == 0)
+            std::cout << "  [Avel-diag check] sum(nu*K_diag over owned)=" << std::scientific
+                      << std::setprecision(8) << gKsum << "  max=" << gKmax << std::defaultfloat
+                      << "  (BOTH rank-count-INVARIANT if owned+halo assembly is consistent; "
+                      << "rank-varying => the bug)\n";
+    }
+
+    // Probe: dump master row stats on each rank that owns masters. Gated by
+    // MARS_PERIODIC_AVEL_DBG=1. Distinguishes:
+    //   (a) diag == expected single-rank value + sumAbsOff > 0 -> seam coupling
+    //       made it into the master row. Bug is elsewhere.
+    //   (b) diag << expected -> slave-side stiffness never reached master row.
+    //       Either cstone didn't deliver the periodic-image element to this
+    //       rank, OR the assembler on this rank skipped its scatter.
+    if (std::getenv("MARS_PERIODIC_AVEL_DBG") != nullptr
+        && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+        && s.periodicMap != nullptr
+        && !s.periodicMap->cross_.d_recvOwnedMasterIds_.empty())
+    {
+        const auto& xr = s.periodicMap->cross_;
+        int firstMasterNode = -1;
+        cudaMemcpy(&firstMasterNode, xr.d_recvOwnedMasterIds_.data(),
+                   sizeof(int), cudaMemcpyDeviceToHost);
+        if (firstMasterNode >= 0 && firstMasterNode < int(s.nodeCount))
+        {
+            int masterDof = -1;
+            cudaMemcpy(&masterDof, s.d_node_to_dof.data() + firstMasterNode,
+                       sizeof(int), cudaMemcpyDeviceToHost);
+            if (masterDof >= 0 && masterDof < s.numOwnedDofs)
+            {
+                int rowOff[2] = {0, 0};
+                cudaMemcpy(rowOff, s.d_rowPtr.data() + masterDof,
+                           2 * sizeof(int), cudaMemcpyDeviceToHost);
+                int rowLen = rowOff[1] - rowOff[0];
+                std::vector<RealType> rowVals(rowLen);
+                cudaMemcpy(rowVals.data(),
+                           s.d_valuesVel.data() + rowOff[0],
+                           rowLen * sizeof(RealType), cudaMemcpyDeviceToHost);
+                int diagIdx = -1;
+                cudaMemcpy(&diagIdx, s.d_diagPtr.data() + masterDof,
+                           sizeof(int), cudaMemcpyDeviceToHost);
+                double diag = 0.0, sumAbsOff = 0.0, maxAbsOff = 0.0;
+                int nnzOff = 0;
+                int diagLocal = diagIdx - rowOff[0];
+                for (int j = 0; j < rowLen; ++j)
+                {
+                    double v = double(rowVals[j]);
+                    if (j == diagLocal) { diag = v; }
+                    else if (v != 0.0)
+                    {
+                        ++nnzOff;
+                        sumAbsOff += std::fabs(v);
+                        if (std::fabs(v) > maxAbsOff) maxAbsOff = std::fabs(v);
+                    }
+                }
+                std::cerr << "[avel-probe rank " << s.rank
+                          << "] masterNode=" << firstMasterNode
+                          << " masterDof=" << masterDof
+                          << " rowLen=" << rowLen
+                          << " diag=" << diag
+                          << " nnzOff=" << nnzOff
+                          << " sumAbsOff=" << sumAbsOff
+                          << " maxAbsOff=" << maxAbsOff
+                          << " (expect interior diag ~ 2.45 nnzOff~17 sumAbs~0.04)"
+                          << std::endl;
+            }
+        }
+    }
+
+    // BDF2 velocity matrix: same K but with mass coefficient 3/(2 dt) instead
+    // of 1/dt. Built as a copy of d_valuesVel BEFORE M/dt was added, then
+    // M-diagonal increment of 3/(2 dt). Equivalently: start from current
+    // d_valuesVel (which has M/dt added) and add an EXTRA 1/(2 dt) of mass
+    // to upgrade the diagonal from M/dt to 3M/(2 dt).
+    if (s.useBdf2)
+    {
+        s.d_valuesVel_bdf2.resize(s.d_valuesVel.size());
+        thrust::copy(thrust::device,
+                     s.d_valuesVel.begin(), s.d_valuesVel.end(),
+                     s.d_valuesVel_bdf2.begin());
+        int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+        addLumpedMassDiagonalKernel<RealType><<<dofBlocks, s.blockSize>>>(
+            s.d_mass.data(), s.d_diagPtr.data(), RealType(1) / (RealType(2) * dt),
+            s.d_valuesVel_bdf2.data(), s.numOwnedDofs);
+        cudaDeviceSynchronize();
+        pt.lap("BDF2 velocity matrix (3M/(2dt) + nu K)");
+    }
+
+    // Global bounding box for BC marking. Reduce locally then MPI_Allreduce.
+    auto xb = thrust::device_pointer_cast(d_x.data());
+    auto yb = thrust::device_pointer_cast(d_y.data());
+    auto zb = thrust::device_pointer_cast(d_z.data());
+    RealType lxmin = thrust::reduce(thrust::device, xb, xb + s.nodeCount, RealType(1e30),  thrust::minimum<RealType>());
+    RealType lxmax = thrust::reduce(thrust::device, xb, xb + s.nodeCount, RealType(-1e30), thrust::maximum<RealType>());
+    RealType lymin = thrust::reduce(thrust::device, yb, yb + s.nodeCount, RealType(1e30),  thrust::minimum<RealType>());
+    RealType lymax = thrust::reduce(thrust::device, yb, yb + s.nodeCount, RealType(-1e30), thrust::maximum<RealType>());
+    RealType lzmin = thrust::reduce(thrust::device, zb, zb + s.nodeCount, RealType(1e30),  thrust::minimum<RealType>());
+    RealType lzmax = thrust::reduce(thrust::device, zb, zb + s.nodeCount, RealType(-1e30), thrust::maximum<RealType>());
+
+    auto mpiType = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+    MPI_Allreduce(&lxmin, &s.xmin, 1, mpiType, MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(&lxmax, &s.xmax, 1, mpiType, MPI_MAX, MPI_COMM_WORLD);
+    MPI_Allreduce(&lymin, &s.ymin, 1, mpiType, MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(&lymax, &s.ymax, 1, mpiType, MPI_MAX, MPI_COMM_WORLD);
+    MPI_Allreduce(&lzmin, &s.zmin, 1, mpiType, MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(&lzmax, &s.zmax, 1, mpiType, MPI_MAX, MPI_COMM_WORLD);
+    s.bboxEps = RealType(1e-10) * std::max({s.xmax - s.xmin, s.ymax - s.ymin, s.zmax - s.zmin});
+    pt.lap("global bbox");
+
+    // BC mask + cavity target velocity.
+    s.d_isBdryDof.resize(s.numOwnedDofs);
+    thrust::fill(thrust::device_pointer_cast(s.d_isBdryDof.data()),
+                 thrust::device_pointer_cast(s.d_isBdryDof.data() + s.numOwnedDofs),
+                 uint8_t(0));
+    s.d_uTarget.resize(s.nodeCount);
+    s.d_vTarget.resize(s.nodeCount);
+    s.d_wTarget.resize(s.nodeCount);
+    {
+        int nBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+        using BCK = typename NSStepper<KeyType, RealType, ElementTag>::BCKind;
+        if (s.bcKind == BCK::Cavity)
+        {
+            markCavityBCKernel<RealType><<<nBlocks, s.blockSize>>>(
+                d_x.data(), d_y.data(), d_z.data(),
+                d_nodeOwnership.data(), s.d_node_to_dof.data(),
+                s.d_isBdryDof.data(),
+                s.d_uTarget.data(), s.d_vTarget.data(), s.d_wTarget.data(),
+                s.nodeCount, s.xmin, s.xmax, s.ymin, s.ymax, s.zmin, s.zmax,
+                s.bboxEps, s.lidU, s.numOwnedDofs);
+        }
+        else if (s.bcKind == BCK::Channel)
+        {
+            markChannelBCKernel<RealType><<<nBlocks, s.blockSize>>>(
+                d_x.data(), d_y.data(), d_z.data(),
+                d_nodeOwnership.data(), s.d_node_to_dof.data(),
+                s.d_isBdryDof.data(),
+                s.d_uTarget.data(), s.d_vTarget.data(), s.d_wTarget.data(),
+                s.nodeCount, s.xmin, s.xmax, s.ymin, s.ymax, s.zmin, s.zmax,
+                s.bboxEps, s.Uinf, s.numOwnedDofs);
+        }
+        else if (s.bcKind == BCK::Pump)
+        {
+            // BC: per-side-set Dirichlet driven by the local-node lists
+            // populated by the driver. Build host arrays then copy to device:
+            //   - isBdryDof[dof] = 1 for nodes on walls/inlet/extra.
+            //   - uTarget/vTarget/wTarget per side-set.
+            // Pressure BC (outlet) is handled in the pressure-BC block below.
+            std::vector<uint8_t> hostIsBdry(s.numOwnedDofs, 0);
+            std::vector<RealType> hostUTgt(s.nodeCount, RealType(0));
+            std::vector<RealType> hostVTgt(s.nodeCount, RealType(0));
+            std::vector<RealType> hostWTgt(s.nodeCount, RealType(0));
+            // Mirror node_to_dof + ownership to host so we can resolve DOF IDs.
+            std::vector<int> hostNodeToDof(s.nodeCount, -1);
+            std::vector<uint8_t> hostOwn(s.nodeCount, 0);
+            thrust::copy(thrust::device_pointer_cast(s.d_node_to_dof.data()),
+                         thrust::device_pointer_cast(s.d_node_to_dof.data() + s.nodeCount),
+                         hostNodeToDof.begin());
+            thrust::copy(thrust::device_pointer_cast(d_nodeOwnership.data()),
+                         thrust::device_pointer_cast(d_nodeOwnership.data() + s.nodeCount),
+                         hostOwn.begin());
+
+            auto tag = [&] (const std::vector<int>& nodes, RealType u, RealType v, RealType w) {
+                for (int li : nodes)
+                {
+                    if (li < 0 || (size_t)li >= s.nodeCount) continue;
+                    // Target velocity is set on EVERY local copy (owned or ghost)
+                    // so predictor/corrector see consistent values across rank
+                    // boundaries.
+                    hostUTgt[li] = u;
+                    hostVTgt[li] = v;
+                    hostWTgt[li] = w;
+                    // Dirichlet mask is per OWNED DOF only.
+                    if (hostOwn[li] != 1) continue;
+                    int dof = hostNodeToDof[li];
+                    if (dof < 0 || dof >= s.numOwnedDofs) continue;
+                    hostIsBdry[dof] = 1;
+                }
+            };
+            tag(s.wallNodes,    RealType(0),     RealType(0), RealType(0));
+            tag(s.inletNodes,   RealType(s.Uinf * s.inletDirX),
+                                RealType(s.Uinf * s.inletDirY),
+                                RealType(s.Uinf * s.inletDirZ));
+            tag(s.extraNodes,   RealType(s.Uinf), RealType(0), RealType(0));
+            // Mass-conserving outlet: velocity-Dirichlet outflow along the
+            // outward normal, sized to remove the inlet flux. Only when the
+            // driver set outletU > 0; otherwise the outlet stays natural-Neumann
+            // (legacy) and only gets the p=0 pressure Dirichlet below.
+            if (s.outletU > RealType(0))
+                tag(s.outletNodes, RealType(s.outletU * s.outletDirX),
+                                       RealType(s.outletU * s.outletDirY),
+                                       RealType(s.outletU * s.outletDirZ));
+
+            thrust::copy(hostIsBdry.begin(), hostIsBdry.end(),
+                         thrust::device_pointer_cast(s.d_isBdryDof.data()));
+            thrust::copy(hostUTgt.begin(), hostUTgt.end(),
+                         thrust::device_pointer_cast(s.d_uTarget.data()));
+            thrust::copy(hostVTgt.begin(), hostVTgt.end(),
+                         thrust::device_pointer_cast(s.d_vTarget.data()));
+            thrust::copy(hostWTgt.begin(), hostWTgt.end(),
+                         thrust::device_pointer_cast(s.d_wTarget.data()));
+            if (s.rank == 0)
+            {
+                std::cout << "  BC: " << s.wallNodes.size()  << " wall nodes (no-slip), "
+                          << s.inletNodes.size() << " inlet nodes (u=" << s.Uinf << "), "
+                          << s.extraNodes.size() << " extra nodes (u=" << s.Uinf << ")\n";
+            }
+        }
+        // Periodic: no boundary DOFs (mask stays zero) and no per-node targets
+        // (targets stay zero; predictor/corrector write the field on every node).
+        cudaDeviceSynchronize();
+    }
+
+    // DIAGNOSTIC: global count of OWNED Dirichlet-velocity DOFs (d_isBdryDof==1)
+    // and the owned-sum of |uTarget|^2. Both are rank-count-INVARIANT: a global
+    // node is owned by exactly one rank, so summed over ranks the tagged-DOF
+    // count and the target energy must MATCH the single-rank values. If 4-rank
+    // differs from 1-rank, BC nodes are being dropped or double-counted across
+    // ranks -- the direct cause of u* (and KE*) differing from step 1.
+    {
+        const uint8_t* bnd = s.d_isBdryDof.data();
+        long long locBnd = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<int>(0),
+            thrust::counting_iterator<int>(s.numOwnedDofs),
+            [bnd] __device__ (int d) -> long long { return bnd[d] ? 1LL : 0LL; },
+            0LL, thrust::plus<long long>());
+        // owned-sum of |uTarget|^2 over Dirichlet nodes (positive => no cancel).
+        const uint8_t* ownPtr = d_nodeOwnership.data();
+        const int* dofPtr     = s.d_node_to_dof.data();
+        const uint8_t* bnode  = (s.d_isBdryNode.size() == s.nodeCount) ? s.d_isBdryNode.data() : nullptr;
+        const RealType* uT = s.d_uTarget.data();
+        const RealType* vT = s.d_vTarget.data();
+        const RealType* wT = s.d_wTarget.data();
+        double locTgt = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0),
+            thrust::counting_iterator<size_t>(s.nodeCount),
+            [ownPtr, dofPtr, uT, vT, wT] __device__ (size_t i) -> double {
+                if (ownPtr[i] != 1 || dofPtr[i] < 0) return 0.0;
+                double u = uT[i], v = vT[i], w = wT[i];
+                return u*u + v*v + w*w;
+            }, 0.0, thrust::plus<double>());
+        (void)bnode;
+        long long gBnd = 0; double gTgt = 0;
+        MPI_Allreduce(&locBnd, &gBnd, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&locTgt, &gTgt, 1, MPI_DOUBLE,    MPI_SUM, MPI_COMM_WORLD);
+        if (s.rank == 0)
+            std::cout << "  [bc-count check] owned Dirichlet-vel DOFs (sum over ranks)=" << gBnd
+                      << "  sum|uTarget|^2(owned)=" << std::scientific << std::setprecision(8) << gTgt
+                      << std::defaultfloat << "  (BOTH rank-count-INVARIANT; differ 1 vs 4 => BC nodes dropped/doubled)\n";
+    }
+
+    // Sync ghost slots of the target arrays so per-node corrector/predictor
+    // can read them on owned-boundary nodes even when those nodes are touched
+    // by ghost elements on other ranks.
+    s.domain.exchangeNodeHalo(s.d_uTarget);
+    s.domain.exchangeNodeHalo(s.d_vTarget);
+    s.domain.exchangeNodeHalo(s.d_wTarget);
+    pt.lap("BC mark + target velocity");
+
+    // d_dofToNode is needed for column-zero enforcement below. The pressure
+    // DDT path builds it later (line ~3291) but we need it earlier for the
+    // velocity periodic-XR column-zero step. Build once here; subsequent
+    // re-builds in the DDT block are idempotent (same input, same output).
+    if (s.d_dofToNode.size() != size_t(s.numTotalDofs))
+    {
+        s.d_dofToNode.resize(s.numTotalDofs);
+        thrust::fill(thrust::device_pointer_cast(s.d_dofToNode.data()),
+                     thrust::device_pointer_cast(s.d_dofToNode.data() + s.numTotalDofs),
+                     -1);
+        int nodeBlocks = int((s.nodeCount + s.blockSize - 1) / s.blockSize);
+        buildDofToNodeKernel<<<nodeBlocks, s.blockSize>>>(
+            s.d_node_to_dof.data(), s.d_dofToNode.data(),
+            s.numTotalDofs, s.nodeCount);
+        cudaDeviceSynchronize();
+    }
+
+    // Build the per-NODE velocity-Dirichlet mask + halo-exchange it so the
+    // symmetric column-zero step on s.d_valuesVel below hits ghost copies of
+    // Dirichlet nodes on non-owning ranks. Mirrors the DDT pattern around
+    // line ~3429-3460 (d_isPressureBdryNode). Re-uses the generic
+    // buildPressureBdryNodeMaskKernel: it takes any per-DOF mask + optional
+    // pin and writes the per-NODE result.
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Channel
+        || s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Pump)
+    {
+        s.d_isBdryNode.resize(s.nodeCount);
+        thrust::fill(thrust::device_pointer_cast(s.d_isBdryNode.data()),
+                     thrust::device_pointer_cast(s.d_isBdryNode.data() + s.nodeCount),
+                     uint8_t(0));
+        {
+            int nodeBlocks = int((s.nodeCount + s.blockSize - 1) / s.blockSize);
+            const uint8_t* maskPtr = (s.d_isBdryDof.size() > 0)
+                                     ? s.d_isBdryDof.data() : nullptr;
+            buildPressureBdryNodeMaskKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                s.d_node_to_dof.data(), d_nodeOwnership.data(),
+                maskPtr, /*pinDof=*/-1,
+                s.d_isBdryNode.data(), s.nodeCount, s.numOwnedDofs);
+            cudaDeviceSynchronize();
+        }
+        // Forward halo via RealType proxy (cstone exchangeNodeHalo is locked
+        // to the domain's RealType). Proxy values are 0.0/1.0; cast back via
+        // >0.5 threshold. Same pattern as DDT pressure mask exchange.
+        {
+            cstone::DeviceVector<RealType> d_maskProxy(s.nodeCount, RealType(0));
+            thrust::transform(thrust::device,
+                              thrust::device_pointer_cast(s.d_isBdryNode.data()),
+                              thrust::device_pointer_cast(s.d_isBdryNode.data() + s.nodeCount),
+                              thrust::device_pointer_cast(d_maskProxy.data()),
+                              [] __device__ (uint8_t v) -> RealType { return v ? RealType(1) : RealType(0); });
+            s.domain.exchangeNodeHalo(d_maskProxy);
+            thrust::transform(thrust::device,
+                              thrust::device_pointer_cast(d_maskProxy.data()),
+                              thrust::device_pointer_cast(d_maskProxy.data() + s.nodeCount),
+                              thrust::device_pointer_cast(s.d_isBdryNode.data()),
+                              [] __device__ (RealType v) -> uint8_t { return (v > RealType(0.5)) ? uint8_t(1) : uint8_t(0); });
+            cudaDeviceSynchronize();
+        }
+        pt.lap("velocity per-node BC mask + halo");
+    }
+
+    // No cross-rank velocity row-sum exchange needed. The DOF-collapse Pass 1
+    // above redirects ALL slave nodeToDof entries to their master's DOF,
+    // including cross-rank pairs where the master is a ghost on this rank. After
+    // this, the slave's "row" doesn't exist as a separate owned DOF -- the
+    // assembler scatters straight into the master's row via the ghost DOF
+    // (cstone's periodic-image halo delivers the rank-A slave-side elements onto
+    // rank D, where the master is owned). Same flow as single-rank periodic.
+
+    // Enforce velocity Dirichlet on the velocity matrix (row=0, diag=1).
+    // - Cavity/channel/pump: zero rows + diag=1 for d_isBdryDof slots.
+    // - Periodic: nothing to enforce. Periodic pairs collapse to one owned
+    //   merged DOF per pair (owner-migration), so there is no separate slave row.
+    {
+        int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+        if (s.bcKind != NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic)
+        {
+            enforceBcMatrixKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                s.d_isBdryDof.data(), s.d_rowPtr.data(), s.d_colInd.data(),
+                s.d_diagPtr.data(), s.d_valuesVel.data(), s.numOwnedDofs);
+            if (s.useBdf2 && s.d_valuesVel_bdf2.size() > 0)
+            {
+                enforceBcMatrixKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                    s.d_isBdryDof.data(), s.d_rowPtr.data(), s.d_colInd.data(),
+                    s.d_diagPtr.data(), s.d_valuesVel_bdf2.data(), s.numOwnedDofs);
+            }
+            // Symmetric column-zero for Pump/Channel. The cstone CG used for
+            // the velocity solve is textbook symmetric PCG (alpha=rho/pAp);
+            // the row-only clear above leaves the velocity matrix asymmetric.
+            // With many Dirichlet DOFs (~125k + 5-OOM diag spread on
+            // anisotropic boundary-layer cells) the asymmetric perturbation
+            // flips pAp sign and breaks SPD: cg_iter_uvw=FAIL on any non-
+            // trivial RHS, even at amplitude=1e-5 (validated this session).
+            // Cavity is intentionally skipped: its Dirichlet set is sparse
+            // enough that the existing asymmetric row-clear converges fine
+            // (same rationale as DDT-cavity at lines ~3500-3508).
+            //
+            // NOTE: no Dirichlet "lift" yet. For zero qTarget (wall no-slip)
+            // it isn't needed. For non-zero qTarget (inlet/extra u=Uinf)
+            // this introduces an O(off-diag * Uinf) perturbation localized to
+            // the 1-cell ring around those faces. Acceptable for the "BC
+            // actually runs" milestone; promote to a proper lift kernel as
+            // a follow-up after validating convergence.
+            if ((s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Channel
+                 || s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Pump)
+                && s.d_isBdryNode.size() == static_cast<size_t>(s.nodeCount))
+            {
+                enforceBcColMatrixKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
+                    s.d_isBdryNode.data(),
+                    s.d_node_to_dof.data(), s.d_dofToNode.data(), s.numTotalDofs,
+                    s.d_rowPtr.data(), s.d_colInd.data(),
+                    s.d_valuesVel.data(), s.numOwnedDofs);
+                if (s.useBdf2 && s.d_valuesVel_bdf2.size() > 0)
+                {
+                    enforceBcColMatrixKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
+                        s.d_isBdryNode.data(),
+                        s.d_node_to_dof.data(), s.d_dofToNode.data(), s.numTotalDofs,
+                        s.d_rowPtr.data(), s.d_colInd.data(),
+                        s.d_valuesVel_bdf2.data(), s.numOwnedDofs);
+                }
+                cudaDeviceSynchronize();
+            }
+        }
+        else if (s.periodicMap != nullptr)
+        {
+            // Periodic: nothing to enforce on the velocity matrix. Each periodic
+            // pair collapses to one owned merged DOF (owner-migration), so the
+            // assembler already scattered the full merged row -- there is no
+            // separate slave row to Dirichlet-identity or mask.
+        }
+        cudaDeviceSynchronize();
+    }
+    pt.lap("velocity matrix BC");
+
+    // Probe 2: confirm enforceBcMatrixKernel actually zeroed the slave row
+    // and set diag=1 on Avel. Read back one cross-rank slave row's diagonal
+    // value and the count of nonzero off-diagonal entries on that row.
+    if (std::getenv("MARS_PERIODIC_PATHB_DBG") != nullptr
+        && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+        && s.periodicMap != nullptr
+        && !s.periodicMap->cross_.d_sendOwnedSlaveIds_.empty())
+    {
+        const auto& xr = s.periodicMap->cross_;
+        int firstSlaveNode = -1;
+        {
+            std::vector<int> tmp(1);
+            cudaMemcpy(tmp.data(), xr.d_sendOwnedSlaveIds_.data(),
+                       sizeof(int), cudaMemcpyDeviceToHost);
+            firstSlaveNode = tmp[0];
+        }
+        int slaveDof = -1;
+        if (firstSlaveNode >= 0 && firstSlaveNode < int(s.nodeCount))
+        {
+            std::vector<int> tmp(1);
+            cudaMemcpy(tmp.data(),
+                       s.d_node_to_dof.data() + firstSlaveNode,
+                       sizeof(int), cudaMemcpyDeviceToHost);
+            slaveDof = tmp[0];
+        }
+        if (slaveDof >= 0 && slaveDof < s.numOwnedDofs)
+        {
+            // Read this row of Avel from CSR.
+            std::vector<int> rowOffsets(2);
+            cudaMemcpy(rowOffsets.data(),
+                       s.d_rowPtr.data() + slaveDof,
+                       2 * sizeof(int), cudaMemcpyDeviceToHost);
+            int rs = rowOffsets[0], re = rowOffsets[1];
+            int nnzInRow = re - rs;
+            std::vector<int>      rowCols(nnzInRow);
+            std::vector<RealType> rowVals(nnzInRow);
+            cudaMemcpy(rowCols.data(),
+                       s.d_colInd.data() + rs,
+                       nnzInRow * sizeof(int), cudaMemcpyDeviceToHost);
+            cudaMemcpy(rowVals.data(),
+                       s.d_valuesVel.data() + rs,
+                       nnzInRow * sizeof(RealType), cudaMemcpyDeviceToHost);
+            int nonzeroOff = 0;
+            RealType diagVal = RealType(0), maxOff = RealType(0);
+            for (int j = 0; j < nnzInRow; ++j)
+            {
+                if (rowCols[j] == slaveDof) diagVal = rowVals[j];
+                else if (rowVals[j] != RealType(0))
+                {
+                    ++nonzeroOff;
+                    if (std::abs(rowVals[j]) > std::abs(maxOff)) maxOff = rowVals[j];
+                }
+            }
+            std::cerr << "[pathb-dbg rank " << s.rank
+                      << "] firstSlaveDof=" << slaveDof
+                      << " rowNnz=" << nnzInRow
+                      << " diag=" << diagVal
+                      << " nonzeroOff=" << nonzeroOff
+                      << " maxOffVal=" << maxOff
+                      << " (expect: diag=1, nonzeroOff=0 after Path-B mask)"
+                      << std::endl;
+        }
+    }
+
+    // Optional one-shot cross-rank periodic matrix-symmetry diagnostic.
+    // For up to N cross-rank pairs, prints A[slave_row, master_ghost_col] on
+    // the slave-owner rank vs A[master_row, slave_ghost_col] on the master
+    // owner rank. Equal -> matrix is symmetric across the seam. Different
+    // -> assembler is producing asymmetric cross-rank coupling. Gated by
+    // MARS_PERIODIC_XR_SYMCHECK=1.
+    if (std::getenv("MARS_PERIODIC_XR_SYMCHECK") != nullptr
+        && s.numRanks > 1
+        && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+        && s.periodicMap != nullptr
+        && !s.periodicMap->cross_.peers_.empty())
+    {
+        const auto& xr   = s.periodicMap->cross_;
+        const int numPeers = int(xr.peers_.size());
+        const int sendTotal = xr.sendOffsets_.empty() ? 0 : xr.sendOffsets_.back();
+        const int recvTotal = xr.recvOffsets_.empty() ? 0 : xr.recvOffsets_.back();
+
+        // Host copies of CSR + DOF map + partner.
+        std::vector<int>      h_rowPtr(s.numTotalDofs + 1);
+        std::vector<int>      h_colInd(s.nnz);
+        std::vector<RealType> h_valsVel(s.nnz);
+        std::vector<int>      h_n2d(s.nodeCount);
+        std::vector<int>      h_partner(s.nodeCount);
+        std::vector<int>      h_sendIds(sendTotal);
+        std::vector<int>      h_recvIds(recvTotal);
+        cudaMemcpy(h_rowPtr.data(), s.d_rowPtr.data(), (s.numTotalDofs+1)*sizeof(int), cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_colInd.data(), s.d_colInd.data(), s.nnz*sizeof(int), cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_valsVel.data(), s.d_valuesVel.data(), s.nnz*sizeof(RealType), cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_n2d.data(), s.d_node_to_dof.data(), s.nodeCount*sizeof(int), cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_partner.data(), s.periodicMap->d_periodicPartner.data(), s.nodeCount*sizeof(int), cudaMemcpyDeviceToHost);
+        if (sendTotal > 0)
+            cudaMemcpy(h_sendIds.data(), xr.d_sendOwnedSlaveIds_.data(), sendTotal*sizeof(int), cudaMemcpyDeviceToHost);
+        if (recvTotal > 0)
+            cudaMemcpy(h_recvIds.data(), xr.d_recvOwnedMasterIds_.data(), recvTotal*sizeof(int), cudaMemcpyDeviceToHost);
+
+        // For each peer bucket: we own slaves (sendIds), peer owns the master.
+        // We exchange the off-diagonal entry value A[slave_row, master_ghost_col]
+        // with the peer, who looks up A[master_row, slave_ghost_col] from its
+        // own CSR. Use point-to-point pair-wise exchange via the xr.comm_.
+        const int N_PROBE = 4;
+        auto mpiType = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+
+        for (int pi = 0; pi < numPeers; ++pi)
+        {
+            int peer = xr.peers_[pi];
+            int sCnt = xr.sendOffsets_[pi+1] - xr.sendOffsets_[pi];
+            int rCnt = xr.recvOffsets_[pi+1] - xr.recvOffsets_[pi];
+            int nProbe = std::min(N_PROBE, std::max(sCnt, rCnt));
+
+            // Slave-side: build our list of (our-A_value-at-slave-row-master-col).
+            std::vector<RealType> sendVals(nProbe, RealType(0));
+            for (int k = 0; k < std::min(nProbe, sCnt); ++k)
+            {
+                int slave_node = h_sendIds[xr.sendOffsets_[pi] + k];
+                int master_ghost_node = h_partner[slave_node];
+                int slave_dof = h_n2d[slave_node];
+                int master_ghost_dof = (master_ghost_node >= 0)
+                                       ? h_n2d[master_ghost_node] : -2;
+                if (slave_dof < 0 || slave_dof >= s.numOwnedDofs || master_ghost_dof < 0) continue;
+                int rs = h_rowPtr[slave_dof];
+                int re = h_rowPtr[slave_dof + 1];
+                for (int j = rs; j < re; ++j)
+                {
+                    if (h_colInd[j] == master_ghost_dof)
+                    {
+                        sendVals[k] = h_valsVel[j];
+                        break;
+                    }
+                }
+            }
+            // Master-side: build our list of (our-A_value-at-master-row-slave-col)
+            // where the slave is the one peer (sender) will be asking about.
+            // We don't know which OUR-owned-master corresponds to which peer-slave
+            // by k, so we send both halves and let each side print.
+            std::vector<RealType> masterVals(nProbe, RealType(0));
+            for (int k = 0; k < std::min(nProbe, rCnt); ++k)
+            {
+                int master_node = h_recvIds[xr.recvOffsets_[pi] + k];
+                int master_dof = h_n2d[master_node];
+                if (master_dof < 0 || master_dof >= s.numOwnedDofs) continue;
+                // Walk the master row; pick the off-diagonal entry whose column is
+                // a GHOST (>= numOwnedDofs) -- that's the slave ghost on this rank.
+                int rs = h_rowPtr[master_dof];
+                int re = h_rowPtr[master_dof + 1];
+                for (int j = rs; j < re; ++j)
+                {
+                    int col = h_colInd[j];
+                    if (col >= s.numOwnedDofs)
+                    {
+                        masterVals[k] = h_valsVel[j];
+                        break;
+                    }
+                }
+            }
+            // Send our slave-side values; receive peer's master-side values for our slaves.
+            std::vector<RealType> peerMasterVals(nProbe, RealType(0));
+            MPI_Sendrecv(masterVals.data(), nProbe, mpiType, peer, 0xBEEF,
+                         peerMasterVals.data(), nProbe, mpiType, peer, 0xBEEF,
+                         xr.comm_, MPI_STATUS_IGNORE);
+            // Print on the SLAVE-owner side (where sCnt > 0). Rank 0 typically
+            // owns masters and has sCnt=0; the slave-owning ranks are the
+            // meaningful side for this check.
+            if (sCnt > 0)
+            {
+                std::cerr << "[xr-symcheck rank " << s.rank
+                          << " (slave-owner) <-> peer " << peer
+                          << " (master-owner)] sCnt=" << sCnt
+                          << " rCnt=" << rCnt
+                          << " nProbe=" << nProbe << std::endl;
+                int nIter = std::min(nProbe, sCnt);
+                for (int k = 0; k < nIter; ++k)
+                {
+                    int slave_node = h_sendIds[xr.sendOffsets_[pi] + k];
+                    int master_ghost_node = h_partner[slave_node];
+                    int slave_dof = h_n2d[slave_node];
+                    int master_ghost_dof = (master_ghost_node >= 0)
+                                           ? h_n2d[master_ghost_node] : -2;
+                    std::cerr << "  k=" << k
+                              << "  slave_node=" << slave_node
+                              << " (dof=" << slave_dof << ")"
+                              << "  master_ghost=" << master_ghost_node
+                              << " (dof=" << master_ghost_dof << ")"
+                              << "  A_local=" << sendVals[k]
+                              << "  A_peer=" << peerMasterVals[k]
+                              << "  diff=" << (sendVals[k] - peerMasterVals[k])
+                              << std::endl;
+                }
+            }
+        }
+        MPI_Barrier(xr.comm_);
+    }
+
+    // Pressure null-space removal.
+    //   Cavity: pin a single owned DOF closest to (xmin, ymin, zmin) and
+    //   leave Neumann everywhere else. Works because pressure is free to be
+    //   zero anywhere with pure-Dirichlet velocity BCs.
+    //   Channel: pin the ENTIRE outflow face (x = xmax) to p = 0 by adding a
+    //   per-owned-DOF mask, then turning matrix rows for those DOFs into
+    //   identity. This matches the physically correct outflow condition for
+    //   channel flow and avoids the single-corner-pin pathology that fought
+    //   the natural inflow-to-outflow pressure gradient.
+    using BCK = typename NSStepper<KeyType, RealType, ElementTag>::BCKind;
+    if (s.bcKind == BCK::Periodic)
+    {
+        // Periodic: pressure is pure-Neumann with a 1D constant-mode null space.
+        // Default: leave it Neumann and clean up with per-step removeMean.
+        //
+        // MARS_PERIODIC_PIN: pin ONE owned DOF (nearest the box corner) to break
+        // the null space explicitly, exactly like the cavity. On >1 rank the
+        // Neumann+removeMean route was observed to break down (the assembled
+        // operator's numerical null vector is not exactly the constant across the
+        // cross-rank seam, so the mean projection is inconsistent -> CG search
+        // direction lands in the near-null space -> pAp<=0). A hard pin removes
+        // the null direction outright and does not depend on seam completeness.
+        // Same mechanism as the cavity pin below (findPressurePinCandidateKernel
+        // + global MINLOC + enforcePinRowMatrixKernel).
+        const char* pinEv = std::getenv("MARS_PERIODIC_PIN");
+        bool periodicPin = (pinEv && std::string(pinEv) != "0");
+        if (!periodicPin)
+        {
+            s.pressurePinDof  = -1;
+            s.pressurePinRank = -1;
+            if (s.rank == 0)
+                std::cout << "  pressure BC: periodic (no pin; null-space removed each step via removeMean)\n";
+        }
+        else
+        {
+            cstone::DeviceVector<RealType> d_d2(s.numOwnedDofs, RealType(1e30));
+            cstone::DeviceVector<int>      d_dofId(s.numOwnedDofs, -1);
+            int nBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+            findPressurePinCandidateKernel<RealType><<<nBlocks, s.blockSize>>>(
+                d_x.data(), d_y.data(), d_z.data(),
+                d_nodeOwnership.data(), s.d_node_to_dof.data(),
+                d_d2.data(), d_dofId.data(),
+                s.nodeCount, s.numOwnedDofs,
+                s.xmin, s.ymin, s.zmin);
+            cudaDeviceSynchronize();
+
+            int localBestDof = -1;
+            RealType localBestD2 = RealType(1e30);
+            if (s.numOwnedDofs > 0)
+            {
+                auto dp = thrust::device_pointer_cast(d_d2.data());
+                auto minIt = thrust::min_element(thrust::device, dp, dp + s.numOwnedDofs);
+                size_t bestIdx = static_cast<size_t>(minIt - dp);
+                thrust::copy(thrust::device_pointer_cast(d_d2.data() + bestIdx),
+                             thrust::device_pointer_cast(d_d2.data() + bestIdx + 1),
+                             &localBestD2);
+                thrust::copy(thrust::device_pointer_cast(d_dofId.data() + bestIdx),
+                             thrust::device_pointer_cast(d_dofId.data() + bestIdx + 1),
+                             &localBestDof);
+            }
+
+            struct { double d; int r; } in{static_cast<double>(localBestD2), s.rank}, out{};
+            MPI_Allreduce(&in, &out, 1, MPI_DOUBLE_INT, MPI_MINLOC, MPI_COMM_WORLD);
+            s.pressurePinRank = out.r;
+            s.pressurePinDof  = (s.rank == out.r) ? localBestDof : -1;
+
+            if (s.pressurePinDof >= 0)
+            {
+                enforcePinRowMatrixKernel<RealType><<<1, 1>>>(
+                    s.pressurePinDof, s.d_rowPtr.data(), s.d_colInd.data(),
+                    s.d_diagPtr.data(), s.d_valuesPre.data());
+                cudaDeviceSynchronize();
+            }
+            if (s.rank == 0)
+                std::cout << "  pressure BC: periodic + single-DOF pin (MARS_PERIODIC_PIN): rank="
+                          << s.pressurePinRank << ", dof="
+                          << ((s.rank == s.pressurePinRank) ? s.pressurePinDof : -1)
+                          << " (anchor near corner (" << s.xmin << "," << s.ymin << "," << s.zmin << "))\n";
+        }
+    }
+    else if (s.bcKind == BCK::Channel)
+    {
+        s.d_isPressureBdryDof.resize(s.numOwnedDofs);
+        thrust::fill(thrust::device_pointer_cast(s.d_isPressureBdryDof.data()),
+                     thrust::device_pointer_cast(s.d_isPressureBdryDof.data() + s.numOwnedDofs),
+                     uint8_t(0));
+        int nBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+        markChannelPressureBCKernel<RealType><<<nBlocks, s.blockSize>>>(
+            d_x.data(),
+            d_nodeOwnership.data(), s.d_node_to_dof.data(),
+            s.d_isPressureBdryDof.data(),
+            s.nodeCount, s.xmax, s.bboxEps, s.numOwnedDofs);
+        cudaDeviceSynchronize();
+
+        int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+        enforceBcMatrixKernel<RealType><<<dofBlocks, s.blockSize>>>(
+            s.d_isPressureBdryDof.data(), s.d_rowPtr.data(), s.d_colInd.data(),
+            s.d_diagPtr.data(), s.d_valuesPre.data(), s.numOwnedDofs);
+        cudaDeviceSynchronize();
+
+        s.pressurePinDof  = -1;     // disable corner-pin path
+        s.pressurePinRank = -1;
+        if (s.rank == 0)
+            std::cout << "  pressure BC: Dirichlet p=0 on outflow face x=" << s.xmax << "\n";
+    }
+    else if (s.bcKind == BCK::Pump)
+    {
+        // Pump: pressure Dirichlet p=0 on the 'out' side-set (outlet face).
+        s.d_isPressureBdryDof.resize(s.numOwnedDofs);
+        thrust::fill(thrust::device_pointer_cast(s.d_isPressureBdryDof.data()),
+                     thrust::device_pointer_cast(s.d_isPressureBdryDof.data() + s.numOwnedDofs),
+                     uint8_t(0));
+        // Host-side scatter from the outlet local-node list. Owned DOFs only.
+        std::vector<uint8_t> hostMask(s.numOwnedDofs, 0);
+        std::vector<int> hostNodeToDof(s.nodeCount, -1);
+        std::vector<uint8_t> hostOwn(s.nodeCount, 0);
+        thrust::copy(thrust::device_pointer_cast(s.d_node_to_dof.data()),
+                     thrust::device_pointer_cast(s.d_node_to_dof.data() + s.nodeCount),
+                     hostNodeToDof.begin());
+        thrust::copy(thrust::device_pointer_cast(d_nodeOwnership.data()),
+                     thrust::device_pointer_cast(d_nodeOwnership.data() + s.nodeCount),
+                     hostOwn.begin());
+        // When the outlet is a VELOCITY-Dirichlet outflow (mass-conserving pump,
+        // outletU>0), prescribing p over the WHOLE outlet face too would
+        // over-constrain it. The pressure then needs only ONE reference DOF, so
+        // mask a single outlet DOF (the first owned one, on the lowest rank that
+        // has one). When outletU<=0 (legacy pressure-outlet), mask the whole
+        // outlet face as before (natural-Neumann velocity there).
+        bool singlePin = (s.outletU > RealType(0));
+        int  pinRankLocal = singlePin ? s.numRanks : -1;  // for the global argmin
+        size_t ownedOutletCount = 0;
+        int firstOutletDof = -1;
+        for (int li : s.outletNodes)
+        {
+            if (li < 0 || (size_t)li >= s.nodeCount) continue;
+            if (hostOwn[li] != 1) continue;
+            int dof = hostNodeToDof[li];
+            if (dof < 0 || dof >= s.numOwnedDofs) continue;
+            if (firstOutletDof < 0) firstOutletDof = dof;
+            if (!singlePin) { hostMask[dof] = 1; ++ownedOutletCount; }
+        }
+        if (singlePin)
+        {
+            // Pick the single global pin: lowest rank that owns an outlet DOF.
+            int haveOutlet = (firstOutletDof >= 0) ? s.rank : s.numRanks;
+            int pinRank = s.numRanks;
+            MPI_Allreduce(&haveOutlet, &pinRank, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+            if (s.rank == pinRank && firstOutletDof >= 0)
+            {
+                hostMask[firstOutletDof] = 1;
+                ownedOutletCount = 1;
+            }
+            (void)pinRankLocal;
+        }
+        thrust::copy(hostMask.begin(), hostMask.end(),
+                     thrust::device_pointer_cast(s.d_isPressureBdryDof.data()));
+
+        int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+        enforceBcMatrixKernel<RealType><<<dofBlocks, s.blockSize>>>(
+            s.d_isPressureBdryDof.data(), s.d_rowPtr.data(), s.d_colInd.data(),
+            s.d_diagPtr.data(), s.d_valuesPre.data(), s.numOwnedDofs);
+        cudaDeviceSynchronize();
+
+        s.pressurePinDof  = -1;
+        s.pressurePinRank = -1;
+        if (s.rank == 0)
+            std::cout << "  pressure BC: " << (singlePin
+                         ? "single p=0 pin (mass-conserving velocity outlet)"
+                         : "Dirichlet p=0 on whole outlet side-set")
+                      << " (" << ownedOutletCount << " masked DOFs on rank 0)\n";
+    }
+    else  // Cavity
+    {
+        cstone::DeviceVector<RealType> d_d2(s.numOwnedDofs, RealType(1e30));
+        cstone::DeviceVector<int>      d_dofId(s.numOwnedDofs, -1);
+        int nBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+        findPressurePinCandidateKernel<RealType><<<nBlocks, s.blockSize>>>(
+            d_x.data(), d_y.data(), d_z.data(),
+            d_nodeOwnership.data(), s.d_node_to_dof.data(),
+            d_d2.data(), d_dofId.data(),
+            s.nodeCount, s.numOwnedDofs,
+            s.xmin, s.ymin, s.zmin);
+        cudaDeviceSynchronize();
+
+        int localBestDof = -1;
+        RealType localBestD2 = RealType(1e30);
+        if (s.numOwnedDofs > 0)
+        {
+            auto dp = thrust::device_pointer_cast(d_d2.data());
+            auto minIt = thrust::min_element(thrust::device, dp, dp + s.numOwnedDofs);
+            size_t bestIdx = static_cast<size_t>(minIt - dp);
+            thrust::copy(thrust::device_pointer_cast(d_d2.data() + bestIdx),
+                         thrust::device_pointer_cast(d_d2.data() + bestIdx + 1),
+                         &localBestD2);
+            thrust::copy(thrust::device_pointer_cast(d_dofId.data() + bestIdx),
+                         thrust::device_pointer_cast(d_dofId.data() + bestIdx + 1),
+                         &localBestDof);
+        }
+
+        struct { double d; int r; } in{static_cast<double>(localBestD2), s.rank}, out{};
+        MPI_Allreduce(&in, &out, 1, MPI_DOUBLE_INT, MPI_MINLOC, MPI_COMM_WORLD);
+        s.pressurePinRank = out.r;
+        s.pressurePinDof  = (s.rank == out.r) ? localBestDof : -1;
+
+        if (s.pressurePinDof >= 0)
+        {
+            enforcePinRowMatrixKernel<RealType><<<1, 1>>>(
+                s.pressurePinDof, s.d_rowPtr.data(), s.d_colInd.data(),
+                s.d_diagPtr.data(), s.d_valuesPre.data());
+            cudaDeviceSynchronize();
+        }
+        if (s.rank == 0)
+        {
+            std::cout << "  pressure pin: rank=" << s.pressurePinRank
+                      << ", dof=" << ((s.rank == s.pressurePinRank) ? s.pressurePinDof : -1)
+                      << " (anchor near corner (" << s.xmin << "," << s.ymin << "," << s.zmin << "))\n";
+        }
+    }
+    pt.lap("pressure BC");
+
+    // Apply the same pressure-Dirichlet identity-row enforcement to the
+    // assembled-DDT matrix so its rows for pinned outlet DOFs (and the cavity
+    // single-pin) match the rule applyDDTPerNode uses at solve time. Without
+    // this, AMG would see inconsistent rows and the preconditioner would
+    // misbehave on boundary DOFs.
+    // Build the dof->node inverse map + per-NODE pressure-Dirichlet mask
+    // (halo-exchanged), used by the symmetric column-zeroing kernel below so
+    // EVERY rank zeros its ghost-copy pin/Dirichlet columns. The earlier
+    // approach only zeroed columns on the owning rank, leaving non-owning
+    // ranks with stale couplings to the pin/mask DOFs -> globally asymmetric
+    // matrix -> BoomerAMG produced wildly wrong phi (|gphi|=32 vs expected 5
+    // on cube16-cavity at step 1).
+    s.d_dofToNode.resize(s.numTotalDofs);
+    thrust::fill(thrust::device_pointer_cast(s.d_dofToNode.data()),
+                 thrust::device_pointer_cast(s.d_dofToNode.data() + s.numTotalDofs),
+                 -1);
+    {
+        int nodeBlocks = int((s.nodeCount + s.blockSize - 1) / s.blockSize);
+        buildDofToNodeKernel<<<nodeBlocks, s.blockSize>>>(
+            s.d_node_to_dof.data(), s.d_dofToNode.data(),
+            s.numTotalDofs, s.nodeCount);
+        cudaDeviceSynchronize();
+    }
+    s.d_isPressureBdryNode.resize(s.nodeCount);
+    thrust::fill(thrust::device_pointer_cast(s.d_isPressureBdryNode.data()),
+                 thrust::device_pointer_cast(s.d_isPressureBdryNode.data() + s.nodeCount),
+                 uint8_t(0));
+    {
+        int nodeBlocks = int((s.nodeCount + s.blockSize - 1) / s.blockSize);
+        const uint8_t* maskPtr = (s.d_isPressureBdryDof.size() > 0)
+                                 ? s.d_isPressureBdryDof.data() : nullptr;
+        int pinDofLocal = s.pressurePinDof;  // -1 if this rank doesn't own pin
+        buildPressureBdryNodeMaskKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            maskPtr, pinDofLocal,
+            s.d_isPressureBdryNode.data(), s.nodeCount, s.numOwnedDofs);
+        cudaDeviceSynchronize();
+    }
+    // Forward halo: ghost slots get owner-rank Dirichlet flag. cstone's
+    // exchangeNodeHalo is locked to the domain's RealType (double), so we
+    // exchange a double proxy then cast back. Proxy values are 0.0/1.0.
+    {
+        cstone::DeviceVector<RealType> d_maskProxy(s.nodeCount, RealType(0));
+        thrust::transform(thrust::device,
+                          thrust::device_pointer_cast(s.d_isPressureBdryNode.data()),
+                          thrust::device_pointer_cast(s.d_isPressureBdryNode.data() + s.nodeCount),
+                          thrust::device_pointer_cast(d_maskProxy.data()),
+                          [] __device__ (uint8_t v) -> RealType { return v ? RealType(1) : RealType(0); });
+        s.domain.exchangeNodeHalo(d_maskProxy);
+        thrust::transform(thrust::device,
+                          thrust::device_pointer_cast(d_maskProxy.data()),
+                          thrust::device_pointer_cast(d_maskProxy.data() + s.nodeCount),
+                          thrust::device_pointer_cast(s.d_isPressureBdryNode.data()),
+                          [] __device__ (RealType v) -> uint8_t { return (v > RealType(0.5)) ? uint8_t(1) : uint8_t(0); });
+        cudaDeviceSynchronize();
+    }
+
+    // These enforce Dirichlet BCs on the ASSEMBLED DDT matrix (s.d_*DDT). Those
+    // buffers are only built inside the if constexpr(hex) DDT block above, so
+    // nnzDDT==0 for tet / any run without an assembled DDT operator -- skip,
+    // or the kernels dereference a null DDT rowPtr (illegal access). The K-path
+    // velocity/pressure matrices get their own BC enforcement separately.
+    if (s.nnzDDT > 0
+        && (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Channel
+            || s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Pump))
+    {
+        int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+        // Row enforcement: zero each Dirichlet row, set diagonal to 1.
+        enforceBcMatrixKernel<RealType><<<dofBlocks, s.blockSize>>>(
+            s.d_isPressureBdryDof.data(), s.d_rowPtrDDT.data(), s.d_colIndDDT.data(),
+            s.d_diagPtrDDT.data(), s.d_valuesDDT.data(), s.numOwnedDofs);
+        // Symmetric column enforcement using per-NODE mask -- works on EVERY
+        // rank (including ghost-copies of Dirichlet nodes).
+        enforceBcColMatrixKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
+            s.d_isPressureBdryNode.data(),
+            s.d_node_to_dof.data(), s.d_dofToNode.data(), s.numTotalDofs,
+            s.d_rowPtrDDT.data(), s.d_colIndDDT.data(),
+            s.d_valuesDDT.data(), s.numOwnedDofs);
+        cudaDeviceSynchronize();
+    }
+    else if (s.nnzDDT > 0
+             && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Cavity
+             && s.pressurePinDof >= 0)
+    {
+        // Row enforcement on pin row, KEEPING the assembled diagonal magnitude
+        // (not forcing it to 1). The DDT operator's diagonal range is ~0.04 to
+        // 0.14; a pin row with diag=1 is 10-25x its neighbors, which CG
+        // tolerates but BoomerAMG's coarsening does not -- Hypre setup returns
+        // generic error 1 on that conditioning spike. Preserving the native
+        // diagonal removes the spike so AMG sees a uniformly-scaled SPD row.
+        enforcePinRowKeepDiagKernel<RealType><<<1, 1>>>(
+            s.pressurePinDof, s.d_rowPtrDDT.data(), s.d_colIndDDT.data(),
+            s.d_diagPtrDDT.data(), s.d_valuesDDT.data());
+    }
+
+    // MARS_DDT_ROWSUM: dump row-sums of the FINAL assembled s.AddT. A D M^-1 D^T
+    // Laplacian row MUST sum to ~0 (it annihilates constants). If multi-rank
+    // row-sums are large where single-rank are ~0, the assembled operator is
+    // wrong multi-rank -> phi comes back wrong-magnitude even though Hypre
+    // "converges". Reports per-rank max|rowsum| over owned rows. Reads CSR to
+    // host (one-shot diagnostic, gated, costs nothing in production).
+    if (std::getenv("MARS_DDT_ROWSUM") && s.nnzDDT > 0 && s.numOwnedDofs > 0)
+    {
+        std::vector<int> hRowPtr(s.numOwnedDofs + 1);
+        cudaMemcpy(hRowPtr.data(), s.d_rowPtrDDT.data(),
+                   (s.numOwnedDofs + 1) * sizeof(int), cudaMemcpyDeviceToHost);
+        int nnzOwned = hRowPtr[s.numOwnedDofs];
+        std::vector<RealType> hVals(nnzOwned);
+        cudaMemcpy(hVals.data(), s.d_valuesDDT.data(),
+                   nnzOwned * sizeof(RealType), cudaMemcpyDeviceToHost);
+        double maxAbs = 0.0;
+        int rMax = -1;
+        for (int r = 0; r < s.numOwnedDofs; ++r) {
+            double rowsum = 0.0;
+            for (int k = hRowPtr[r]; k < hRowPtr[r + 1]; ++k) rowsum += double(hVals[k]);
+            if (std::abs(rowsum) > maxAbs) { maxAbs = std::abs(rowsum); rMax = r; }
+        }
+        std::cout << "  [DDT-rowsum rank " << s.rank << "] owned rows=" << s.numOwnedDofs
+                  << " max|rowsum|=" << maxAbs << " (row " << rMax
+                  << ")  -- Laplacian rows should be ~0\n" << std::flush;
+    }
+
+    // Cavity DDT: column-clear stays disabled. A symmetric col-clear changed
+    // neighboring rows' row-sum from ~0 to ~|A[r,pin]|, breaking AMG's
+    // strength-of-connection metric (earlier attempt -> Hypre setup error 1).
+    // K-path doesn't col-clear for cavity and works fine; matching that
+    // asymmetric-pin treatment for DDT-cavity, now with a scale-matched pin
+    // diagonal so AMG can coarsen the resulting SPD row uniformly. For
+    // channel/pump the col-clear above is kept since those have an entire
+    // Dirichlet face, not a single pin, and the row-sum drift is negligible
+    // relative to the boundary mass.
+
+    // Bochev-Dohrmann polynomial pressure projection stabilization. Added to
+    // the assembled K-path pressure matrix (d_valuesPre, full 27-NNZ
+    // sparsity). The DDT pressure solve also needs BD; we apply it
+    // matrix-free in applyDDTPerNode() to avoid the sparsity mismatch (DDT
+    // uses graph sparsity with only 7 NNZ/row, which cannot hold all 28
+    // distinct corner-pair contributions per Q1 hex element).
+    //
+    // Q1-Q1 equal-order CG-FEM is LBB-unstable without BD on periodic
+    // domains: the pressure checkerboard mode is unconstrained, grad(p)
+    // explodes via predictor feedback, simulation blows up around step 30
+    // regardless of dt or Re. BD adds the element-local symmetric PSD term
+    //   S^e_ij = tau * V_e * (delta_ij/8 - 1/64)
+    // which has row sum zero (kills constant pressure) and removes the
+    // checkerboard null-space. Applied AFTER pin/outflow enforcement so
+    // identity rows are preserved (BD is only enabled when bcKind == Periodic,
+    // which has no pin and no outflow Dirichlet, so this ordering is moot in
+    // practice but the assert is cheap).
+    if (s.stabBochevDohrmann)
+    {
+        RealType tau = s.stabPressureTau;
+        if (tau <= 0)
+        {
+            RealType bx = std::max(RealType(1e-30), s.xmax - s.xmin);
+            RealType by = std::max(RealType(1e-30), s.ymax - s.ymin);
+            RealType bz = std::max(RealType(1e-30), s.zmax - s.zmin);
+            RealType h = std::cbrt((bx * by * bz) /
+                                   RealType(std::max<size_t>(1, s.elementCount)));
+            // Lumped-mass BD over-stabilizes by ~27x on the checkerboard mode
+            // vs the consistent form (verified numerically: scratch/verify_bd.py).
+            // Scale tau by 1/8 so we land between the Frobenius-match (~1/5)
+            // and the eigenvalue-match (~1/3 to 1/27). Conservative but
+            // physically sensible: kills the spurious mode strongly without
+            // over-damping resolved pressure structures.
+            tau = h * h / RealType(8);
+        }
+        addBochevDohrmannStab<KeyType, RealType, ElementTag>(s, tau);
+        if (s.rank == 0)
+            std::cout << "  pressure stabilization: Bochev-Dohrmann polynomial projection (K-path matrix + DDT matrix-free), tau=" << tau << "\n";
+        pt.lap("BD pressure stabilization");
+    }
+
+    // Cache the DDT diagonal (BC-modified, post-shift) for use as the Jacobi
+    // preconditioner in solvePressureDDT. Single O(numOwnedDofs) kernel; the
+    // diagonal stays valid for the whole run because BC enforcement and the
+    // optional shift are setup-time-only modifications of s.d_valuesDDT.
+    // Note: BD-periodic adds matrix-free terms inside applyDDTPerNode that are
+    // NOT reflected in s.d_valuesDDT, so this cached diagonal will be slightly
+    // off the actual operator diagonal on periodic runs. Acceptable: Jacobi
+    // is a preconditioner, not the exact inverse; a small mismatch only slows
+    // convergence, not correctness.
+    if (s.numOwnedDofs > 0 && s.nnzDDT > 0)
+    {
+        s.d_diagDDT.resize(s.numOwnedDofs);
+        int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+        extractDiagByDiagPtrKernel<RealType><<<dofBlocks, s.blockSize>>>(
+            s.d_diagPtrDDT.data(), s.d_valuesDDT.data(),
+            s.d_diagDDT.data(), s.numOwnedDofs);
+        cudaDeviceSynchronize();
+        // Cavity-only override: the cavity pin is enforced in the matrix-free
+        // applyDDTPerNode as an identity row (out[pin]=phi[pin], effective
+        // diag=1.0), but the assembled s.d_valuesDDT keeps the pin's native
+        // diagonal (~0.04-0.14) via enforcePinRowKeepDiagKernel. Without this
+        // override the Jacobi step would compute z[pin] = r[pin]/0.04 = ~25x
+        // amplification at the pin DOF every iter -- biasing the global
+        // search direction and producing the |gphi|~5x divergence injection
+        // observed earlier in this session before the loop-bound fix landed.
+        // Channel/pump already get diag=1 from enforceBcMatrixKernel so they
+        // need no override. Predicted Jacobi-PCG pump iter count: ~400-700
+        // to 1e-8 (vs un-precond stall at 1e-3 after 20k).
+        if (s.pressurePinDof >= 0
+            && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Cavity)
+        {
+            RealType one = RealType(1);
+            cudaMemcpy(s.d_diagDDT.data() + s.pressurePinDof, &one,
+                       sizeof(RealType), cudaMemcpyHostToDevice);
+        }
+    }
+    else if (s.numOwnedDofs > 0 && s.pressureSolve == PressureSolveKind::DDT
+             && std::is_same_v<ElementTag, TetTag>)
+    {
+        // Tet has no assembled DDT matrix (nnzDDT==0), so build the Jacobi
+        // diagonal matrix-free from the SCS area vectors + node lumped mass,
+        // matching the matrix-free applyDDTPerNode operator. Without this the
+        // tet DDT CG runs unpreconditioned and stalls at the iter cap.
+        //
+        // HARD DEPENDENCY: this build reads s.d_areaVec_{x,y,z} (filled by
+        // precomputeTetAreaVectorsGpu) and s.d_massNode (filled by the lumped-
+        // mass step). Both run earlier in setupNSStepper, so they are populated
+        // here. If a future refactor moves this block ahead of either, the
+        // accumulator comes back all-zero -> floored to a constant 1.0 -> the
+        // Jacobi preconditioner becomes a no-op (useJacobi stays true but CG
+        // runs effectively un-preconditioned). Catch that at the source.
+        if (s.d_areaVec_x.size() != s.elementCount * ElemTraits<ElementTag>::ScsPerElem
+            || s.d_massNode.size() != s.nodeCount)
+        {
+            if (s.rank == 0)
+                std::cout << "[cg-ddt] WARNING: tet DDT diagonal build ran before its "
+                             "inputs were ready (areaVec/massNode unsized) -> Jacobi "
+                             "preconditioner will be a useless constant. Move this block "
+                             "AFTER the area-vector + lumped-mass steps.\n";
+        }
+        s.d_diagDDT.resize(s.numOwnedDofs);
+        thrust::fill(thrust::device_pointer_cast(s.d_diagDDT.data()),
+                     thrust::device_pointer_cast(s.d_diagDDT.data() + s.numOwnedDofs),
+                     RealType(0));
+        cstone::DeviceVector<RealType> d_diagAccNode(s.nodeCount, RealType(0));
+
+        auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+        const KeyType* c0 = cp[0]; const KeyType* c1 = cp[1];
+        const KeyType* c2 = cp[2]; const KeyType* c3 = cp[3];
+        const size_t startElem = s.domain.startIndex();
+        const size_t numLocal  = s.domain.localElementCount();
+        const int eBlocks = numLocal > 0 ? int((numLocal + s.blockSize - 1) / s.blockSize) : 0;
+        if (eBlocks > 0)
+        {
+            computeTetDDTDiagonalKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                c0, c1, c2, c3, nullptr, nullptr, nullptr, nullptr,
+                s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                s.d_massNode.data(), d_diagAccNode.data(), startElem, numLocal);
+            cudaDeviceSynchronize();
+        }
+        // Sum cross-rank / periodic incident-face contributions exactly as the
+        // operator does for its accumulators.
+        s.domain.reverseExchangeNodeHaloAdd(d_diagAccNode);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_diagAccNode);
+
+        int nodeBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+        gatherTetDDTDiagToDofKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            d_diagAccNode.data(), s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            s.d_diagDDT.data(), s.nodeCount, s.numOwnedDofs);
+        cudaDeviceSynchronize();
+        // Floor any zero/negative diagonal so the Jacobi 1/diag step is safe.
+        thrust::transform(thrust::device,
+            thrust::device_pointer_cast(s.d_diagDDT.data()),
+            thrust::device_pointer_cast(s.d_diagDDT.data() + s.numOwnedDofs),
+            thrust::device_pointer_cast(s.d_diagDDT.data()),
+            [] __device__ (RealType d) { return (d > RealType(1e-30)) ? d : RealType(1); });
+    }
+
+    // Shared clipped-Jacobi epsilon floor (runs for whichever path filled
+    // d_diagDDT -- hex assembled or tet matrix-free). Wing meshes with
+    // anisotropic boundary-layer cells have a diag spread of 5+ orders of
+    // magnitude; without a floor the Jacobi step amplifies tiny-diag rows by
+    // ~1/diag, biasing the CG search direction. The floor caps amplification
+    // at 1/eps. 1e-3 fraction is the PETSc/Hypre default; env override
+    // MARS_DDT_JACOBI_CLIP_FRAC=F sets eps = F * max(diag).
+    if (s.d_diagDDT.size() == static_cast<size_t>(s.numOwnedDofs) && s.numOwnedDofs > 0)
+    {
+        RealType localMax = thrust::reduce(
+            thrust::device,
+            thrust::device_pointer_cast(s.d_diagDDT.data()),
+            thrust::device_pointer_cast(s.d_diagDDT.data() + s.numOwnedDofs),
+            RealType(0), thrust::maximum<RealType>());
+        RealType globalMax = localMax;
+        if (s.numRanks > 1)
+        {
+            MPI_Datatype mpiR = std::is_same<RealType, double>::value
+                                ? MPI_DOUBLE : MPI_FLOAT;
+            MPI_Allreduce(&localMax, &globalMax, 1, mpiR, MPI_MAX, MPI_COMM_WORLD);
+        }
+        RealType frac = RealType(1e-3);
+        const char* ev = std::getenv("MARS_DDT_JACOBI_CLIP_FRAC");
+        if (ev) { double v = std::atof(ev); if (v > 0) frac = RealType(v); }
+        s.diagDDTEpsClip = frac * globalMax;
+        if (s.rank == 0)
+        {
+            auto oldFlags = std::cout.flags();
+            std::cout << std::scientific << std::setprecision(4)
+                      << "  [DDT-jacobi-clip] eps = " << s.diagDDTEpsClip
+                      << " (= " << frac << " * max_diag " << globalMax
+                      << "; floors tiny boundary-layer diagonals)\n";
+            std::cout.flags(oldFlags);
+        }
+    }
+    pt.lap("DDT diagonal cache (for Jacobi PCG)");
+
+    // Wrap into SparseMatrix for the solvers. Avel and Apre share K's 27-NNZ
+    // layout; AddT uses its own reduced 7-NNZ layout (rowPtrDDT/colIndDDT).
+    // Avel_bdf2 (when present) uses the SAME row layout as Avel but with the
+    // 3M/(2 dt) mass coefficient instead of M/dt; used from step 1 of BDF2.
+    wrapIntoSparseMatrix<RealType>(s.Avel, s.numOwnedDofs, s.numTotalDofs, s.nnz,
+                                   s.d_rowPtr.data(), s.d_colInd.data(), s.d_valuesVel.data());
+    if (s.useBdf2 && s.d_valuesVel_bdf2.size() > 0)
+    {
+        wrapIntoSparseMatrix<RealType>(s.Avel_bdf2, s.numOwnedDofs, s.numTotalDofs, s.nnz,
+                                       s.d_rowPtr.data(), s.d_colInd.data(), s.d_valuesVel_bdf2.data());
+    }
+    wrapIntoSparseMatrix<RealType>(s.Apre, s.numOwnedDofs, s.numTotalDofs, s.nnz,
+                                   s.d_rowPtr.data(), s.d_colInd.data(), s.d_valuesPre.data());
+    // AddT only exists when the DDT operator was assembled (hex). For tet,
+    // nnzDDT==0 and the d_*DDT buffers are null/empty -- wrapping them does a
+    // cudaMemcpy on a null pointer (cudaErrorInvalidValue -> poisoned context).
+    if (s.nnzDDT > 0)
+        wrapIntoSparseMatrix<RealType>(s.AddT, s.numOwnedDofs, s.numTotalDofs, s.nnzDDT,
+                                       s.d_rowPtrDDT.data(), s.d_colIndDDT.data(), s.d_valuesDDT.data());
+    pt.lap("SparseMatrix wrap (vel+pre+ddt)");
+
+    // Optional diagnostic: env MARS_DDT_PROBE_DIFF=1 enables a one-shot
+    // probe-and-compare check at setup time. For a few owned DOFs k, set
+    // phi = e_k, apply BOTH the matrix-free applyDDTPerNode AND a manual
+    // CSR SpMV of the assembled s.AddT, gather both back to per-DOF, and
+    // print row-by-row diffs for the worst entries. If the assembled matrix
+    // is bit-correct, all diffs print as ~1e-15; if it's wrong, we see
+    // exactly which rows and how much. Used to debug the node-driven
+    // assembler vs matrix-free identity.
+    //
+    // Hex-only: applyDDTPerNode is a no-op for tet and the assembled DDT CSR
+    // (s.d_rowPtrDDT etc.) is only built in the hex branch above. if constexpr
+    // keeps the whole probe out of the tet compile.
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    if (s.bcKind != NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+        && std::getenv("MARS_DDT_PROBE_DIFF"))
+    {
+        // Choose probe DOFs scattered across the owned range. Skip dof 0
+        // because in cavity mode it's the pressure pin and BC enforcement
+        // (row-zero + col-zero) is INTENTIONALLY applied to the assembled
+        // matrix but NOT to the matrix-free apply -- comparing them at the
+        // pin would always show a false positive.
+        std::vector<int> probeDofs;
+        if (s.numOwnedDofs > 100) {
+            probeDofs = { 50, 100, 500, 1500 };
+        } else {
+            for (int k = 1; k < std::min(s.numOwnedDofs, 5); ++k) probeDofs.push_back(k);
+        }
+        if (s.rank == 0)
+            std::cout << "  [MARS_DDT_PROBE_DIFF] running " << probeDofs.size()
+                      << " probe(s) of e_k through both apply-paths\n";
+
+        cstone::DeviceVector<RealType> phiNode(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> yMfNode(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> gx(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> gy(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> gz(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> xDof(s.numTotalDofs, RealType(0));
+        cstone::DeviceVector<RealType> yAsmDof(s.numOwnedDofs, RealType(0));
+
+        const int*     n2dPtr = s.d_node_to_dof.data();
+        const uint8_t* ownPtr = d_nodeOwnership.data();
+        size_t nNodes = s.nodeCount;
+        size_t nTotal = s.numTotalDofs;
+        size_t nOwned = s.numOwnedDofs;
+
+        for (int targetDof : probeDofs)
+        {
+            if (targetDof >= s.numOwnedDofs) continue;
+            // Reset
+            cudaMemset(phiNode.data(), 0, nNodes * sizeof(RealType));
+            cudaMemset(yMfNode.data(), 0, nNodes * sizeof(RealType));
+            cudaMemset(xDof.data(),    0, nTotal * sizeof(RealType));
+            cudaMemset(yAsmDof.data(), 0, nOwned * sizeof(RealType));
+
+            // Set phiNode[node such that nodeToDof[node]==targetDof, owned] = 1.
+            thrust::for_each(thrust::device,
+                thrust::counting_iterator<size_t>(0),
+                thrust::counting_iterator<size_t>(nNodes),
+                [n2dPtr, ownPtr, targetDof, p = phiNode.data()]
+                __device__ (size_t k) {
+                    if (ownPtr[k] == 1 && n2dPtr[k] == targetDof) p[k] = RealType(1);
+                });
+            // Set xDof[targetDof] = 1.
+            thrust::for_each(thrust::device,
+                thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
+                [targetDof, x = xDof.data()] __device__ (int) { x[targetDof] = RealType(1); });
+            cudaDeviceSynchronize();
+
+            // Forward halo of phiNode so D^T scatter sees correct ghost values.
+            s.domain.exchangeNodeHalo(phiNode);
+
+            // Matrix-free path
+            applyDDTPerNode<KeyType, RealType, ElementTag>(s, phiNode, yMfNode, gx, gy, gz);
+
+            // Manual CSR SpMV: yAsm[r] = sum_{k in rowPtr[r]..rowPtr[r+1]} A[r,k] * x[k]
+            const int* rpPtr = s.d_rowPtrDDT.data();
+            const int* ciPtr = s.d_colIndDDT.data();
+            const RealType* vPtr = s.d_valuesDDT.data();
+            const RealType* xPtr = xDof.data();
+            RealType* yAsmPtr = yAsmDof.data();
+            thrust::for_each(thrust::device,
+                thrust::counting_iterator<int>(0), thrust::counting_iterator<int>((int)nOwned),
+                [rpPtr, ciPtr, vPtr, xPtr, yAsmPtr] __device__ (int r) {
+                    int rs = rpPtr[r], re = rpPtr[r + 1];
+                    RealType acc = RealType(0);
+                    for (int j = rs; j < re; ++j) acc += vPtr[j] * xPtr[ciPtr[j]];
+                    yAsmPtr[r] = acc;
+                });
+            cudaDeviceSynchronize();
+
+            // Pull both vectors back to host (small probe count, OK).
+            std::vector<RealType> hMf(nNodes), hAsm(nOwned);
+            std::vector<int> hN2D(nNodes);
+            std::vector<uint8_t> hOwn(nNodes);
+            thrust::copy(thrust::device_pointer_cast(yMfNode.data()),
+                         thrust::device_pointer_cast(yMfNode.data() + nNodes), hMf.begin());
+            thrust::copy(thrust::device_pointer_cast(yAsmDof.data()),
+                         thrust::device_pointer_cast(yAsmDof.data() + nOwned), hAsm.begin());
+            thrust::copy(thrust::device_pointer_cast(s.d_node_to_dof.data()),
+                         thrust::device_pointer_cast(s.d_node_to_dof.data() + nNodes), hN2D.begin());
+            thrust::copy(thrust::device_pointer_cast(d_nodeOwnership.data()),
+                         thrust::device_pointer_cast(d_nodeOwnership.data() + nNodes), hOwn.begin());
+
+            // Compare per OWNED dof. Print top-5 |diff|.
+            std::vector<std::pair<int, RealType>> diffs;
+            // gather yMf[node] -> per-dof
+            std::vector<RealType> yMfDof(nOwned, RealType(0));
+            for (size_t n = 0; n < nNodes; ++n) {
+                if (hOwn[n] == 1 && hN2D[n] >= 0 && hN2D[n] < (int)nOwned)
+                    yMfDof[hN2D[n]] = hMf[n];
+            }
+            for (int r = 0; r < (int)nOwned; ++r) {
+                RealType d = hAsm[r] - yMfDof[r];
+                if (std::abs(d) > 1e-12)
+                    diffs.emplace_back(r, d);
+            }
+            std::sort(diffs.begin(), diffs.end(),
+                      [](auto& a, auto& b){ return std::abs(a.second) > std::abs(b.second); });
+            if (s.rank == 0) {
+                RealType maxDiff = diffs.empty() ? RealType(0) : std::abs(diffs[0].second);
+                std::cout << "    probe dof " << targetDof << " : "
+                          << diffs.size() << " rows with |diff|>1e-12, maxDiff="
+                          << std::scientific << std::setprecision(3) << maxDiff
+                          << std::defaultfloat << "\n";
+                for (size_t k = 0; k < std::min(diffs.size(), size_t(5)); ++k) {
+                    int r = diffs[k].first;
+                    std::cout << "      row " << r
+                              << "  asm=" << std::scientific << std::setprecision(6) << hAsm[r]
+                              << "  mf="  << yMfDof[r]
+                              << "  diff="  << diffs[k].second
+                              << std::defaultfloat << "\n";
+                }
+            }
+        }
+    }
+
+#ifdef MARS_ENABLE_HYPRE
+    if (s.solverKind == SolverKind::Hypre)
+    {
+        // Build contiguous global-DOF numbering (same recipe as
+        // mars_amr_advdiff/mars_amr_pressure_poisson). Used by both matrix
+        // solves; pre and vel share the same map since they share row layout.
+        int64_t numOwnedLocal = static_cast<int64_t>(s.numOwnedDofs);
+        int64_t exscan = 0;
+        MPI_Exscan(&numOwnedLocal, &exscan, 1, MPI_INT64_T, MPI_SUM, MPI_COMM_WORLD);
+        if (s.rank == 0) exscan = 0;
+        s.globalRowStart    = exscan;
+        s.globalRowEnd      = s.globalRowStart + numOwnedLocal;
+        MPI_Allreduce(&numOwnedLocal, &s.numInteriorGlobal, 1, MPI_INT64_T, MPI_SUM, MPI_COMM_WORLD);
+
+        cstone::DeviceVector<RealType> d_nodeGlobalDof(s.nodeCount, RealType(-1));
+        {
+            const int* nodeToDofPtr = s.d_node_to_dof.data();
+            const uint8_t* ownPtr   = d_nodeOwnership.data();
+            RealType rs             = static_cast<RealType>(s.globalRowStart);
+            int nOwn                = s.numOwnedDofs;
+            thrust::for_each(thrust::device,
+                              thrust::counting_iterator<size_t>(0),
+                              thrust::counting_iterator<size_t>(s.nodeCount),
+                              [nodeToDofPtr, ownPtr, rs, nOwn,
+                               out = d_nodeGlobalDof.data()] __device__(size_t i)
+                              {
+                                  if (ownPtr[i] == 1)
+                                  {
+                                      int dof = nodeToDofPtr[i];
+                                      // Bound to owned dofs: a migrated cross-rank slave
+                                      // is still cstone-owned but its dof is the master
+                                      // GHOST dof (>= numOwned). Seeding rs+ghostdof would
+                                      // publish a wrong owned global id; instead leave it -1
+                                      // and let exchangeNodeHalo below fill it with the
+                                      // master's global id (one global row per pair).
+                                      if (dof >= 0 && dof < nOwn)
+                                          out[i] = rs + static_cast<RealType>(dof);
+                                  }
+                              });
+            s.domain.exchangeNodeHalo(d_nodeGlobalDof);
+        }
+        // Build the local-DOF -> global-DOF map directly on the device. The
+        // per-node d_nodeGlobalDof has already been halo-exchanged above, so
+        // ghost slots have the owner's global ID.
+        s.d_localToGlobalDof.resize(s.numTotalDofs);
+        thrust::fill(s.d_localToGlobalDof.begin(),
+                     s.d_localToGlobalDof.end(),
+                     HYPRE_BigInt(-1));
+        {
+            const int* nodeToDofPtr  = s.d_node_to_dof.data();
+            const RealType* gPtr     = d_nodeGlobalDof.data();
+            HYPRE_BigInt* outPtr     = thrust::raw_pointer_cast(s.d_localToGlobalDof.data());
+            thrust::for_each(thrust::device,
+                              thrust::counting_iterator<size_t>(0),
+                              thrust::counting_iterator<size_t>(s.nodeCount),
+                              [nodeToDofPtr, gPtr, outPtr] __device__(size_t i)
+                              {
+                                  int dof = nodeToDofPtr[i];
+                                  if (dof >= 0)
+                                  {
+                                      RealType g = gPtr[i];
+                                      if (g >= RealType(0))
+                                          outPtr[dof] = static_cast<HYPRE_BigInt>(g);
+                                  }
+                              });
+        }
+        cudaDeviceSynchronize();
+        pt.lap("Hypre global DOF map (on-device)");
+    }
+#endif
+
+    // Allocate the per-step solution / staging buffers (all per-node, sized
+    // nodeCount so ghost slots are addressable).
+    auto zfill = [&](cstone::DeviceVector<RealType>& v) {
+        v.resize(s.nodeCount);
+        thrust::fill(thrust::device_pointer_cast(v.data()),
+                     thrust::device_pointer_cast(v.data() + s.nodeCount),
+                     RealType(0));
+    };
+    zfill(s.d_u); zfill(s.d_v); zfill(s.d_w);
+    zfill(s.d_uStar); zfill(s.d_vStar); zfill(s.d_wStar);
+    zfill(s.d_uStarStar); zfill(s.d_vStarStar); zfill(s.d_wStarStar);
+    zfill(s.d_p); zfill(s.d_phi);
+    zfill(s.d_gradPx); zfill(s.d_gradPy); zfill(s.d_gradPz);
+    zfill(s.d_gradPhix); zfill(s.d_gradPhiy); zfill(s.d_gradPhiz);
+    // BDF2/EXT2 history: velocity at n-1 and the persistent advection
+    // accumulators for N(u^n) and N(u^(n-1)). bdfStep reset to 0; the very
+    // first runNsStep call uses BDF1 (no history), step 1+ uses BDF2.
+    if (s.useBdf2)
+    {
+        zfill(s.d_u_nm1); zfill(s.d_v_nm1); zfill(s.d_w_nm1);
+        zfill(s.d_advU_n);   zfill(s.d_advV_n);   zfill(s.d_advW_n);
+        zfill(s.d_advU_nm1); zfill(s.d_advV_nm1); zfill(s.d_advW_nm1);
+        s.bdfStep = 0;
+    }
+    pt.lap("field allocation");
+
+    pt.report(s.rank, "setup");
+}
+
+// =============================================================================
+// Set the IC -- velocity = 0 inside, lid value on top face, pressure = 0.
+// Boundary node slots already carry the right values via d_uTarget etc; we
+// just initialize the actual velocity arrays from those targets so the very
+// first predictor sees the BC correctly. Halo exchange syncs ghost slots.
+// =============================================================================
+
+template<typename RealType>
+__global__ void initialConditionKernel(const uint8_t* isBdryDof,
+                                       const int* nodeToDof,
+                                       const uint8_t* ownership,
+                                       const RealType* uTarget,
+                                       const RealType* vTarget,
+                                       const RealType* wTarget,
+                                       RealType* u,
+                                       RealType* v,
+                                       RealType* w,
+                                       size_t numNodes,
+                                       // If nonzero, set interior u=interiorU
+                                       // instead of u=0 (pump free-stream IC).
+                                       RealType interiorU,
+                                       RealType interiorV,
+                                       RealType interiorW)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    // Default interior = (interiorU, interiorV, interiorW). For cavity that is
+    // (0,0,0); for pump flow it is the free-stream (Uinf, 0, 0) so step 1's
+    // predictor doesn't see a 1-cell-thick velocity discontinuity at the inlet
+    // and extra Dirichlet faces.
+    RealType uu = interiorU, vv = interiorV, ww = interiorW;
+    if (ownership[i] == 1)
+    {
+        int dof = nodeToDof[i];
+        if (dof >= 0 && isBdryDof[dof])
+        {
+            uu = uTarget[i]; vv = vTarget[i]; ww = wTarget[i];
+        }
+    }
+    u[i] = uu; v[i] = vv; w[i] = ww;
+}
+
+// Smooth low-mode perturbation on interior (v, w) so the wing system has
+// a broken symmetry for body force / advection to amplify. Coordinate-based
+// (sinusoidal) rather than per-DOF white noise: white-noise IC fails the
+// implicit-diffusion CG on high-aspect-ratio boundary-layer cells because
+// the noise wavelength is below the mesh's local resolution in the wall-
+// normal direction, producing huge K*u_perturb and an ill-conditioned RHS.
+// NekRS's userdat2 examples (eddy_uv, taylor_green) use exactly this form:
+// few-mode trigonometric perturbation, eps*Uinf*sin(k*x)... amplitude.
+// Owned nodes only; halo resyncs ghosts after.
+template<typename RealType>
+__global__ void perturbInteriorVWKernel(const uint8_t* isBdryDof,
+                                        const int* nodeToDof,
+                                        const uint8_t* ownership,
+                                        const RealType* nodeX,
+                                        const RealType* nodeY,
+                                        const RealType* nodeZ,
+                                        RealType* v,
+                                        RealType* w,
+                                        size_t numNodes,
+                                        RealType amplitude,
+                                        RealType kx, RealType ky, RealType kz,
+                                        int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    if (isBdryDof[dof]) return;
+    RealType x = nodeX[i], y = nodeY[i], z = nodeZ[i];
+    // v: sin(kx*x) * cos(ky*y) * sin(kz*z) -- divergence-friendly, low-mode
+    // w: cos(kx*x) * sin(ky*y) * cos(kz*z) -- distinct phase so v,w differ
+    RealType vp = sin(kx * x) * cos(ky * y) * sin(kz * z);
+    RealType wp = cos(kx * x) * sin(ky * y) * cos(kz * z);
+    v[i] += amplitude * vp;
+    w[i] += amplitude * wp;
+}
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void applyInitialCondition(NSStepper<KeyType, RealType, ElementTag>& s)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    int nBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+    // Interior IC: cavity/channel default to (0,0,0). Pump starts at free-stream
+    // (Uinf, 0, 0) so step 1's predictor doesn't see a velocity discontinuity
+    // at the inlet/extra Dirichlet boundaries.
+    RealType iu = 0, iv = 0, iw = 0;
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Pump)
+    {
+        iu = s.Uinf;
+    }
+    initialConditionKernel<RealType><<<nBlocks, s.blockSize>>>(
+        s.d_isBdryDof.data(), s.d_node_to_dof.data(), d_nodeOwnership.data(),
+        s.d_uTarget.data(), s.d_vTarget.data(), s.d_wTarget.data(),
+        s.d_u.data(), s.d_v.data(), s.d_w.data(),
+        s.nodeCount, iu, iv, iw);
+    // Optional interior perturbation on (v, w). Required for wing/tunnel runs
+    // where the IC is uniform free-stream -- a discrete steady state of the
+    // predictor unless something breaks the symmetry (NekRS userdat2 pattern).
+    if (s.icPerturbMag > RealType(0))
+    {
+        RealType amp = s.icPerturbMag * s.Uinf;
+        // Few-mode trigonometric perturbation (~3 waves across each bbox axis)
+        // -- well-resolved on any mesh that resolves the geometry, regardless
+        // of anisotropy. Two-pi/(L/3) = 6*pi/L wavenumber.
+        const RealType twoPi = RealType(2) * RealType(3.14159265358979323846);
+        RealType Lx = std::max(RealType(1e-30), s.xmax - s.xmin);
+        RealType Ly = std::max(RealType(1e-30), s.ymax - s.ymin);
+        RealType Lz = std::max(RealType(1e-30), s.zmax - s.zmin);
+        RealType kx = twoPi * RealType(3) / Lx;
+        RealType ky = twoPi * RealType(3) / Ly;
+        RealType kz = twoPi * RealType(3) / Lz;
+        const auto& d_x = s.domain.getNodeX();
+        const auto& d_y = s.domain.getNodeY();
+        const auto& d_z = s.domain.getNodeZ();
+        perturbInteriorVWKernel<RealType><<<nBlocks, s.blockSize>>>(
+            s.d_isBdryDof.data(), s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            d_x.data(), d_y.data(), d_z.data(),
+            s.d_v.data(), s.d_w.data(), s.nodeCount, amp, kx, ky, kz,
+            s.numOwnedDofs);
+        if (s.rank == 0)
+        {
+            // Force scientific 4-sig-figs to override stream state leaked
+            // from prior std::fixed/std::setprecision(2) used by pt.lap printer.
+            auto oldFlags = std::cout.flags();
+            std::cout << std::scientific << std::setprecision(4)
+                      << "IC perturbation: (v, w) += eps*Uinf * smooth-mode-3, eps=" << s.icPerturbMag
+                      << " Uinf=" << s.Uinf << " amplitude=" << amp
+                      << " kx,ky,kz=(" << kx << "," << ky << "," << kz << ")"
+                      << "  (NekRS userdat2 trig-mode pattern)\n";
+            std::cout.flags(oldFlags);
+        }
+    }
+    thrust::fill(thrust::device_pointer_cast(s.d_p.data()),
+                 thrust::device_pointer_cast(s.d_p.data() + s.nodeCount),
+                 RealType(0));
+    cudaDeviceSynchronize();
+    s.domain.exchangeNodeHalo(s.d_u);
+    s.domain.exchangeNodeHalo(s.d_v);
+    s.domain.exchangeNodeHalo(s.d_w);
+    s.domain.exchangeNodeHalo(s.d_p);
+}
+
+// =============================================================================
+// One projection-method step. d_u/v/w and d_p come in as the n-state and leave
+// as the (n+1)-state. All halo exchanges between substeps are explicit.
+// =============================================================================
+
+// Helper: per-component velocity solve. b is built by the caller into b_rhs;
+// the solve writes the per-DOF solution into x, which we then scatter back to
+// the per-node array qOut. Returns iteration count.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+int solveOneComponent(NSStepper<KeyType, RealType, ElementTag>& s,
+                      cstone::DeviceVector<RealType>& b_rhs,
+                      cstone::DeviceVector<RealType>& xVec,
+                      cstone::DeviceVector<RealType>& qOut,
+                      typename NSStepper<KeyType, RealType, ElementTag>::Matrix& A,
+                      KrylovHint krylov = KrylovHint::PCG)
+{
+    bool converged = false;
+    int iters = 0;
+
+    if (s.solverKind == SolverKind::CG)
+    {
+        ConjugateGradientSolver<RealType, int, cstone::GpuTag> solver(s.maxIter, s.tolerance);
+        solver.setVerbose(false);
+        solver.setOwnedSize(s.numOwnedDofs);
+        if (s.numRanks > 1)
+        {
+            const int* dofMapPtr = s.d_node_to_dof.data();
+            auto& dom = s.domain;
+            // Periodic-aware halo exchange. The standard cstone exchange syncs
+            // owners->ghosts for ordinary shared nodes. For multi-rank periodic
+            // we additionally broadcast master->slave on the search vector p
+            // every iteration, otherwise the periodic-image DOF columns that
+            // the assembler put in the matrix reference stale values, A*p
+            // produces garbage, and pAp<=0 -> CG breakdown -> NaN.
+            const int* partnerPtr = (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+                                     && s.periodicMap)
+                                    ? s.periodicMap->d_periodicPartner.data()
+                                    : nullptr;
+            size_t nNodes = s.nodeCount;
+            int bs = s.blockSize;
+            // The per-iter master->slave broadcast on the INPUT p keeps p periodic
+            // across the seam so the matvec reads consistent values. With pairs
+            // collapsed to one owned merged DOF (owner-migration) there is no slave
+            // copy to skip, so no skip mask.
+            const uint8_t* xrSkipPtr = nullptr;
+            int nOwnedDofs = s.numOwnedDofs;
+            // Probe 3: capture firstSlaveDof and a flag for the first 2 callback
+            // invocations so we can verify p[firstSlaveDof] stays 0.
+            const bool pathbDbg = (std::getenv("MARS_PERIODIC_PATHB_DBG") != nullptr);
+            int firstSlaveDof = -1;
+            if (pathbDbg && xrSkipPtr != nullptr)
+            {
+                // Find the first dof with mask==1 on host.
+                std::vector<uint8_t> hMask(nOwnedDofs);
+                cudaMemcpy(hMask.data(), xrSkipPtr,
+                           nOwnedDofs * sizeof(uint8_t),
+                           cudaMemcpyDeviceToHost);
+                for (int i = 0; i < nOwnedDofs; ++i)
+                    if (hMask[i]) { firstSlaveDof = i; break; }
+            }
+            std::shared_ptr<int> callCounter = std::make_shared<int>(0);
+            int rankCapture = s.rank;
+            solver.setHaloExchangeCallback(
+                [&dom, dofMapPtr, partnerPtr, nNodes, bs, xrSkipPtr, nOwnedDofs,
+                 pathbDbg, firstSlaveDof, callCounter, rankCapture]
+                (cstone::DeviceVector<RealType>& p)
+                {
+                    // Probe 3a: read p[firstSlaveDof] BEFORE halo exchange/broadcast
+                    RealType pBefore = RealType(0), pAfter = RealType(0);
+                    if (pathbDbg && firstSlaveDof >= 0 && *callCounter < 3)
+                    {
+                        cudaMemcpy(&pBefore,
+                                   p.data() + firstSlaveDof,
+                                   sizeof(RealType), cudaMemcpyDeviceToHost);
+                    }
+                    dom.exchangeNodeHalo(p, dofMapPtr);
+                    if (partnerPtr)
+                    {
+                        int grd = int((nNodes + bs - 1) / bs);
+                        mars::fem::periodicBroadcastDofKernel<RealType>
+                            <<<grd, bs>>>(partnerPtr, dofMapPtr, nNodes, p.data(),
+                                          xrSkipPtr, nOwnedDofs);
+                        cudaDeviceSynchronize();
+                    }
+                    // Probe 3b: read p[firstSlaveDof] AFTER halo+broadcast.
+                    // If the skip-mask works, pAfter MUST equal pBefore (the
+                    // broadcast skipped this slot). If pAfter != pBefore, the
+                    // skip-mask is being ignored.
+                    if (pathbDbg && firstSlaveDof >= 0 && *callCounter < 3)
+                    {
+                        cudaMemcpy(&pAfter,
+                                   p.data() + firstSlaveDof,
+                                   sizeof(RealType), cudaMemcpyDeviceToHost);
+                        std::cerr << "[pathb-dbg rank " << rankCapture
+                                  << " cgcall=" << *callCounter
+                                  << "] firstSlaveDof=" << firstSlaveDof
+                                  << " p_before=" << pBefore
+                                  << " p_after=" << pAfter
+                                  << " (expect equal)" << std::endl;
+                    }
+                    ++(*callCounter);
+                });
+        }
+
+        converged = solver.solve(A, b_rhs, xVec);
+        iters = solver.getIterations();
+    }
+    else
+    {
+#ifdef MARS_ENABLE_HYPRE
+        // Env MARS_HYPRE_PRECOND=jacobi switches BoomerAMG -> Jacobi for debug.
+        // Env MARS_HYPRE_KRYLOV=pcg|gmres (DEBUG ONLY) overrides the caller's
+        // hint. Production behavior: PCG default; DDT pressure call passes
+        // GMRES explicitly.
+        KrylovHint krylovEff = krylov;
+        {
+            const char* kEnv = std::getenv("MARS_HYPRE_KRYLOV");
+            if (kEnv)
+            {
+                std::string v(kEnv);
+                if      (v == "pcg")   krylovEff = KrylovHint::PCG;
+                else if (v == "gmres") krylovEff = KrylovHint::GMRES;
+            }
+        }
+        if (krylovEff == KrylovHint::PCG)
+        {
+            using HSol = mars::fem::HyprePCGSolver<RealType, int, cstone::GpuTag>;
+            auto precond = HSol::BOOMERAMG;
+            {
+                const char* p = std::getenv("MARS_HYPRE_PRECOND");
+                if (p && std::string(p) == "jacobi") precond = HSol::JACOBI;
+            }
+            HSol hypreSolver(MPI_COMM_WORLD, s.maxIter, s.tolerance, precond);
+            hypreSolver.setVerbose(false);
+            converged = hypreSolver.solve(
+                A, b_rhs, xVec,
+                static_cast<int>(s.globalRowStart), static_cast<int>(s.globalRowEnd),
+                0, static_cast<int>(s.numInteriorGlobal),
+                s.d_localToGlobalDof);
+            iters = converged ? hypreSolver.getLastIterations() : -2;
+            if (s.rank == 0 && hypreSolver.getLastFinalResidual() > s.tolerance * 10)
+            {
+                std::cout << "  [hypre-pcg] iters=" << hypreSolver.getLastIterations()
+                          << " final_res=" << hypreSolver.getLastFinalResidual()
+                          << " (tol=" << s.tolerance << ", looser than expected)\n";
+            }
+        }
+        else  // KrylovHint::GMRES
+        {
+            using HSol = mars::fem::HypreGMRESSolver<RealType, int, cstone::GpuTag>;
+            auto precond = HSol::BOOMERAMG;
+            {
+                const char* p = std::getenv("MARS_HYPRE_PRECOND");
+                if (p && std::string(p) == "jacobi") precond = HSol::JACOBI;
+            }
+            HSol hypreSolver(MPI_COMM_WORLD, s.maxIter, s.tolerance, precond);
+            hypreSolver.setVerbose(false);
+            converged = hypreSolver.solve(
+                A, b_rhs, xVec,
+                static_cast<int>(s.globalRowStart), static_cast<int>(s.globalRowEnd),
+                0, static_cast<int>(s.numInteriorGlobal),
+                s.d_localToGlobalDof);
+            iters = converged ? hypreSolver.getLastIterations() : -2;
+            if (s.rank == 0 && hypreSolver.getLastFinalResidual() > s.tolerance * 10)
+            {
+                std::cout << "  [hypre-gmres] iters=" << hypreSolver.getLastIterations()
+                          << " final_res=" << hypreSolver.getLastFinalResidual()
+                          << " (tol=" << s.tolerance << ", looser than expected)\n";
+            }
+        }
+#else
+        if (s.rank == 0)
+            std::cerr << "ERROR: --solver=hypre requested but MARS built without MARS_ENABLE_HYPRE\n";
+        MPI_Abort(MPI_COMM_WORLD, 1);
+#endif
+    }
+    cudaDeviceSynchronize();
+
+    // Only scatter a CONVERGED solution into qOut. A failed Hypre solve
+    // (error 1 on the near-singular DDT operator) can leave xVec holding
+    // partial garbage; scattering it would poison qOut (= phi) and the
+    // corrector would turn that into a NaN velocity field, cascading the
+    // whole run. On failure we leave qOut untouched (caller warm-started it
+    // to its previous value) and signal -2 so the step is recognizably bad.
+    if (converged)
+    {
+        int nBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+        scatterDofToNodeKernel<RealType><<<nBlocks, s.blockSize>>>(
+            xVec.data(), s.d_node_to_dof.data(), qOut.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+    }
+
+    return converged ? iters : -2;
+}
+
+// =============================================================================
+// Phase E: matrix-free pressure-Poisson SpMV  A phi = (D M^{-1} D^T) phi.
+//
+// D is the per-node divergence scatter, D^T its literal transpose. A is SPSD:
+//   phi^T A phi = (D^T phi)^T M^{-1} (D^T phi) >= 0.
+// The transpose scatter (0.5*(p[L]-p[R])*A_f same-sign to L and R) integrates
+// to D^T p ~ -V grad(p), so M^{-1} D^T ~ -grad. The corrector
+//   u^{n+1} = u** - (dt/rho) * (M^{-1} D^T phi)
+// therefore adds + (dt/rho) grad(phi) to u**, and closing  D u^{n+1} = 0  gives
+//   A phi = -(rho/dt) D u**   (RHS sign matches the K-path's buildPressureRhs).
+// The K-path lacks this algebraic identity: K (Galerkin Laplacian from
+// assembleFull) is NOT D M^{-1} D^T, so its phi only approximately cancels
+// D u**. The DDT path cancels exactly, hence div_max ~ roundoff every step.
+// =============================================================================
+
+// out = A phi = (D M^{-1} D^T) phi. gxAcc/gyAcc/gzAcc are caller-allocated
+// scratch reused across CG iterations (no allocation in the hot path).
+// Mirrors mars_amr_ddt.cu's applyDDT (Stages 1+2 validated). Local addition:
+// identity-row enforcement (out[i]=phi[i]) on Dirichlet pressure DOFs --
+// either a single corner pin (cavity) or the d_isPressureBdryDof mask over
+// the outflow face (channel). Combined with b[i]=0 at the same slots, phi is
+// pinned to 0 there exactly.
+// Default arg for ElementTag is specified ONLY on the forward decl above
+// (~line 1661); repeating it here is a C++ "redefinition of default
+// argument" error.
+template<typename KeyType, typename RealType, typename ElementTag>
+void applyDDTPerNode(NSStepper<KeyType, RealType, ElementTag>& s,
+                     cstone::DeviceVector<RealType>& phi,
+                     cstone::DeviceVector<RealType>& outAcc,
+                     cstone::DeviceVector<RealType>& gxAcc,
+                     cstone::DeviceVector<RealType>& gyAcc,
+                     cstone::DeviceVector<RealType>& gzAcc,
+                     bool applyPeriodic,  // defaults on the forward decl above
+                     bool reducedPeriodicFold)
+{
+    // Matrix-free D M^-1 D^T operator. Element-generic: steps a/b/c go through
+    // the templated applyDivTransposePerNodeKernel / computeDivergencePerNodeKernel
+    // (which read c0..c3 only for tet), and the halo/periodic/normalize helpers
+    // are element-agnostic. connPtrs<ElementTag> sets c4..c7 = nullptr for tet.
+    // The only hex-specific code is the Bochev-Dohrmann lambda below (n[8],
+    // n[6], c4..c7 deref), which is already dead (if(false)) AND now also
+    // if constexpr(hex)-gated so it never compiles for tet.
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const auto& d_conn          = s.domain.getElementToNodeConnectivity();
+    // connPtrs gives NodesPerElem pointers; c4..c7 stay nullptr for tet (the
+    // templated Phase-1 kernels read c0..c3 only when ElementTag==TetTag).
+    auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+    const KeyType* c0 = cp[0]; const KeyType* c1 = cp[1];
+    const KeyType* c2 = cp[2]; const KeyType* c3 = cp[3];
+    const KeyType* c4 = nullptr; const KeyType* c5 = nullptr;
+    const KeyType* c6 = nullptr; const KeyType* c7 = nullptr;
+    if constexpr (std::is_same_v<ElementTag, HexTag>) { c4 = cp[4]; c5 = cp[5]; c6 = cp[6]; c7 = cp[7]; }
+    // OWNED-only per-element scatter. Each rank owns its share of the elements
+    // it sees; rank-boundary face contributions are picked up by the OWNER side
+    // of the face and then routed to the ghost side via reverseExchangeNodeHaloAdd
+    // immediately below. Looping owned+halo here would DOUBLE-COUNT shared faces
+    // because the halo element on this rank is the same physical element the
+    // owning rank already scatters, and reverseExchangeNodeHaloAdd then folds the
+    // ghost-side contribution back. Restored to the proven-green pattern from
+    // commit 5da5d6a (regression: div_max=1.65e-5 at cube16 cavity step 500).
+    const size_t startElem = s.domain.startIndex();
+    const size_t numLocal  = s.domain.localElementCount();
+    const int eBlocks    = numLocal > 0 ? int((numLocal + s.blockSize - 1) / s.blockSize) : 0;
+    const int nodeBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+
+    auto zeroVec = [&](cstone::DeviceVector<RealType>& v) {
+        thrust::fill(thrust::device_pointer_cast(v.data()),
+                     thrust::device_pointer_cast(v.data() + s.nodeCount), RealType(0));
+    };
+
+    // Periodic prolongation P (input side): copy phi[master] -> phi[slave] for
+    // every collapsed periodic pair BEFORE D^T reads phi. This is the MFEM/
+    // deal.II P^T A P pattern: the operator is A_reduced = P^T A P, where P
+    // spreads the single periodic DOF's value to both its node slots and P^T
+    // (maybePeriodicSum on outAcc in step c) sums both slots' contributions back
+    // onto the one DOF. Applying P here -- inside the matvec, on the operator
+    // input -- makes the D^T read transpose-consistent with the D/P^T write, so
+    // A is symmetric across the cross-rank seam. Doing this on the OPERATOR input
+    // (not by mutating the CG iterate r/p between matvecs) is what keeps the
+    // Krylov recurrence conjugate; the per-iteration broadcast it replaces is the
+    // documented anti-pattern that stalled CG on >1 rank. No-op for Dirichlet/
+    // pump (no periodic map). The slave's own incoming value is overwritten and
+    // inert -- it never contributes to a dot product (ownedDot skips slaves).
+    // applyPeriodic=false (reduced P^T A P path): the caller has ALREADY done the
+    // node-indexed prolongation P (scatter dof->node + periodic master->slave +
+    // plain node halo) before this matvec, so the input is already periodic-
+    // consistent. Re-applying P here would double the prolongation. Gated so the
+    // bare element-op-only operator (this branch off, the g-bcast off, the output
+    // P^T off) is structurally self-adjoint. Default true keeps every existing
+    // node-indexed caller bit-identical.
+    if (applyPeriodic
+        && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.periodicMap)
+    {
+        const int* d_partner = s.periodicMap->d_periodicPartner.data();
+        mars::fem::periodicBroadcastSameRankKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            d_partner, d_nodeOwnership.data(), s.nodeCount, phi.data());
+        cudaDeviceSynchronize();
+        if (s.numRanks > 1)
+            mars::fem::crossRankPeriodicBroadcast<KeyType, RealType>(*s.periodicMap, phi);
+        s.domain.exchangeNodeHalo(phi);
+    }
+
+    // Step a: g = D^T phi (un-normalized per-node 3-vector accumulator).
+    zeroVec(gxAcc); zeroVec(gyAcc); zeroVec(gzAcc);
+    if (eBlocks > 0)
+    {
+        applyDivTransposePerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+            c0, c1, c2, c3, c4, c5, c6, c7, phi.data(),
+            s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+            gxAcc.data(), gyAcc.data(), gzAcc.data(), startElem, numLocal);
+        cudaDeviceSynchronize();
+    }
+    // Reverse-halo each component so the owner sees contributions from neighbor
+    // ranks' local elements at corner-only-neighbor nodes.
+    s.domain.reverseExchangeNodeHaloAdd(gxAcc);
+    s.domain.reverseExchangeNodeHaloAdd(gyAcc);
+    s.domain.reverseExchangeNodeHaloAdd(gzAcc);
+    // Periodic P^T on the intermediate gradient. Off on the reduced path: there
+    // the single restriction P^T is applied once on the final output (in the
+    // caller, sum-only), and folding the slave g onto the master here too would
+    // be a second, unpaired P^T inside the operator -> asymmetric.
+    if (applyPeriodic)
+    {
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, gxAcc);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, gyAcc);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, gzAcc);
+    }
+
+    // Step b: g <- M^{-1} g (in-place; gather is same-index, safe).
+    normalizeGradientPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+        gxAcc.data(), gyAcc.data(), gzAcc.data(), s.d_massNode.data(),
+        s.d_node_to_dof.data(), d_nodeOwnership.data(),
+        gxAcc.data(), gyAcc.data(), gzAcc.data(), s.nodeCount);
+    cudaDeviceSynchronize();
+    // Forward halo: D-scatter in step c reads g[iL], g[iR] at ghost slots too.
+    s.domain.exchangeNodeHalo(gxAcc);
+    s.domain.exchangeNodeHalo(gyAcc);
+    s.domain.exchangeNodeHalo(gzAcc);
+
+    // MARS_OP_GRADDUMP=1 (one-shot, first matvec): dump g[M] and g[S] inside
+    // the operator at the first owned cross-rank periodic pair. Tells us whether
+    // |g[S]| ≈ 0.65*|g[M]| (matches FACTOR=1.65 = 1 + 0.65) so the missing
+    // master->slave g-broadcast is exactly the algebraic gap.
+    {
+        static int s_opGradDumpCount = 0;
+        const char* envDump = std::getenv("MARS_OP_GRADDUMP");
+        if (envDump && envDump[0] == '1' && s_opGradDumpCount < 1 && s.periodicMap)
+        {
+            s_opGradDumpCount++;
+            const int* partnerP = s.periodicMap->d_periodicPartner.data();
+            const uint8_t* ownP = d_nodeOwnership.data();
+            const size_t N = s.nodeCount;
+            // find first owned slave with cross-rank ghost master
+            long long localFirst = thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0),
+                thrust::counting_iterator<size_t>(N),
+                [partnerP, ownP, N] __device__ (size_t i) -> long long {
+                    if (ownP[i] != 1) return (long long)N;
+                    int m = partnerP[i];
+                    if (m < 0 || ownP[m] == 1) return (long long)N;
+                    return (long long)i;
+                }, (long long)N, thrust::minimum<long long>());
+            if (localFirst < (long long)N) {
+                size_t i = (size_t)localFirst;
+                int h_m;
+                RealType h_gS[3], h_gM[3];
+                cudaMemcpy(&h_m, partnerP + i, sizeof(int), cudaMemcpyDeviceToHost);
+                cudaMemcpy(&h_gS[0], gxAcc.data() + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                cudaMemcpy(&h_gS[1], gyAcc.data() + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                cudaMemcpy(&h_gS[2], gzAcc.data() + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                cudaMemcpy(&h_gM[0], gxAcc.data() + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                cudaMemcpy(&h_gM[1], gyAcc.data() + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                cudaMemcpy(&h_gM[2], gzAcc.data() + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                RealType nM = std::sqrt(h_gM[0]*h_gM[0]+h_gM[1]*h_gM[1]+h_gM[2]*h_gM[2]);
+                RealType nS = std::sqrt(h_gS[0]*h_gS[0]+h_gS[1]*h_gS[1]+h_gS[2]*h_gS[2]);
+                std::cout << "  [OP_GRADDUMP r" << s.rank << "] PRE-BCAST i=" << i
+                          << " m=" << h_m
+                          << "  g[M]=(" << h_gM[0] << "," << h_gM[1] << "," << h_gM[2] << ")"
+                          << "  g[S]=(" << h_gS[0] << "," << h_gS[1] << "," << h_gS[2] << ")"
+                          << "  |gM|=" << nM << "  |gS|=" << nS
+                          << "  ratio_|gS|/|gM|=" << (nM > 0 ? nS/nM : RealType(0))
+                          << std::endl;
+            }
+        }
+    }
+
+    // Periodic g-consistency: maybePeriodicSum above merged the same-rank slave
+    // accumulator onto the master and ZEROED the slave slot; normalize then left
+    // g[slave]=0/mass=0 while g[master] carries M^-1 D^T phi. The forward halo
+    // does NOT fix this (slave and master have distinct SFC keys). If step c
+    // scatters with g[slave]=0 the D operator is ASYMMETRIC at the periodic
+    // face and the projection identity div(u^{n+1})=0 never closes there.
+    // Broadcast g master->slave (same-rank only) so both node slots of the one
+    // collapsed DOF hold the same value -> symmetric D-scatter. No-op for
+    // Dirichlet/pump (no periodic map) and for cross-rank slaves.
+    // applyPeriodic=false (reduced path): this master->slave g-overwrite is the
+    // documented adjointness-breaker (an overwrite is not self-adjoint). The
+    // reduced P^T A P operator must be BARE (element op + cstone halo only), so
+    // it is gated entirely off there.
+    // MARS_OP_GBCAST_REDUCED=1: enable the master->slave g-broadcast on the
+    // reduced-CG path (applyPeriodic=false, reducedPeriodicFold=true). Per
+    // workflow w2luca219 algebra: the RHS path broadcasts u**[slave]=u**[master]
+    // before its D-scatter (NS:7434-7438), so b[master_DOF] sees u**[S]=u**[M].
+    // The bare reduced operator does NOT do the analogous g-broadcast, so the
+    // operator's slave-side D-scatter reads g[S]=G_S/m_merged (= ~0.65*|g[M]|
+    // per GRADDUMP empirics), producing FACTOR=1.65 and PROJ-P3=0.508. Enabling
+    // this mirrors the RHS path; algebra predicts PROJ-P3 -> 0. SYMPROBE may
+    // break (workflow's risk).
+    static const bool opGbcastReduced = (std::getenv("MARS_OP_GBCAST_REDUCED") != nullptr);
+    if ((applyPeriodic || (reducedPeriodicFold && opGbcastReduced))
+        && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.periodicMap)
+    {
+        // Diagnostic toggles (MARS_DDT_SYMPROBE workflow): the master->slave
+        // broadcast of g overwrites the slave slot, which is NOT self-adjoint;
+        // inserting it unpaired between M^-1 and the D-scatter can break the
+        // symmetry of A = D M^-1 D^T. These two env vars let us disable each
+        // broadcast independently (without recompiling) to MEASURE which one
+        // breaks adjointness via the symmetry probe. Default (unset) = both
+        // broadcasts ON = current behavior. Read once, cache in a static bool.
+        static const bool skipSrGbcast = (std::getenv("MARS_DDT_NO_SR_GBCAST") != nullptr);
+        static const bool skipXrGbcast = (std::getenv("MARS_DDT_NO_XR_GBCAST") != nullptr);
+
+        const int* d_partner = s.periodicMap->d_periodicPartner.data();
+        if (!skipSrGbcast)
+        {
+            mars::fem::periodicBroadcastSameRankKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                d_partner, d_nodeOwnership.data(), s.nodeCount, gxAcc.data());
+            mars::fem::periodicBroadcastSameRankKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                d_partner, d_nodeOwnership.data(), s.nodeCount, gyAcc.data());
+            mars::fem::periodicBroadcastSameRankKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                d_partner, d_nodeOwnership.data(), s.nodeCount, gzAcc.data());
+            cudaDeviceSynchronize();
+        }
+        // Cross-rank leg: refresh a cross-rank slave's OWNED g slot from the
+        // master's owner rank. The forward halo above only touches ghosts, and
+        // the same-rank kernel skipped this pair (master is a ghost here). The
+        // subsequent D-scatter (step c) reads g[slave] and g[master] at the
+        // seam; they must be equal or D is asymmetric there. No-op when peers_
+        // empty (single-rank / no cross-rank pairs).
+        if (s.numRanks > 1 && !skipXrGbcast)
+        {
+            mars::fem::crossRankPeriodicBroadcast<KeyType, RealType>(*s.periodicMap, gxAcc);
+            mars::fem::crossRankPeriodicBroadcast<KeyType, RealType>(*s.periodicMap, gyAcc);
+            mars::fem::crossRankPeriodicBroadcast<KeyType, RealType>(*s.periodicMap, gzAcc);
+        }
+    }
+
+    // Step c: out = D g (un-normalized per-node divergence accumulator).
+    zeroVec(outAcc);
+    if (eBlocks > 0)
+    {
+        computeDivergencePerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+            c0, c1, c2, c3, c4, c5, c6, c7,
+            gxAcc.data(), gyAcc.data(), gzAcc.data(),
+            s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+            outAcc.data(), startElem, numLocal);
+        cudaDeviceSynchronize();
+    }
+    // Reduced-DOF P^T: fold the periodic slave's contribution onto its partner
+    // (master, possibly a GHOST) BEFORE the reverse-halo. This is the exact
+    // transpose of STEP P's order (scatter -> halo -> broadcast): P^T must be
+    // fold -> reverse-halo -> gather. periodicFoldToMasterKernel = transpose of
+    // periodicBroadcastKernel (no ownership gate, so cross-rank slaves fold onto
+    // the master-GHOST); the reverseExchangeNodeHaloAdd below then carries those
+    // ghost contributions to the master's owner -- the transpose of the halo that
+    // delivered the master value to the ghost in STEP P. Same-rank slaves fold
+    // directly onto the owned master. Doing this AFTER the reverse-halo (the old
+    // order) left cross-rank folds on a ghost the halo had already processed ->
+    // asymmetric A (SYMPROBE rel~0.2). Only on the reduced path.
+    if (reducedPeriodicFold && s.periodicMap)
+    {
+        int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
+        mars::fem::periodicFoldToMasterKernel<RealType><<<grd, blk>>>(
+            s.periodicMap->d_periodicPartner.data(), s.nodeCount, outAcc.data());
+        cudaDeviceSynchronize();
+    }
+    s.domain.reverseExchangeNodeHaloAdd(outAcc);
+    // Diagnostic gate: MARS_DDT_NO_PERIODIC_SUM=1 disables the cross-rank
+    // slave->master Ap sum on the SpMV result. Under the conditional-collapse
+    // design, slave_on_A and master_on_D are separate owned DOFs representing
+    // two distinct equations. The cross-rank slave->master sum was designed
+    // for the OLD shared-DOF design and now merges two equations -> non-SPD.
+    // Standard cstone reverseExchangeNodeHaloAdd already routes per-node
+    // ghost accumulations to their owners by SFC key, so the cross-rank
+    // physics SHOULD be captured by the reverseExchange alone -- as long as
+    // the matrix-free operator emits the correct per-node face contributions
+    // and the periodic-image element is iterated on both ranks.
+    // applyPeriodic=false (reduced path): the single restriction P^T is applied
+    // once by the caller (sum-only maybePeriodicSum + node->dof gather). Doing it
+    // here too would be a double P^T. The bare reverseExchangeNodeHaloAdd above
+    // (real cstone ghost->owner, NOT periodic) stays unconditional.
+    if (applyPeriodic && std::getenv("MARS_DDT_NO_PERIODIC_SUM") == nullptr)
+    {
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, outAcc);
+    }
+    else if (applyPeriodic && std::getenv("MARS_DDT_PROBE") != nullptr && s.rank == 0)
+    {
+        // One-shot print so we see the gate is active.
+        static bool printed = false;
+        if (!printed) { std::cerr << "[ddt] periodic-sum DISABLED on Ap" << std::endl; printed = true; }
+    }
+
+    // NOTE: BD is intentionally NOT applied to the matrix-free DDT operator.
+    // Adding S*phi to (D M^-1 D^T) phi breaks the algebraic identity
+    // div(u^{n+1}) = 0 that DDT is built for: the corrector
+    // u^{n+1} = u** - dt/rho * grad phi cancels exactly only when phi solves
+    // (D M^-1 D^T) phi = source. BD on the DDT path produces a phi that does
+    // NOT cancel divergence, and the residual is proportional to the BD
+    // strength -- destroying the whole point of using DDT. For periodic
+    // pressure runs use --pressure-solve=K, which is regularized by BD via
+    // the assembled d_valuesPre matrix.
+    // if constexpr(hex): the lambda reads n[8]={c0..c7} and n[6] (fixed hex
+    // 8-corner stencil). Already dead via if(false); the if constexpr keeps the
+    // c4..c7 / n[6] deref out of the tet compile entirely.
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    if (false && s.stabBochevDohrmann && eBlocks > 0)
+    {
+        RealType tau = s.stabPressureTau;
+        if (tau <= 0)
+        {
+            RealType bx = std::max(RealType(1e-30), s.xmax - s.xmin);
+            RealType by = std::max(RealType(1e-30), s.ymax - s.ymin);
+            RealType bz = std::max(RealType(1e-30), s.zmax - s.zmin);
+            RealType h = std::cbrt((bx * by * bz) /
+                                   RealType(std::max<size_t>(1, s.elementCount)));
+            // Match the K-path auto-tau (lumped BD over-stabilizes by ~27x
+            // on checkerboard vs consistent form, see scratch/verify_bd.py).
+            tau = h * h / RealType(8);
+        }
+        const RealType* d_xNode = s.domain.getNodeX().data();
+        const RealType* d_yNode = s.domain.getNodeY().data();
+        const RealType* d_zNode = s.domain.getNodeZ().data();
+        RealType* outPtr        = outAcc.data();
+        const RealType* phiPtr  = phi.data();
+        thrust::for_each(thrust::device,
+            thrust::counting_iterator<size_t>(0),
+            thrust::counting_iterator<size_t>(numLocal),
+            [c0, c1, c2, c3, c4, c5, c6, c7, startElem,
+             d_xNode, d_yNode, d_zNode,
+             tau, outPtr, phiPtr,
+             ownPtr = d_nodeOwnership.data(), n2d = s.d_node_to_dof.data()]
+            __device__ (size_t k) {
+                size_t e = startElem + k;
+                KeyType n[8] = {c0[e], c1[e], c2[e], c3[e], c4[e], c5[e], c6[e], c7[e]};
+                RealType x0 = d_xNode[n[0]], x6 = d_xNode[n[6]];
+                RealType y0 = d_yNode[n[0]], y6 = d_yNode[n[6]];
+                RealType z0 = d_zNode[n[0]], z6 = d_zNode[n[6]];
+                RealType V_e = fabs((x6 - x0) * (y6 - y0) * (z6 - z0));
+                // S^e_ij = tau V_e (delta_ij/8 - 1/64); algebra collapses
+                // (S^e phi)_i to tau V_e (phi_i - meanPhi) / 8.
+                RealType phiE[8];
+                #pragma unroll
+                for (int i = 0; i < 8; ++i) phiE[i] = phiPtr[n[i]];
+                RealType meanPhi = RealType(0);
+                #pragma unroll
+                for (int i = 0; i < 8; ++i) meanPhi += phiE[i];
+                meanPhi *= RealType(1)/RealType(8);
+                // (S phi)_i = tau V_e (phi_i - meanPhi) / 8  -- equivalent
+                // to diagC phi_i + offC sum_{j!=i} phi_j after algebra.
+                #pragma unroll
+                for (int i = 0; i < 8; ++i) {
+                    if (ownPtr[n[i]] != 1) continue;
+                    if (n2d[n[i]] < 0) continue;
+                    RealType contrib = tau * V_e * (phiE[i] - meanPhi) / RealType(8);
+                    atomicAdd(&outPtr[n[i]], contrib);
+                }
+            });
+        cudaDeviceSynchronize();
+        s.domain.reverseExchangeNodeHaloAdd(outAcc);
+        // BD scatter: same gate as the main DDT sum above.
+        if (std::getenv("MARS_DDT_NO_PERIODIC_SUM") == nullptr)
+        {
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, outAcc);
+        }
+    }
+
+    // Identity-row enforcement on pinned pressure DOFs (cavity: single corner;
+    // channel: outflow-face mask). out[i] = phi[i] makes the row act as identity.
+    // applyPeriodic=false (reduced path): TGV is pure-Neumann periodic with no
+    // pin/mask, so this is a no-op there anyway; gating it keeps the reduced
+    // operator strictly bare (element op + cstone halo) and self-adjoint.
+    const int pinDof          = s.pressurePinDof;
+    const uint8_t* maskPtr    = (s.d_isPressureBdryDof.size() > 0)
+                                ? s.d_isPressureBdryDof.data() : nullptr;
+    if (applyPeriodic && (pinDof >= 0 || maskPtr != nullptr))
+    {
+        const int  numOwnedDofs = s.numOwnedDofs;
+        const int* dofPtr       = s.d_node_to_dof.data();
+        const uint8_t* ownPtr   = d_nodeOwnership.data();
+        const RealType* phPtr   = phi.data();
+        RealType* outPtr        = outAcc.data();
+        thrust::for_each(thrust::device,
+            thrust::counting_iterator<size_t>(0),
+            thrust::counting_iterator<size_t>(s.nodeCount),
+            [pinDof, maskPtr, dofPtr, ownPtr, phPtr, outPtr, numOwnedDofs] __device__ (size_t i) {
+                if (ownPtr[i] != 1) return;
+                int dof = dofPtr[i];
+                if (dof < 0 || dof >= numOwnedDofs) return;
+                bool flagged = (pinDof >= 0 && dof == pinDof) ||
+                               (maskPtr != nullptr && maskPtr[dof] != 0);
+                if (flagged) outPtr[i] = phPtr[i];
+            });
+        cudaDeviceSynchronize();
+    }
+}
+
+// =============================================================================
+// DOF-space helpers for the reduced (P^T A P) periodic-pressure CG. These run
+// over [0, numOwnedDofs) -- the single unknown per periodic pair. The slave DOF
+// of a cross-rank pair does NOT exist as a live unknown here (its node slot is
+// summed onto the master by the sum-only P^T and then counted once via the
+// xr-slave mask). All trivial / element-agnostic, hence templated on RealType.
+// Defined before applyDDTReduced / solvePressureDDTReduced so the kernel names
+// are visible at their use sites.
+// =============================================================================
+
+// P^T (restriction) node->dof: fold every owned node's value onto its DOF.
+// For a same-rank periodic pair both node slots already carry node_to_dof[]==
+// the same DOF, so both slots atomicAdd onto the one DOF automatically (the
+// same-rank collapse the setup did). For a cross-rank pair the caller has
+// already run the sum-only periodic P^T (maybePeriodicSum) on the NODE array,
+// which zeroed the slave's node slot, so this gather adds 0 from the slave.
+template<typename RealType>
+__global__ void gatherNodeToDofSumKernel(const RealType* nodeIn,
+                                         const int* nodeToDof,
+                                         const uint8_t* ownership,
+                                         RealType* dofOut,
+                                         size_t numNodes,
+                                         int numOwnedDofs)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dof = nodeToDof[i];
+    if (dof < 0 || dof >= numOwnedDofs) return;
+    atomicAdd(&dofOut[dof], nodeIn[i]);
+}
+
+// Jacobi precond in DOF space: z = r / max(diag, eps) over [0,n).
+template<typename RealType>
+__global__ void jacobiPrecondDofKernel(const RealType* r, const RealType* diag,
+                                       RealType eps, RealType* z, int n)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    RealType d = diag[i];
+    if (d < eps) d = eps;
+    z[i] = r[i] / d;
+}
+
+// axpy in DOF space: out = a + alpha * b over [0,n).
+template<typename RealType>
+__global__ void axpyDofKernel(RealType* out, const RealType* a, const RealType* b,
+                              RealType alpha, int n)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    out[i] = a[i] + alpha * b[i];
+}
+
+// DOF-space inner product, counting the co-owned cross-rank seam DOF ONCE
+// globally: a cross-rank pair has its slave DOF owned HERE and its master DOF
+// owned on the partner rank; both rank-local sums would otherwise add the same
+// physical unknown twice. Skip i where xrSlaveMask[i] (the slave copy) so the
+// master copy on the owner rank is the sole contributor, then Allreduce SUM.
+// xrSlaveMask == nullptr (single-rank or no cross-rank pairs) -> plain owned-DOF
+// dot, unchanged.
+template<typename RealType>
+RealType dotDof(const cstone::DeviceVector<RealType>& a,
+                const cstone::DeviceVector<RealType>& b,
+                int numOwnedDofs,
+                const uint8_t* xrSlaveMask)
+{
+    const RealType* aPtr = a.data();
+    const RealType* bPtr = b.data();
+    RealType localSum = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<int>(0),
+        thrust::counting_iterator<int>(numOwnedDofs),
+        [aPtr, bPtr, xrSlaveMask] __device__ (int i) -> RealType {
+            if (xrSlaveMask && xrSlaveMask[i]) return RealType(0);
+            return aPtr[i] * bPtr[i];
+        }, RealType(0), thrust::plus<RealType>());
+    RealType globalSum = 0;
+    auto mpiType = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+    MPI_Allreduce(&localSum, &globalSum, 1, mpiType, MPI_SUM, MPI_COMM_WORLD);
+    return globalSum;
+}
+
+// =============================================================================
+// Reduced (P^T A P) matrix-free DDT operator for MULTI-RANK periodic pressure.
+// The CG that calls this runs in REDUCED DOF space: one unknown per periodic
+// pair, the slave DOF is NOT a live unknown. The seam stays symmetric because
+// the operator is assembled as a clean P^T A P:
+//
+//   p_dof  --P-->  phiNode  --A(bare)-->  ApNode  --P^T(sum-only)-->  Ap_dof
+//
+//   P   (prolongation, NODE-indexed): scatter dof->node, then broadcast the
+//       master's value into the slave's NODE slot (same-rank kernel + cross-
+//       rank broadcast), then a PLAIN node halo. This makes phiNode periodic-
+//       consistent in exactly the layout applyDivTransposePerNodeKernel reads
+//       (phi[iL], phi[iR] by NODE index).
+//   A   bare self-adjoint element op + cstone halo (applyPeriodic=false): no
+//       g-broadcast, no in-operator P^T, no identity rows.
+//   P^T (restriction, sum-only): maybePeriodicSum's cross leg is broadcastBack
+//       =false, so the slave NODE slot is summed onto the master and left ZERO
+//       -- the transpose of the node-indexed P above. Then node->dof gather.
+//
+// After this the slave DOF's Ap is structurally 0 (its node contribution was
+// summed onto the master); combined with dotDof skipping xr-slave DOFs, the
+// slave is a Dirichlet identity in reduced space, counted once -> SYMMETRIC by
+// construction. Gated numRanks>1 by the caller (single rank uses the proven
+// node-indexed solvePressureDDT, byte-identical).
+//
+// phiNode / ApNode / gx / gy / gz are nodeCount-sized scratch. p_dof / Ap_dof
+// are numOwnedDofs-sized.
+// =============================================================================
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void applyDDTReduced(NSStepper<KeyType, RealType, ElementTag>& s,
+                     const cstone::DeviceVector<RealType>& p_dof,
+                     cstone::DeviceVector<RealType>& Ap_dof,
+                     cstone::DeviceVector<RealType>& phiNode,
+                     cstone::DeviceVector<RealType>& ApNode,
+                     cstone::DeviceVector<RealType>& gx,
+                     cstone::DeviceVector<RealType>& gy,
+                     cstone::DeviceVector<RealType>& gz)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const int nodeBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+
+    // STEP P: prolong p_dof -> phiNode (NODE-indexed), then make every slave NODE
+    // slot carry its master's value so the element D^T read is periodic.
+    //
+    // Communication is cstone's halo ONLY -- no bespoke periodic MPI. The
+    // periodic image of a master IS a cstone ghost on the slave's rank, so a
+    // plain exchangeNodeHalo delivers the master value into the master-GHOST node
+    // slot; a LOCAL periodicBroadcastKernel (phiNode[slave]=phiNode[partner],
+    // partner = master's local node/ghost index) then copies it onto the slave.
+    // Order matters: scatter -> halo (master ghost now valid) -> local broadcast.
+    // This replaces crossRankPeriodicBroadcast (a hand-rolled, redundant
+    // Isend/Irecv layer that duplicated the halo and crashed on the asymmetric
+    // seam). cstone's exchangeNodeHalo is the single, proven, index-safe comm.
+    // dofBound=numOwnedDofs: p_dof is numOwnedDofs-sized, but we loop all nodes
+    // incl. ghosts (nodeToDof>=numOwnedDofs) -> bound the read so owned node slots
+    // get p_dof and ghost slots stay 0 (the halo below fills them from owners).
+    scatterDofToNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+        p_dof.data(), s.d_node_to_dof.data(), phiNode.data(), s.nodeCount,
+        s.numOwnedDofs);
+    cudaDeviceSynchronize();
+    // PLAIN node-indexed halo (NO nodeToDof): phiNode is NODE-indexed; this fills
+    // the master-ghost NODE slot by node index, matching applyDivTransposePerNodeKernel.
+    s.domain.exchangeNodeHalo(phiNode);
+    if (s.periodicMap)
+    {
+        // Local master->slave copy (no MPI). periodicBroadcastKernel reads
+        // phiNode[d_periodicPartner[slave]]: for a same-rank pair the master is
+        // owned here, for a cross-rank pair it is the master GHOST the halo above
+        // just filled. Either way the slave node slot gets the master value.
+        int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
+        mars::fem::periodicBroadcastKernel<<<grd, blk>>>(
+            s.periodicMap->d_periodicPartner.data(), s.nodeCount, phiNode.data());
+        cudaDeviceSynchronize();
+    }
+
+    // STEP A + STEP P^T (fold leg): applyDDTPerNode with reducedPeriodicFold=true.
+    // The bare element op runs (applyPeriodic=false), then INSIDE applyDDTPerNode
+    // the correct-order P^T fold happens: periodicFoldToMasterKernel(outAcc)
+    // [slave->partner, incl. cross-rank slave->master-GHOST] BEFORE its
+    // reverseExchangeNodeHaloAdd [ghost->owner]. That ordering (fold THEN
+    // reverse-halo) is the exact transpose of STEP P (halo THEN broadcast), so
+    // A = P^T A P is symmetric across the seam. After this ApNode has every
+    // periodic contribution summed onto the (owned) master and slave slots zero.
+    applyDDTPerNode<KeyType, RealType, ElementTag>(s, phiNode, ApNode, gx, gy, gz,
+                                                   /*applyPeriodic=*/false,
+                                                   /*reducedPeriodicFold=*/true);
+
+    // node->dof sum: the DOF-space half of P^T. Slave node slot is 0 (folded
+    // onto master above), so the slave DOF gathers 0 and stays Dirichlet-zero.
+    thrust::fill(thrust::device_pointer_cast(Ap_dof.data()),
+                 thrust::device_pointer_cast(Ap_dof.data() + s.numOwnedDofs), RealType(0));
+    gatherNodeToDofSumKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+        ApNode.data(), s.d_node_to_dof.data(), d_nodeOwnership.data(),
+        Ap_dof.data(), s.nodeCount, s.numOwnedDofs);
+    cudaDeviceSynchronize();
+}
+
+// Plain Euclidean dot over owned nodes (CG operates on un-normalized acc form).
+// d_partner (optional): the periodic partner table. A periodic slave (partner>=0)
+// ALIASES its master's DOF -- it is the SAME equation living on a second node.
+// In the DDT path maybePeriodicSum merges the slave onto the master and zeroes/
+// mirrors the slave slot, and bcastMasterToSlave keeps slave==master, so the pair
+// is ONE DOF. Counting the slave would weight that DOF twice: by face multiplicity
+// for a same-rank pair, and GLOBALLY (slave on this rank + master on the owner
+// rank) for a cross-rank pair. The latter breaks SPD -> pAp<=0 -> CG breakdown.
+// So we skip ALL slaves; the DOF is counted exactly once on the rank that owns its
+// master (where ownership[master]==1). d_partner==nullptr (Dirichlet/pump, no
+// collapse) reduces to the old owned-node dot exactly.
+template<typename RealType>
+RealType ownedDot(const cstone::DeviceVector<RealType>& a,
+                  const cstone::DeviceVector<RealType>& b,
+                  const cstone::DeviceVector<int>& d_nodeToDof,
+                  const uint8_t* d_ownership,
+                  size_t numNodes,
+                  const int* d_partner = nullptr)
+{
+    const RealType* aPtr = a.data();
+    const RealType* bPtr = b.data();
+    const int* dofPtr    = d_nodeToDof.data();
+    RealType localSum = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<size_t>(0),
+        thrust::counting_iterator<size_t>(numNodes),
+        [aPtr, bPtr, dofPtr, d_ownership, d_partner] __device__ (size_t i) -> RealType {
+            if (d_ownership[i] != 1 || dofPtr[i] < 0) return RealType(0);
+            if (d_partner && d_partner[i] >= 0) return RealType(0);
+            return aPtr[i] * bPtr[i];
+        }, RealType(0), thrust::plus<RealType>());
+    RealType globalSum = 0;
+    auto mpiType = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+    MPI_Allreduce(&localSum, &globalSum, 1, mpiType, MPI_SUM, MPI_COMM_WORLD);
+    return globalSum;
+}
+
+// out = a + alpha * b on owned nodes only (ghosts untouched).
+template<typename RealType>
+__global__ void axpyOwnedKernel(RealType* out, const RealType* a, const RealType* b,
+                                RealType alpha,
+                                const int* nodeToDof, const uint8_t* ownership,
+                                size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1 || nodeToDof[i] < 0) return;
+    out[i] = a[i] + alpha * b[i];
+}
+
+// DDT pressure RHS: b = -coef * divAccNode  (coef = rho/dt).
+// Sign comes from the projection algebra. D^T as written
+// (applyDivTransposePerNodeKernel: same-sign 0.5*(p[L]-p[R])*A to both L,R)
+// integrates to  D^T p ~ -V * grad(p)  so  M^{-1} D^T ~ -grad. The corrector
+// u^{n+1} = u** - (dt/rho) * gradPhiq  with gradPhiq = M^{-1} D^T phi  then
+// adds  +(dt/rho) grad(phi) to u**. Closing  D u^{n+1} = D u** + (dt/rho) A phi
+// to zero requires  A phi = -(rho/dt) D u**, i.e. RHS has negative sign.
+// Same magnitude/sign convention as the K-path's buildPressureRhsKernel.
+template<typename RealType>
+__global__ void buildPressureRhsDDTKernel(const RealType* divAccNode,
+                                          const int* nodeToDof,
+                                          const uint8_t* ownership,
+                                          RealType coef, RealType* rhsNode,
+                                          size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1 || nodeToDof[i] < 0) { rhsNode[i] = RealType(0); return; }
+    // Confirmed by sign-discrimination test (mars_amr_ddt.cu --test=sign):
+    // A models the standard -Laplacian (all three axes give (A*phi)/V_i ~ -2
+    // for phi=coord^2). Closing the projection D u^{n+1}=0 with corrector
+    // u = u** - (dt/rho) grad(phi) requires A phi = -(rho/dt) D u**.
+    rhsNode[i] = -coef * divAccNode[i];
+}
+
+// DOF-space mean removal for the reduced periodic-pressure path ONLY. The
+// reduced DDT operator is pure-Neumann (constant null mode), so b must be
+// projected onto range(A) (sum=0) and phi pinned by removing its mean. We skip
+// xr-slave DOFs from BOTH the sum and the count so the co-owned seam DOF is
+// counted exactly once globally (it is the master copy on the owner rank that
+// counts), then subtract the mean from every NON-slave DOF (slave rows stay at
+// their Dirichlet-zero value). This is a NEW function used only on b_dof/phi_dof
+// in the reduced path -- the existing NODE-space removeMean calls on d_bNode and
+// s.d_phi are deliberately NOT routed through it (they operate on node arrays
+// with a different counting rule and are shared by the K / single-rank paths).
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void removeMeanDof(NSStepper<KeyType, RealType, ElementTag>& s,
+                   cstone::DeviceVector<RealType>& vec_dof)
+{
+    if (s.numOwnedDofs <= 0) return;
+    const uint8_t* xrMask = nullptr;
+    RealType* vp = vec_dof.data();
+    RealType localSum = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<int>(0),
+        thrust::counting_iterator<int>(s.numOwnedDofs),
+        [vp, xrMask] __device__ (int i) -> RealType {
+            if (xrMask && xrMask[i]) return RealType(0);
+            return vp[i];
+        }, RealType(0), thrust::plus<RealType>());
+    long long localN = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<int>(0),
+        thrust::counting_iterator<int>(s.numOwnedDofs),
+        [xrMask] __device__ (int i) -> long long {
+            return (xrMask && xrMask[i]) ? 0LL : 1LL;
+        }, 0LL, thrust::plus<long long>());
+    RealType globalSum = 0;
+    long long globalN = 0;
+    auto mpiType = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+    MPI_Allreduce(&localSum, &globalSum, 1, mpiType, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&localN,   &globalN,   1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+    if (globalN <= 0) return;
+    RealType mean = globalSum / RealType(globalN);
+    thrust::for_each(thrust::device,
+        thrust::counting_iterator<int>(0),
+        thrust::counting_iterator<int>(s.numOwnedDofs),
+        [vp, xrMask, mean] __device__ (int i) {
+            if (xrMask && xrMask[i]) return;
+            vp[i] -= mean;
+        });
+}
+
+// Reduced-DOF Jacobi-PCG for the multi-rank periodic DDT pressure solve. Runs
+// in REDUCED space ([0,numOwnedDofs), one unknown per periodic pair) with
+// applyDDTReduced as the matvec (P^T A P). The slave DOF is never a live
+// unknown and the iterate is NEVER mutated to enforce slave==master -- that is
+// the whole point: the P/P^T pairing keeps A symmetric across the seam so the
+// Krylov recurrence stays conjugate. Multi-rank only (asserted); single-rank
+// stays on the node-indexed solvePressureDDT. Mirrors that CG's recurrence but
+// over dof-space vectors via dotDof / axpyDofKernel / jacobiPrecondDofKernel.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+int solvePressureDDTReduced(NSStepper<KeyType, RealType, ElementTag>& s,
+                            cstone::DeviceVector<RealType>& b_dof,
+                            cstone::DeviceVector<RealType>& phi_dof)
+{
+    assert(s.numRanks > 1);
+
+    const int n          = s.numOwnedDofs;
+    const int dofBlocks  = (n + s.blockSize - 1) / s.blockSize;
+
+    cstone::DeviceVector<RealType> r_dof(n, RealType(0));
+    cstone::DeviceVector<RealType> p_dof(n, RealType(0));
+    cstone::DeviceVector<RealType> z_dof(n, RealType(0));
+    cstone::DeviceVector<RealType> Ap_dof(n, RealType(0));
+    // Node-sized scratch for the P / A / P^T legs inside applyDDTReduced.
+    cstone::DeviceVector<RealType> phiNode(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> ApNode(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> gx(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> gy(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> gz(s.nodeCount, RealType(0));
+
+    // Periodic pairs collapse to one owned merged DOF per pair (owner-migration),
+    // so there is no slave copy to skip -- plain owned-DOF dot.
+    const uint8_t* xrMask = nullptr;
+
+    // ---- MARS_DDT_SYMPROBE (reduced-DOF): the go/no-go symmetry test ----
+    // A_reduced = P^T A P must be self-adjoint for CG. Bilinear form: for any two
+    // DOF vectors u,v we must have <u, A_reduced v> == <v, A_reduced u>. Build two
+    // deterministic dof vectors (skip xr-slaves so they stay Dirichlet-zero), run
+    // each through applyDDTReduced, compare the cross dots via dotDof. rel ~
+    // roundoff PROVES the node-indexed P prolongation is the exact transpose of
+    // the sum-only P^T restriction (the two verified fixes). Runs once, gated.
+    {
+        static bool symProbeReducedDone = false;
+        const char* ev1 = std::getenv("MARS_PERIODIC_DDT_SYMPROBE");
+        const char* ev2 = std::getenv("MARS_DDT_SYMPROBE");
+        const bool symGate = (ev1 != nullptr) || (ev2 != nullptr);
+        const bool periodicGate =
+            (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic)
+            && (s.periodicMap != nullptr);
+        if (!symProbeReducedDone && symGate && periodicGate)
+        {
+            symProbeReducedDone = true;
+            cstone::DeviceVector<RealType> uD(n, RealType(0)), vD(n, RealType(0));
+            cstone::DeviceVector<RealType> AuD(n, RealType(0)), AvD(n, RealType(0));
+            cstone::DeviceVector<RealType> phiS(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> ApS(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> g1(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> g2(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> g3(s.nodeCount, RealType(0));
+            {
+                RealType* uP = uD.data();
+                RealType* vP = vD.data();
+                thrust::for_each(thrust::device,
+                    thrust::counting_iterator<int>(0),
+                    thrust::counting_iterator<int>(n),
+                    [uP, vP, xrMask] __device__ (int i) {
+                        if (xrMask && xrMask[i]) return;   // slave stays 0
+                        uP[i] = RealType(1) + RealType(i % 7);
+                        vP[i] = RealType(1) + RealType((i * 3 + 1) % 11);
+                    });
+                cudaDeviceSynchronize();
+            }
+            applyDDTReduced<KeyType, RealType, ElementTag>(s, vD, AvD, phiS, ApS, g1, g2, g3);
+            applyDDTReduced<KeyType, RealType, ElementTag>(s, uD, AuD, phiS, ApS, g1, g2, g3);
+            RealType uAv = dotDof<RealType>(uD, AvD, n, xrMask);
+            RealType vAu = dotDof<RealType>(vD, AuD, n, xrMask);
+            if (s.rank == 0)
+            {
+                RealType denom = std::max(std::abs(uAv), std::abs(vAu));
+                RealType rel = (denom > RealType(0)) ? std::abs(uAv - vAu) / denom : RealType(0);
+                const char* srOff = std::getenv("MARS_DDT_NO_SR_GBCAST");
+                const char* xrOff = std::getenv("MARS_DDT_NO_XR_GBCAST");
+                std::cout << "  [SYMPROBE-reduced] <u,Av>=" << uAv << "  <v,Au>=" << vAu
+                          << "  |diff|=" << std::abs(uAv - vAu) << "  rel=" << rel
+                          << "  SR_GBCAST=" << (srOff ? "OFF" : "ON")
+                          << "  XR_GBCAST=" << (xrOff ? "OFF" : "ON")
+                          << "   (rel<=1e-6 => H2 dead; rel>=1e-3 => H2 lives)\n";
+            }
+        }
+    }
+
+    bool useJacobi = (s.d_diagDDT.size() == static_cast<size_t>(n) && n > 0);
+    {
+        const char* ev = std::getenv("MARS_DDT_NO_JACOBI");
+        if (ev && std::string(ev) != "0") useJacobi = false;
+    }
+
+    // phi = 0 fresh start; r = b - A*phi = b. z = M^-1 r. p = z.
+    thrust::fill(thrust::device_pointer_cast(phi_dof.data()),
+                 thrust::device_pointer_cast(phi_dof.data() + n), RealType(0));
+    thrust::copy(thrust::device_pointer_cast(b_dof.data()),
+                 thrust::device_pointer_cast(b_dof.data() + n),
+                 thrust::device_pointer_cast(r_dof.data()));
+    if (useJacobi)
+    {
+        jacobiPrecondDofKernel<RealType><<<dofBlocks, s.blockSize>>>(
+            r_dof.data(), s.d_diagDDT.data(), s.diagDDTEpsClip, z_dof.data(), n);
+        cudaDeviceSynchronize();
+    }
+    else
+    {
+        thrust::copy(thrust::device_pointer_cast(r_dof.data()),
+                     thrust::device_pointer_cast(r_dof.data() + n),
+                     thrust::device_pointer_cast(z_dof.data()));
+    }
+    thrust::copy(thrust::device_pointer_cast(z_dof.data()),
+                 thrust::device_pointer_cast(z_dof.data() + n),
+                 thrust::device_pointer_cast(p_dof.data()));
+
+    RealType rho_old = dotDof<RealType>(r_dof, z_dof, n, xrMask);
+    RealType rr0     = dotDof<RealType>(r_dof, r_dof, n, xrMask);
+    RealType r0_norm = std::sqrt(rr0);
+    s.lastPressR0    = r0_norm;
+    s.lastPressResid = RealType(1);
+    if (r0_norm < std::numeric_limits<RealType>::min()) { s.lastPressResid = RealType(0); return 0; }
+    const RealType absTol = s.tolerance * r0_norm;
+
+    int liveEvery = (s.maxIter >= 500) ? 100 : 25;
+    {
+        const char* ev = std::getenv("MARS_DDT_CG_PRINT_EVERY");
+        if (ev) { int v = std::atoi(ev); if (v > 0) liveEvery = v; }
+    }
+
+    int iters = -2;
+    for (int it = 0; it < s.maxIter; ++it)
+    {
+        applyDDTReduced<KeyType, RealType, ElementTag>(s, p_dof, Ap_dof,
+                                                       phiNode, ApNode, gx, gy, gz);
+        RealType pAp = dotDof<RealType>(p_dof, Ap_dof, n, xrMask);
+        if (pAp <= RealType(0)) { iters = -2; break; }
+        RealType alpha = rho_old / pAp;
+
+        axpyDofKernel<RealType><<<dofBlocks, s.blockSize>>>(
+            phi_dof.data(), phi_dof.data(), p_dof.data(), alpha, n);
+        axpyDofKernel<RealType><<<dofBlocks, s.blockSize>>>(
+            r_dof.data(), r_dof.data(), Ap_dof.data(), -alpha, n);
+        cudaDeviceSynchronize();
+
+        RealType rr_new = dotDof<RealType>(r_dof, r_dof, n, xrMask);
+        s.lastPressResid = std::sqrt(rr_new) / std::max(r0_norm, std::numeric_limits<RealType>::min());
+        if (s.rank == 0 && (it == 0 || (it + 1) % liveEvery == 0))
+        {
+            std::cout << "    [cg-ddt-reduced] iter " << std::setw(6) << (it + 1)
+                      << "  |r|/|r0| = " << std::scientific << std::setprecision(3)
+                      << s.lastPressResid << std::defaultfloat << "\n" << std::flush;
+        }
+        if (std::sqrt(rr_new) < absTol) { iters = it + 1; break; }
+
+        if (useJacobi)
+        {
+            jacobiPrecondDofKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                r_dof.data(), s.d_diagDDT.data(), s.diagDDTEpsClip, z_dof.data(), n);
+            cudaDeviceSynchronize();
+        }
+        else
+        {
+            thrust::copy(thrust::device_pointer_cast(r_dof.data()),
+                         thrust::device_pointer_cast(r_dof.data() + n),
+                         thrust::device_pointer_cast(z_dof.data()));
+        }
+        RealType rho_new = dotDof<RealType>(r_dof, z_dof, n, xrMask);
+        RealType beta    = rho_new / rho_old;
+        axpyDofKernel<RealType><<<dofBlocks, s.blockSize>>>(
+            p_dof.data(), z_dof.data(), p_dof.data(), beta, n);
+        cudaDeviceSynchronize();
+        rho_old = rho_new;
+    }
+    return iters;
+}
+
+// Unpreconditioned matrix-free CG for (D M^{-1} D^T) phi = b. Returns iters
+// at convergence, -2 on max-iter. Mirrors runCgTest from mars_amr_ddt.cu
+// byte-for-byte (rho on <r,r>, convergence on sqrt(rho)=|r|, owned-only dots).
+// Pin/mask handling: b[i]=0 at every Dirichlet-pressure DOF (cavity single
+// pin or channel outflow mask), matching the SpMV's identity-row rule
+// out[i]=phi[i] at those slots. A production version adds Jacobi/AMG.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+int solvePressureDDT(NSStepper<KeyType, RealType, ElementTag>& s,
+                     cstone::DeviceVector<RealType>& b_node,
+                     cstone::DeviceVector<RealType>& phi_node)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const int nodeBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+
+    cstone::DeviceVector<RealType> r(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> p(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> Ap(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> z(s.nodeCount, RealType(0));   // M^-1 r
+    cstone::DeviceVector<RealType> gx(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> gy(s.nodeCount, RealType(0));
+    cstone::DeviceVector<RealType> gz(s.nodeCount, RealType(0));
+
+    // Periodic DOF aliasing: on a periodic mesh setupNSStepper collapses each
+    // same-rank slave node onto its master's DOF (node_to_dof[slave] ==
+    // node_to_dof[master]) but slave and master remain TWO distinct NODES, both
+    // owned. The CG below is NODE-indexed, so that one collapsed DOF occupies
+    // two node slots. To make the CG consistent in DOF space we (i) count each
+    // DOF once -- ownedDot skips same-rank slaves via partnerPtr -- and (ii)
+    // keep the two slots identical -- bcastMasterToSlave copies master->slave
+    // after every update of r/p/phi and inside the operator on g. partnerPtr is
+    // null off the periodic path, so both are exact no-ops for Dirichlet/pump.
+    const int* partnerPtr = (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+                             && s.periodicMap)
+                            ? s.periodicMap->d_periodicPartner.data() : nullptr;
+    auto bcastMasterToSlave = [&](cstone::DeviceVector<RealType>& v) {
+        if (!partnerPtr) return;
+        // (a) same-rank leg: collapsed slave node slot := its owned master's slot.
+        mars::fem::periodicBroadcastSameRankKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            partnerPtr, d_nodeOwnership.data(), s.nodeCount, v.data());
+        cudaDeviceSynchronize();
+        // (b) cross-rank leg: a cross-rank slave is OWNED here but its master is
+        // a ghost, so the same-rank kernel skipped it and the cstone halo (owners
+        // ->ghosts) never touches an owned slot. Without this refresh its node
+        // slot drifts from the master's value on the master-owner rank, and the
+        // matrix-free D^T scatter reads asymmetric p across the periodic seam ->
+        // seam divergence blows up. Mirrors maybePeriodicSum's cross-rank leg for
+        // the SUM direction. No-op when peers_ empty (single-rank / no XR pairs).
+        if (s.numRanks > 1)
+        {
+            mars::fem::crossRankPeriodicBroadcast<KeyType, RealType>(*s.periodicMap, v);
+        }
+    };
+
+    // Jacobi preconditioning is ON by default. Two earlier session bugs masked
+    // its correctness; both are now fixed:
+    //   1. The per-element scatter loop-bound double-count (FIXED in this
+    //      session): used to make the matrix-free operator disagree with the
+    //      assembled s.d_valuesDDT at rank-boundary nodes, so the cached diag
+    //      didn't match what CG saw.
+    //   2. The cavity pin-row diag mismatch (FIXED in the setup-time cache
+    //      build): matrix-free applyDDTPerNode enforces identity (diag=1) at
+    //      the pin, but enforcePinRowKeepDiagKernel keeps the assembled value
+    //      (~0.04) in s.d_valuesDDT. The cache build now overrides the pin
+    //      slot to 1.0 so Jacobi z[pin] = r[pin]/1.0 matches the operator.
+    // With both fixes in, Jacobi PCG should converge in ~30-60 iters on cube16
+    // cavity (vs un-precond 104) and ~400-700 iters on the wing 15M-hex (vs
+    // un-precond stalling at 1e-3 after 20k). Env MARS_DDT_NO_JACOBI=1 opts
+    // OUT for diagnostic A/B against the un-precond baseline.
+    bool useJacobi = (s.d_diagDDT.size() == static_cast<size_t>(s.numOwnedDofs)
+                      && s.numOwnedDofs > 0);
+    {
+        const char* ev = std::getenv("MARS_DDT_NO_JACOBI");
+        if (ev && std::string(ev) != "0") useJacobi = false;
+    }
+    if (s.rank == 0)
+    {
+        static bool printedOnce = false;
+        if (!printedOnce)
+        {
+            std::cout << "[cg-ddt] preconditioner = "
+                      << (useJacobi
+                          ? (std::is_same_v<ElementTag, TetTag>
+                             ? "Jacobi (diag from s.d_diagDDT; matrix-free area+mass)"
+                             : "Jacobi (diag from s.d_diagDDT; extracted from assembled s.d_valuesDDT)")
+                          : "NONE (un-precond)")
+                      << "\n";
+            if (useJacobi)
+            {
+                // One-shot diag range print so we see what we're dividing by.
+                auto dp = thrust::device_pointer_cast(s.d_diagDDT.data());
+                auto mm = thrust::minmax_element(thrust::device, dp,
+                                                  dp + s.numOwnedDofs);
+                RealType dmin = 0, dmax = 0;
+                cudaMemcpy(&dmin, thrust::raw_pointer_cast(&*mm.first),  sizeof(RealType), cudaMemcpyDeviceToHost);
+                cudaMemcpy(&dmax, thrust::raw_pointer_cast(&*mm.second), sizeof(RealType), cudaMemcpyDeviceToHost);
+                std::cout << "[cg-ddt] cached diag range on rank 0: ["
+                          << dmin << ", " << dmax << "]\n";
+                // A constant diagonal carries no per-DOF scaling: Jacobi then
+                // reduces to z = r / const, i.e. CG runs effectively
+                // UN-preconditioned even though useJacobi==true. For tet this
+                // means the matrix-free area+mass accumulator came back empty
+                // (all zero -> floored to 1.0): check that d_areaVec and
+                // d_massNode were populated before this build. Loud on purpose
+                // so the "preconditioner present but useless" state is never
+                // silent (it only shows up as a sluggish, high-iter solve).
+                if (dmin == dmax)
+                    std::cout << "[cg-ddt] WARNING: DDT Jacobi diagonal is CONSTANT ("
+                              << dmin << ") -> no per-DOF preconditioning; CG will be slow. "
+                              << (std::is_same_v<ElementTag, TetTag>
+                                  ? "Tet matrix-free diag accumulator was empty/uniform."
+                                  : "Assembled diag was empty/uniform.")
+                              << "\n";
+            }
+            printedOnce = true;
+        }
+    }
+
+    // ---- MARS_DDT_SYMPROBE: cross-rank operator-symmetry measurement ----
+    // A = D M^-1 D^T must be symmetric for CG (pAp>0). On >1 rank with a
+    // periodic seam the CG breaks (pAp<=0) even with Jacobi off, so A itself
+    // is non-SPD across the seam. The suspect is the master->slave g-broadcast
+    // (an overwrite is not self-adjoint) inserted between M^-1 and the
+    // D-scatter inside applyDDTPerNode. This probe MEASURES adjointness:
+    // for a cross-rank seam pair of DOFs (i,j) it computes A[i,j]=(A e_j)[i]
+    // and A[j,i]=(A e_i)[j] and prints |A[i,j]-A[j,i]|. Symmetric => roundoff;
+    // asymmetric => O(operator). Run it under the two NO_*_GBCAST toggles to
+    // isolate which broadcast breaks symmetry. Runs ONCE (static guard), only
+    // on the first solve, and is fully gated -- default behavior unchanged.
+    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    {
+        static bool symProbeDoneV2 = false;
+        if (!symProbeDoneV2 && std::getenv("MARS_DDT_SYMPROBE") != nullptr
+            && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+            && s.periodicMap != nullptr)
+        {
+            symProbeDoneV2 = true;
+
+            // Bilinear-form symmetry test (no pair/coupling guesswork): for the
+            // self-adjoint operator A=D M^-1 D^T we must have <u,A v> == <v,A u>
+            // for ANY u,v. Build two arbitrary OWNED vectors, apply A to each,
+            // and compare the two cross inner products. The gap IS the asymmetry.
+            // No RNG (unavailable on device-build); use deterministic index hashes.
+            // Run under the NO_*_GBCAST toggles to see which broadcast breaks it.
+            cstone::DeviceVector<RealType> uVec(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> vVec(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> AuVec(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> AvVec(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> g1(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> g2(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> g3(s.nodeCount, RealType(0));
+            {
+                RealType* uP = uVec.data();
+                RealType* vP = vVec.data();
+                const int*     dofP = s.d_node_to_dof.data();
+                const uint8_t* ownP = d_nodeOwnership.data();
+                const int*     parP = partnerPtr;
+                // owned, non-slave nodes get a smooth deterministic value; the
+                // exact values don't matter, only that u != v and both nonzero.
+                thrust::for_each(thrust::device,
+                    thrust::counting_iterator<size_t>(0),
+                    thrust::counting_iterator<size_t>(s.nodeCount),
+                    [uP, vP, dofP, ownP, parP] __device__ (size_t i) {
+                        if (ownP[i] != 1 || dofP[i] < 0) return;
+                        if (parP && parP[i] >= 0) return;
+                        int d = dofP[i];
+                        uP[i] = RealType(1) + RealType(d % 7);
+                        vP[i] = RealType(1) + RealType((d * 3 + 1) % 11);
+                    });
+                cudaDeviceSynchronize();
+            }
+            // Av and Au through the SAME operator path the CG uses (incl. the
+            // master->slave broadcasts + halo the toggles control).
+            bcastMasterToSlave(vVec); s.domain.exchangeNodeHalo(vVec);
+            applyDDTPerNode<KeyType, RealType, ElementTag>(s, vVec, AvVec, g1, g2, g3);
+            bcastMasterToSlave(uVec); s.domain.exchangeNodeHalo(uVec);
+            applyDDTPerNode<KeyType, RealType, ElementTag>(s, uVec, AuVec, g1, g2, g3);
+
+            RealType uAv = ownedDot<RealType>(uVec, AvVec, s.d_node_to_dof,
+                                              d_nodeOwnership.data(), s.nodeCount, partnerPtr);
+            RealType vAu = ownedDot<RealType>(vVec, AuVec, s.d_node_to_dof,
+                                              d_nodeOwnership.data(), s.nodeCount, partnerPtr);
+            if (s.rank == 0)
+            {
+                RealType denom = std::max(std::abs(uAv), std::abs(vAu));
+                RealType rel = (denom > RealType(0)) ? std::abs(uAv - vAu) / denom : RealType(0);
+                std::cout << "  [SYMPROBE] <u,Av>=" << uAv << "  <v,Au>=" << vAu
+                          << "  |diff|=" << std::abs(uAv - vAu)
+                          << "  rel=" << rel
+                          << "   (symmetric => rel~roundoff; asymmetric => rel~O(1))\n";
+            }
+        }
+        // ---- legacy pair-probe (kept disabled; superseded by the bilinear test) ----
+        static bool symProbeDone = false;
+        if (false && !symProbeDone && std::getenv("MARS_DDT_SYMPROBE_PAIRS") != nullptr
+            && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+            && s.periodicMap != nullptr)
+        {
+            symProbeDone = true;
+
+            // Step 1 (host, tiny): each rank picks up to 3 of its OWNED
+            // cross-rank periodic masters i (those with a remote slave) and,
+            // for each, an OWNED interior neighbor j that shares an element
+            // with i (via the node->element CSR + element->node connectivity).
+            // We gather (masterNode i, neighborNode j) pairs to host so the
+            // collective apply below can build e_i / e_j on device. Only the
+            // rank that owns the master proposes -- the others contribute 0 to
+            // the MPI reduction, so no DOF is counted twice and none is missed.
+            const auto& xr = s.periodicMap->cross_;
+            std::vector<int> hMasters;
+            const int wantPairs = 3;
+            if (!xr.d_recvOwnedMasterIds_.empty())
+            {
+                int nMasters = std::min<int>(int(xr.d_recvOwnedMasterIds_.size()), wantPairs);
+                hMasters.resize(nMasters);
+                cudaMemcpy(hMasters.data(), xr.d_recvOwnedMasterIds_.data(),
+                           nMasters * sizeof(int), cudaMemcpyDeviceToHost);
+            }
+
+            // Pull the small CSR + connectivity + dof/partner/ownership arrays
+            // to host once to find neighbors. nodeCount-sized D2H, but the
+            // probe is one-shot and diagnostic-only (no steady-state cost).
+            const auto& d_n2eOff = s.domain.getNodeToElementOffsets();
+            const auto& d_n2eLst = s.domain.getNodeToElementList();
+            const auto& d_conn   = s.domain.getElementToNodeConnectivity();
+            auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+            constexpr int NPE = ElemTraits<ElementTag>::NodesPerElem;
+
+            std::vector<KeyType> hOff(s.nodeCount + 1);
+            cudaMemcpy(hOff.data(), d_n2eOff.data(),
+                       (s.nodeCount + 1) * sizeof(KeyType), cudaMemcpyDeviceToHost);
+            std::vector<KeyType> hLst(hOff.empty() ? 0 : size_t(hOff.back()));
+            if (!hLst.empty())
+                cudaMemcpy(hLst.data(), d_n2eLst.data(),
+                           hLst.size() * sizeof(KeyType), cudaMemcpyDeviceToHost);
+            std::vector<int>     hN2D(s.nodeCount);
+            std::vector<uint8_t> hOwn(s.nodeCount);
+            std::vector<int>     hPartner(s.nodeCount, -1);
+            cudaMemcpy(hN2D.data(), s.d_node_to_dof.data(),
+                       s.nodeCount * sizeof(int), cudaMemcpyDeviceToHost);
+            cudaMemcpy(hOwn.data(), d_nodeOwnership.data(),
+                       s.nodeCount * sizeof(uint8_t), cudaMemcpyDeviceToHost);
+            cudaMemcpy(hPartner.data(), s.periodicMap->d_periodicPartner.data(),
+                       s.nodeCount * sizeof(int), cudaMemcpyDeviceToHost);
+            // Element connectivity columns (NPE node-id arrays). Hex only here.
+            std::vector<std::vector<KeyType>> hCol(NPE);
+            for (int c = 0; c < NPE; ++c)
+            {
+                hCol[c].resize(s.elementCount);
+                cudaMemcpy(hCol[c].data(), cp[c],
+                           s.elementCount * sizeof(KeyType), cudaMemcpyDeviceToHost);
+            }
+
+            // For each master i, scan its incident elements (node->element CSR)
+            // and pick a neighbor node j off the SAME element via the
+            // element->node connectivity. Sharing an element makes A[i,j] a real
+            // nonzero entry of the 27-pt D M^-1 D^T stencil (A[i,j]!=0 iff i,j
+            // share an element), so |A[i,j]-A[j,i]| actually measures asymmetry
+            // instead of probing a structural zero. j is required owned with a
+            // distinct valid owned DOF and partner<0 (a clean interior DOF, not a
+            // periodic alias). Owned-on-this-rank => i,j are same-rank here; the
+            // print labels that, and a future remotely-owned j would auto-label
+            // cross-rank via the ownerOfJ reduction below.
+            std::vector<std::pair<int,int>> pairsIJ;  // (masterNode i, neighbor j)
+            for (int mi : hMasters)
+            {
+                if (mi < 0 || mi >= int(s.nodeCount)) continue;
+                int dofI = hN2D[mi];
+                if (dofI < 0 || dofI >= s.numOwnedDofs) continue;
+                int found = -1;
+                KeyType b = hOff[mi], e = hOff[mi + 1];
+                for (KeyType t = b; t < e && found < 0; ++t)
+                {
+                    size_t elem = size_t(hLst[t]);
+                    if (elem >= s.elementCount) continue;
+                    for (int c = 0; c < NPE; ++c)
+                    {
+                        int nj = int(hCol[c][elem]);
+                        if (nj < 0 || nj >= int(s.nodeCount)) continue;
+                        if (nj == mi) continue;
+                        if (hOwn[nj] != 1) continue;
+                        if (hPartner[nj] >= 0) continue;            // skip slaves/aliases
+                        int dofJ = hN2D[nj];
+                        if (dofJ < 0 || dofJ >= s.numOwnedDofs) continue;
+                        if (dofJ == dofI) continue;                 // distinct DOF
+                        found = nj;
+                        break;
+                    }
+                }
+                if (found >= 0) pairsIJ.emplace_back(mi, found);
+            }
+
+            // Step 2: round-robin a GLOBAL list of pairs across ranks so the
+            // collective applyDDTPerNode is called the same number of times on
+            // every rank. Each rank announces how many pairs it has; we then
+            // process up to wantPairs pairs total, one per (rank, slot).
+            int myPairs = int(pairsIJ.size());
+            std::vector<int> allCounts(s.numRanks, 0);
+            MPI_Allgather(&myPairs, 1, MPI_INT, allCounts.data(), 1, MPI_INT, MPI_COMM_WORLD);
+
+            // Device scratch for the unit vectors and the operator output. Sized
+            // like the existing scaffold (phi over nodeCount, Ap over nodeCount).
+            cstone::DeviceVector<RealType> phiE(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> ApE(s.nodeCount, RealType(0));
+            const int*     n2dPtr = s.d_node_to_dof.data();
+            const uint8_t* ownPtr = d_nodeOwnership.data();
+
+            // Set phiE = e_{dof} on the owner rank only (others leave it 0); the
+            // halo exchange then fills any ghost copies of that node so the
+            // collective D^T scatter sees a globally-consistent unit vector.
+            auto setUnit = [&](int targetDof, bool ownerHere) {
+                cudaMemset(phiE.data(), 0, s.nodeCount * sizeof(RealType));
+                if (ownerHere)
+                {
+                    thrust::for_each(thrust::device,
+                        thrust::counting_iterator<size_t>(0),
+                        thrust::counting_iterator<size_t>(s.nodeCount),
+                        [n2dPtr, ownPtr, targetDof, p = phiE.data()] __device__ (size_t k) {
+                            if (ownPtr[k] == 1 && n2dPtr[k] == targetDof) p[k] = RealType(1);
+                        });
+                    cudaDeviceSynchronize();
+                }
+                s.domain.exchangeNodeHalo(phiE);
+            };
+            // Read (A e)[node with owned dof==targetDof] on the owner rank only;
+            // returns 0 on non-owners so MPI_SUM picks exactly one contributor.
+            auto readAt = [&](int targetDof, bool ownerHere) -> RealType {
+                if (!ownerHere) return RealType(0);
+                RealType acc = thrust::transform_reduce(thrust::device,
+                    thrust::counting_iterator<size_t>(0),
+                    thrust::counting_iterator<size_t>(s.nodeCount),
+                    [n2dPtr, ownPtr, targetDof, a = ApE.data()] __device__ (size_t k) -> RealType {
+                        return (ownPtr[k] == 1 && n2dPtr[k] == targetDof) ? a[k] : RealType(0);
+                    }, RealType(0), thrust::plus<RealType>());
+                return acc;
+            };
+
+            auto mpiType = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+            int printed = 0;
+            for (int r = 0; r < s.numRanks && printed < wantPairs; ++r)
+            {
+                int slots = std::min(allCounts[r], wantPairs - printed);
+                for (int sIdx = 0; sIdx < slots; ++sIdx, ++printed)
+                {
+                    bool ownerHere = (s.rank == r);
+                    // Local DOF indices of this pair live ONLY on the owner rank
+                    // r; other ranks pass -1 (their set/read self-select to 0).
+                    int dofI = -1, dofJ = -1;
+                    if (ownerHere)
+                    {
+                        dofI = hN2D[pairsIJ[sIdx].first];
+                        dofJ = hN2D[pairsIJ[sIdx].second];
+                    }
+
+                    // A[j,i] = (A e_i)[j]: collective apply with phi=e_i.
+                    setUnit(dofI, ownerHere);
+                    applyDDTPerNode<KeyType, RealType, ElementTag>(s, phiE, ApE, gx, gy, gz);
+                    RealType Aji_local = readAt(dofJ, ownerHere);
+
+                    // A[i,j] = (A e_j)[i]: collective apply with phi=e_j.
+                    setUnit(dofJ, ownerHere);
+                    applyDDTPerNode<KeyType, RealType, ElementTag>(s, phiE, ApE, gx, gy, gz);
+                    RealType Aij_local = readAt(dofI, ownerHere);
+
+                    // A[i,i] = (A e_i)[i]: diagonal sanity. If this comes back 0
+                    // the unit-vector/readAt machinery itself is broken (a node
+                    // is always coupled to itself in the 27-pt DDT stencil), so a
+                    // zero here, not just |Aij-Aji|=0, is the first thing to check:
+                    // it means setUnit/exchange/applyDDTPerNode/readAt are wrong
+                    // and the off-diagonal numbers are meaningless. A[i,i] must be
+                    // > 0 (SPD diagonal). Same collective shape as the legs above.
+                    setUnit(dofI, ownerHere);
+                    applyDDTPerNode<KeyType, RealType, ElementTag>(s, phiE, ApE, gx, gy, gz);
+                    RealType Aii_local = readAt(dofI, ownerHere);
+
+                    // Each entry is owned by exactly one rank (owner of i for
+                    // A[i,j]/A[i,i], owner of j for A[j,i]); everyone else packed
+                    // 0, so SUM merges them with no double-count and no miss.
+                    RealType Aji = 0, Aij = 0, Aii = 0;
+                    MPI_Allreduce(&Aji_local, &Aji, 1, mpiType, MPI_SUM, MPI_COMM_WORLD);
+                    MPI_Allreduce(&Aij_local, &Aij, 1, mpiType, MPI_SUM, MPI_COMM_WORLD);
+                    MPI_Allreduce(&Aii_local, &Aii, 1, mpiType, MPI_SUM, MPI_COMM_WORLD);
+
+                    // Rank that owns j (the proposing rank r owns both i and j
+                    // because the neighbor walk only accepts owned nodes; -1 from
+                    // everyone else, MAX picks the real owner). Report same-rank
+                    // vs cross-rank so a future selection that picks a remotely
+                    // owned j is labelled correctly without further changes.
+                    int ownerOfJ_local = ownerHere ? s.rank : -1;
+                    int ownerOfJ = -1;
+                    MPI_Allreduce(&ownerOfJ_local, &ownerOfJ, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+                    if (s.rank == 0)
+                    {
+                        // dofI/dofJ are owner-local; report owner rank + locals
+                        // for traceability. The signal is |Aij-Aji|; A[i,i]>0
+                        // gates whether that signal is trustworthy at all.
+                        int repI = -1, repJ = -1;
+                        if (r == 0) { repI = dofI; repJ = dofJ; }
+                        const char* loc = (ownerOfJ == r) ? "same-rank" : "cross-rank";
+                        std::cout << "  [MARS_DDT_SYMPROBE] seam pair (ownerRank(i)=" << r
+                                  << ", ownerRank(j)=" << ownerOfJ << ", " << loc
+                                  << ", dofI=" << repI << ", dofJ=" << repJ << "): "
+                                  << std::scientific << std::setprecision(6)
+                                  << "A[i,i]=" << Aii
+                                  << " A[i,j]=" << Aij << " A[j,i]=" << Aji
+                                  << " |diff|=" << std::abs(Aij - Aji)
+                                  << std::defaultfloat << "\n";
+                    }
+                }
+            }
+            if (printed == 0 && s.rank == 0)
+                std::cout << "  [MARS_DDT_SYMPROBE] no cross-rank seam masters found "
+                             "(single-rank or no cross-rank periodic pairs)\n";
+        }
+    }
+
+    // Fresh start: phi = 0. With b[i]=0 at every pinned DOF and out[i]=phi[i]
+    // in the SpMV, the pinned-row equation reads 0 = phi[i] => phi[i] stays 0.
+    thrust::fill(thrust::device_pointer_cast(phi_node.data()),
+                 thrust::device_pointer_cast(phi_node.data() + s.nodeCount), RealType(0));
+
+    const int pinDof          = s.pressurePinDof;
+    const uint8_t* maskPtr    = (s.d_isPressureBdryDof.size() > 0)
+                                ? s.d_isPressureBdryDof.data() : nullptr;
+    if (pinDof >= 0 || maskPtr != nullptr)
+    {
+        const int  numOwnedDofs = s.numOwnedDofs;
+        const int* dofPtr       = s.d_node_to_dof.data();
+        const uint8_t* ownPtr   = d_nodeOwnership.data();
+        RealType* bPtr          = b_node.data();
+        thrust::for_each(thrust::device,
+            thrust::counting_iterator<size_t>(0),
+            thrust::counting_iterator<size_t>(s.nodeCount),
+            [pinDof, maskPtr, dofPtr, ownPtr, bPtr, numOwnedDofs] __device__ (size_t i) {
+                if (ownPtr[i] != 1) return;
+                int dof = dofPtr[i];
+                if (dof < 0 || dof >= numOwnedDofs) return;
+                bool flagged = (pinDof >= 0 && dof == pinDof) ||
+                               (maskPtr != nullptr && maskPtr[dof] != 0);
+                if (flagged) bPtr[i] = RealType(0);
+            });
+        cudaDeviceSynchronize();
+    }
+
+    // r = b - A*phi  (phi=0 so r = b on owned slots). z = M^-1 r. p = z.
+    thrust::copy(thrust::device_pointer_cast(b_node.data()),
+                 thrust::device_pointer_cast(b_node.data() + s.nodeCount),
+                 thrust::device_pointer_cast(r.data()));
+    // NOTE: the periodic master<->slave identity is now applied INSIDE the
+    // operator (P on phi at the top of applyDDTPerNode, P^T = maybePeriodicSum on
+    // outAcc) -- the P^T A P pattern. The CG iterate r/p/phi is therefore NEVER
+    // re-broadcast between matvecs (that was the anti-pattern that broke Krylov
+    // conjugacy on >1 rank). The slave slot of r is left at b[slave]=0 by the RHS
+    // assembly; it rides along inert because ownedDot skips slaves and the next
+    // matvec's P re-establishes phi[slave]=phi[master].
+    if (useJacobi)
+    {
+        jacobiPrecondNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            r.data(), s.d_diagDDT.data(),
+            s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            s.diagDDTEpsClip, z.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+    }
+    else
+    {
+        thrust::copy(thrust::device_pointer_cast(r.data()),
+                     thrust::device_pointer_cast(r.data() + s.nodeCount),
+                     thrust::device_pointer_cast(z.data()));
+    }
+    thrust::copy(thrust::device_pointer_cast(z.data()),
+                 thrust::device_pointer_cast(z.data() + s.nodeCount),
+                 thrust::device_pointer_cast(p.data()));
+
+    // rho = (r, z): preconditioned inner product drives alpha/beta.
+    // Convergence check still uses the Euclidean residual |r| so the tolerance
+    // semantics match the un-preconditioned baseline and the K-path numbers.
+    RealType rho_old = ownedDot<RealType>(r, z, s.d_node_to_dof,
+                                          d_nodeOwnership.data(), s.nodeCount, partnerPtr);
+    RealType rr0     = ownedDot<RealType>(r, r, s.d_node_to_dof,
+                                          d_nodeOwnership.data(), s.nodeCount, partnerPtr);
+    RealType r0_norm = std::sqrt(rr0);
+    // Diagnostic capture (every step, regardless of the gated per-iter print):
+    // |r0| is the pressure RHS magnitude; lastPressResid starts at the not-yet-
+    // iterated ratio 1 and is overwritten with the latest |r|/|r0| in the loop.
+    s.lastPressR0    = r0_norm;
+    s.lastPressResid = RealType(1);
+    if (r0_norm < std::numeric_limits<RealType>::min()) { s.lastPressResid = RealType(0); return 0; }
+    const RealType absTol = s.tolerance * r0_norm;
+
+    int iters = -2;
+    // Live progress every N CG iterations on rank 0 so large-mesh runs show
+    // residual-decay rate instead of going silent for minutes. Each line
+    // prints |r|/|r0| so the user can extrapolate iters-to-convergence.
+    // liveEvery: print |r|/|r0| every N iters on rank 0. Default 100 for
+    // maxIter>=500 (cube/wing scale), 25 for smaller runs. Env override
+    // MARS_DDT_CG_PRINT_EVERY=N forces N (useful on wing to see whether the
+    // solve is making progress without waiting for 100 SpMVs to elapse, which
+    // at 4M owned DOFs on H100 can be tens of seconds per print interval).
+    int liveEvery = (s.maxIter >= 500) ? 100 : 25;
+    {
+        const char* ev = std::getenv("MARS_DDT_CG_PRINT_EVERY");
+        if (ev)
+        {
+            int v = std::atoi(ev);
+            if (v > 0) liveEvery = v;
+        }
+    }
+    for (int it = 0; it < s.maxIter; ++it)
+    {
+        // applyDDTPerNode applies P (periodic master->slave) and the ghost halo
+        // to its input internally, so we pass p straight in -- no iterate mutation.
+        applyDDTPerNode<KeyType, RealType, ElementTag>(s, p, Ap, gx, gy, gz);
+
+        RealType pAp = ownedDot<RealType>(p, Ap, s.d_node_to_dof,
+                                          d_nodeOwnership.data(), s.nodeCount, partnerPtr);
+        // MARS_DDT_PAP_DEBUG: on the FIRST solve's FIRST iteration, dump the
+        // actual scalars that decide pAp<=0. The PER-RANK local contribution
+        // (before the Allreduce) is the key unknown: if one rank's local pAp is
+        // a large negative or NaN/inf, the operator/vectors are inconsistent on
+        // that rank's seam. Also dump |p|,|Ap|, min/max(Ap) over owned to see if
+        // Ap carries a poison value. Gated + once -> zero cost in production.
+        {
+            static bool papDbgDone = false;
+            if (!papDbgDone && std::getenv("MARS_DDT_PAP_DEBUG") != nullptr && it == 0)
+            {
+                papDbgDone = true;
+                const RealType* pPtr  = p.data();
+                const RealType* ApPtr = Ap.data();
+                const int*      dofP  = s.d_node_to_dof.data();
+                const uint8_t*  ownP  = d_nodeOwnership.data();
+                const int*      parP  = partnerPtr;
+                // local pAp (same gate as ownedDot, but keep the un-reduced value)
+                RealType localPap = thrust::transform_reduce(thrust::device,
+                    thrust::counting_iterator<size_t>(0),
+                    thrust::counting_iterator<size_t>(s.nodeCount),
+                    [pPtr, ApPtr, dofP, ownP, parP] __device__ (size_t i) -> RealType {
+                        if (ownP[i] != 1 || dofP[i] < 0) return RealType(0);
+                        if (parP && parP[i] >= 0) return RealType(0);
+                        return pPtr[i] * ApPtr[i];
+                    }, RealType(0), thrust::plus<RealType>());
+                // local |p|^2 and |Ap|^2 over owned (same gate)
+                RealType localPP = thrust::transform_reduce(thrust::device,
+                    thrust::counting_iterator<size_t>(0),
+                    thrust::counting_iterator<size_t>(s.nodeCount),
+                    [pPtr, dofP, ownP, parP] __device__ (size_t i) -> RealType {
+                        if (ownP[i] != 1 || dofP[i] < 0) return RealType(0);
+                        if (parP && parP[i] >= 0) return RealType(0);
+                        return pPtr[i] * pPtr[i];
+                    }, RealType(0), thrust::plus<RealType>());
+                RealType localApAp = thrust::transform_reduce(thrust::device,
+                    thrust::counting_iterator<size_t>(0),
+                    thrust::counting_iterator<size_t>(s.nodeCount),
+                    [ApPtr, dofP, ownP, parP] __device__ (size_t i) -> RealType {
+                        if (ownP[i] != 1 || dofP[i] < 0) return RealType(0);
+                        if (parP && parP[i] >= 0) return RealType(0);
+                        return ApPtr[i] * ApPtr[i];
+                    }, RealType(0), thrust::plus<RealType>());
+                cudaDeviceSynchronize();
+                // gather per-rank local pAp to rank 0
+                std::vector<double> allLocal(s.numRanks, 0.0);
+                double myLocal = static_cast<double>(localPap);
+                MPI_Gather(&myLocal, 1, MPI_DOUBLE, allLocal.data(), 1, MPI_DOUBLE,
+                           0, MPI_COMM_WORLD);
+                double gPP = 0, gApAp = 0, lPP = localPP, lApAp = localApAp;
+                MPI_Allreduce(&lPP,   &gPP,   1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+                MPI_Allreduce(&lApAp, &gApAp, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+                if (s.rank == 0)
+                {
+                    std::cout << "  [pAp-dbg] pAp(global)=" << pAp
+                              << "  rho_old(r,z)=" << rho_old
+                              << "  rr0(r,r)=" << rr0
+                              << "  |p|=" << std::sqrt(gPP)
+                              << "  |Ap|=" << std::sqrt(gApAp) << "\n";
+                    std::cout << "  [pAp-dbg] per-rank local pAp:";
+                    for (int rr = 0; rr < s.numRanks; ++rr)
+                        std::cout << " r" << rr << "=" << allLocal[rr];
+                    std::cout << "\n";
+                }
+            }
+        }
+        if (pAp <= RealType(0)) { iters = -2; break; }
+        RealType alpha = rho_old / pAp;
+
+        axpyOwnedKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            phi_node.data(), phi_node.data(), p.data(), alpha,
+            s.d_node_to_dof.data(), d_nodeOwnership.data(), s.nodeCount);
+        axpyOwnedKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            r.data(), r.data(), Ap.data(), -alpha,
+            s.d_node_to_dof.data(), d_nodeOwnership.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+        // No iterate re-broadcast: r[slave] (and phi[slave]) ride along inert.
+        // The slave is excluded from every ownedDot, and each matvec re-applies
+        // P (phi[slave]:=phi[master]) inside applyDDTPerNode, so the stale slave
+        // slots never enter a reduction or the operator. Re-broadcasting them
+        // here is the documented anti-pattern (a projection between matvecs that
+        // breaks CG conjugacy -> the >1-rank converge-then-diverge stall).
+
+        // Convergence on the Euclidean residual; alpha/beta on the
+        // preconditioned (r,z) inner product. Equivalent to un-precond CG when
+        // z == r (the useJacobi=false fallback path).
+        RealType rr_new  = ownedDot<RealType>(r, r, s.d_node_to_dof,
+                                              d_nodeOwnership.data(), s.nodeCount, partnerPtr);
+        // Keep the diagnostic resid current on every iter (the print below is
+        // gated; this store is not, so lastPressResid is the true exit ratio).
+        s.lastPressResid = std::sqrt(rr_new) / std::max(r0_norm, std::numeric_limits<RealType>::min());
+        if (s.rank == 0 && (it == 0 || (it + 1) % liveEvery == 0))
+        {
+            std::cout << "    [cg-ddt] iter " << std::setw(6) << (it + 1)
+                      << "  |r|/|r0| = " << std::scientific << std::setprecision(3)
+                      << s.lastPressResid
+                      << std::defaultfloat << "\n" << std::flush;
+        }
+        if (std::sqrt(rr_new) < absTol) { iters = it + 1; break; }
+        // z = M^-1 r (or z := r if no preconditioner).
+        if (useJacobi)
+        {
+            jacobiPrecondNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                r.data(), s.d_diagDDT.data(),
+                s.d_node_to_dof.data(), d_nodeOwnership.data(),
+                s.diagDDTEpsClip, z.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+        }
+        else
+        {
+            thrust::copy(thrust::device_pointer_cast(r.data()),
+                         thrust::device_pointer_cast(r.data() + s.nodeCount),
+                         thrust::device_pointer_cast(z.data()));
+        }
+        RealType rho_new = ownedDot<RealType>(r, z, s.d_node_to_dof,
+                                              d_nodeOwnership.data(), s.nodeCount, partnerPtr);
+        RealType beta    = rho_new / rho_old;
+        // p = z + beta * p   (un-precond reduces to p = r + beta*p when z=r).
+        axpyOwnedKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            p.data(), z.data(), p.data(), beta,
+            s.d_node_to_dof.data(), d_nodeOwnership.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+        // p is NOT re-broadcast: its slave slot rides along inert (excluded from
+        // ownedDot; re-established by P inside the next matvec). Mutating the
+        // search direction here breaks M-conjugacy -- the P^T A P structure keeps
+        // the iterate consistent without touching it (MFEM/deal.II pattern).
+        rho_old = rho_new;
+    }
+
+    // cg_p=-2 means the loop ran all maxIter without hitting absTol (iters stays
+    // at its -2 init) -- a NON-convergence, NOT a pAp<=0 breakdown (that path
+    // sets -2 too but we instrument pAp separately). Print the exit state so we
+    // can tell "slow but decreasing" from "stalled" from "residual went NaN".
+    if (iters == -2 && std::getenv("MARS_DDT_PAP_DEBUG") != nullptr && s.rank == 0)
+    {
+        std::cout << "  [cg-exit] ran maxIter=" << s.maxIter
+                  << " without converging: final |r|/|r0|=" << s.lastPressResid
+                  << "  absTol/|r0|=" << s.tolerance << "\n";
+    }
+    s.domain.exchangeNodeHalo(phi_node);
+    return iters;
+}
+
+// Negate three per-node vectors in place on owned DOFs only. Used when the
+// gradient was produced by applyDivTransposePerNodeKernel (which integrates
+// to -V*grad), so after normalize we have -grad; flipping the sign here makes
+// the result a true +grad that predictor/corrector kernels (which subtract
+// dt/rho * grad) can consume without their own sign awareness. Ghost slots
+// are zeroed -- caller does a forward halo if needed.
+template<typename RealType>
+__global__ void negateThreeOwnedKernel(RealType* gx, RealType* gy, RealType* gz,
+                                       const int* nodeToDof, const uint8_t* ownership,
+                                       size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) { gx[i] = gy[i] = gz[i] = RealType(0); return; }
+    int dof = nodeToDof[i];
+    if (dof < 0) { gx[i] = gy[i] = gz[i] = RealType(0); return; }
+    gx[i] = -gx[i];
+    gy[i] = -gy[i];
+    gz[i] = -gz[i];
+}
+
+// =============================================================================
+// Periodic post-scatter helper. Single-rank: gated intra-rank kernel is a
+// no-op because the DOF collapse aliased nodeToDof[slave]=nodeToDof[master],
+// so per-DOF accumulators already merged. Multi-rank periodic: the gated
+// intra-rank kernel handles same-rank pairs (where the local-master-collapse
+// hit); the cross-rank pair sum bridges pairs whose master is owned on a
+// remote rank.
+//
+// Pre-condition: d_field is per-NODE (size = nodeCount). Caller has scattered
+// owned-element contributions onto all 8 corners and (optionally) run
+// reverseExchangeNodeHaloAdd to fold standard cross-rank ghost contributions
+// back to owners.
+// =============================================================================
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+inline void maybePeriodicSum(NSStepper<KeyType, RealType, ElementTag>& s,
+                             cstone::DeviceVector<RealType>& d_field)
+{
+    if (s.bcKind != NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic) return;
+    if (s.periodicMap == nullptr) return;
+
+    const auto& d_own = s.domain.getNodeOwnershipMap();
+    size_t nNodes = d_field.size();
+    int blk = 256, grd = int((nNodes + blk - 1) / blk);
+
+    // (a) Gated intra-rank pair sum on the FLATTENED partner (ultimate master),
+    // ONE pass. Same-rank pairs (own[ultimate]==1): atomicAdd field[ult] += field[i];
+    // field[i] = 0. Cross-rank pairs (own[ultimate]!=1): no-op -- handled by (b).
+    //
+    // This is race-free because source set (slaves: partner>=0) and destination
+    // set (terminals: partner==-1) are DISJOINT by flatten construction, so no
+    // thread reads what another thread writes. Multiple slaves at a corner
+    // chain to the same ultimate; concurrent atomicAdd handles that.
+    //
+    // Earlier attempts (3eb6dee + 70c8d36) tried a 3-hop telescoping loop on the
+    // DIRECT parent. The first version had a hop-internal read/write race
+    // (chain link j reads field[j] while link k atomicAdd-s to it). The staged
+    // variant removed that race but ZEROED the slave between hops, which dropped
+    // contributions just received from upstream chain links -> consistent
+    // under-fold at edges/corners (defect=+529, eq{4,8}={0,0}, max_master=12).
+    // The flattened-single-pass below is the original (pre-3eb6dee) algorithm
+    // and is structurally correct.
+    mars::fem::periodicPairSumKernel<RealType><<<grd, blk>>>(
+        s.periodicMap->d_periodicPartner.data(),
+        d_own.data(), nNodes, d_field.data());
+    cudaDeviceSynchronize();
+
+    // (b) Cross-rank pair sum -- SUM-ONLY (broadcastBack=false). This is the
+    // operator's restriction P^T: slave summed onto master, owned slave slot left
+    // at zero, EXACTLY matching the same-rank periodicPairSumKernel above. The
+    // master->slave re-broadcast (Leg 2) is deliberately NOT done here -- it would
+    // make P^T into P^T followed by P, breaking the transpose pairing with the D^T
+    // read and hence the symmetry of A across the cross-rank seam. Slave slots are
+    // re-established for the next matvec by the P prolongation on the operator
+    // INPUT (top of applyDDTPerNode), not by mutating the output here.
+    if (s.numRanks > 1)
+    {
+        mars::fem::crossRankPeriodicPairSum<KeyType, RealType>(
+            *s.periodicMap, d_field, /*broadcastBack=*/false);
+    }
+}
+
+// =============================================================================
+// Diagnostic helpers used by the sub-steps below. RMS of a 3-vector magnitude
+// and max of |scalar| over owned interior DOFs (boundary skipped because lid
+// Dirichlet picks up an artificial step). Defined above the step routines so
+// they are visible at template instantiation time.
+// =============================================================================
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+RealType rmsOwnedInterior3(NSStepper<KeyType, RealType, ElementTag>& s,
+                            const cstone::DeviceVector<RealType>& d_gx,
+                            const cstone::DeviceVector<RealType>& d_gy,
+                            const cstone::DeviceVector<RealType>& d_gz)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const uint8_t* ownPtr = d_nodeOwnership.data();
+    const int* dofPtr     = s.d_node_to_dof.data();
+    const uint8_t* bnd    = s.d_isBdryDof.data();
+    const uint8_t* pmask  = (s.d_isPressureBdryDof.size() > 0)
+                            ? s.d_isPressureBdryDof.data() : nullptr;
+    const RealType* gxP   = d_gx.data();
+    const RealType* gyP   = d_gy.data();
+    const RealType* gzP   = d_gz.data();
+    RealType locSumSq = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<size_t>(0),
+        thrust::counting_iterator<size_t>(s.nodeCount),
+        [ownPtr, dofPtr, bnd, pmask, gxP, gyP, gzP] __device__ (size_t i) -> RealType {
+            if (ownPtr[i] != 1) return RealType(0);
+            int dof = dofPtr[i];
+            if (dof < 0 || bnd[dof])             return RealType(0);
+            if (pmask != nullptr && pmask[dof])  return RealType(0);
+            RealType gx = gxP[i], gy = gyP[i], gz = gzP[i];
+            return gx*gx + gy*gy + gz*gz;
+        }, RealType(0), thrust::plus<RealType>());
+    long long locCnt = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<size_t>(0),
+        thrust::counting_iterator<size_t>(s.nodeCount),
+        [ownPtr, dofPtr, bnd, pmask] __device__ (size_t i) -> long long {
+            if (ownPtr[i] != 1) return 0LL;
+            int dof = dofPtr[i];
+            if (dof < 0 || bnd[dof])             return 0LL;
+            if (pmask != nullptr && pmask[dof])  return 0LL;
+            return 1LL;
+        }, 0LL, thrust::plus<long long>());
+    auto mpiType = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+    RealType gSum = 0;
+    long long gCnt = 0;
+    MPI_Allreduce(&locSumSq, &gSum, 1, mpiType,       MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&locCnt,   &gCnt, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+    return (gCnt > 0) ? std::sqrt(gSum / RealType(gCnt)) : RealType(0);
+}
+
+// RMS of a scalar per-node field over interior owned DOFs (skip velocity-
+// Dirichlet AND pressure-Dirichlet DOFs). Complements maxOwnedInteriorAbs:
+// max is dominated by 1-cell ring next to Dirichlet pressure outflow; RMS
+// averages it down so the bulk-interior divergence is visible.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+RealType rmsOwnedInterior1(NSStepper<KeyType, RealType, ElementTag>& s,
+                            const cstone::DeviceVector<RealType>& d_q)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const uint8_t* ownPtr = d_nodeOwnership.data();
+    const int* dofPtr     = s.d_node_to_dof.data();
+    const uint8_t* bnd    = s.d_isBdryDof.data();
+    const uint8_t* pmask  = (s.d_isPressureBdryDof.size() > 0)
+                            ? s.d_isPressureBdryDof.data() : nullptr;
+    const RealType* qP    = d_q.data();
+    RealType locSumSq = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<size_t>(0),
+        thrust::counting_iterator<size_t>(s.nodeCount),
+        [ownPtr, dofPtr, bnd, pmask, qP] __device__ (size_t i) -> RealType {
+            if (ownPtr[i] != 1) return RealType(0);
+            int dof = dofPtr[i];
+            if (dof < 0 || bnd[dof])             return RealType(0);
+            if (pmask != nullptr && pmask[dof])  return RealType(0);
+            RealType q = qP[i];
+            return q * q;
+        }, RealType(0), thrust::plus<RealType>());
+    long long locCnt = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<size_t>(0),
+        thrust::counting_iterator<size_t>(s.nodeCount),
+        [ownPtr, dofPtr, bnd, pmask] __device__ (size_t i) -> long long {
+            if (ownPtr[i] != 1) return 0LL;
+            int dof = dofPtr[i];
+            if (dof < 0 || bnd[dof])             return 0LL;
+            if (pmask != nullptr && pmask[dof])  return 0LL;
+            return 1LL;
+        }, 0LL, thrust::plus<long long>());
+    auto mpiType = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+    RealType gSum = 0;
+    long long gCnt = 0;
+    MPI_Allreduce(&locSumSq, &gSum, 1, mpiType,       MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&locCnt,   &gCnt, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+    return (gCnt > 0) ? std::sqrt(gSum / RealType(gCnt)) : RealType(0);
+}
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+RealType maxOwnedInteriorAbs(NSStepper<KeyType, RealType, ElementTag>& s,
+                             const cstone::DeviceVector<RealType>& d_q)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const uint8_t* ownPtr = d_nodeOwnership.data();
+    const int* dofPtr     = s.d_node_to_dof.data();
+    const uint8_t* bnd    = s.d_isBdryDof.data();
+    const uint8_t* pmask  = (s.d_isPressureBdryDof.size() > 0)
+                            ? s.d_isPressureBdryDof.data() : nullptr;
+    const RealType* qP    = d_q.data();
+    RealType locMax = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<size_t>(0),
+        thrust::counting_iterator<size_t>(s.nodeCount),
+        [ownPtr, dofPtr, bnd, pmask, qP] __device__ (size_t i) -> RealType {
+            if (ownPtr[i] != 1) return RealType(0);
+            int dof = dofPtr[i];
+            if (dof < 0 || bnd[dof])             return RealType(0);
+            if (pmask != nullptr && pmask[dof])  return RealType(0);
+            return fabs(qP[i]);
+        }, RealType(0), thrust::maximum<RealType>());
+    auto mpiType = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+    RealType gMax = 0;
+    MPI_Allreduce(&locMax, &gMax, 1, mpiType, MPI_MAX, MPI_COMM_WORLD);
+    return gMax;
+}
+
+// =============================================================================
+// runNsStep is composed of four sub-steps. They share NO state outside
+// NSStepper; each can be invoked in isolation for unit testing (e.g. drive
+// only runPressureSolveStep with a known velocity field to reproduce the
+// DDT bug without setting up a full time loop).
+//
+// The sub-steps assume the previous one has left the relevant fields in a
+// consistent (ghost-synced) state. runNsStep handles the chaining; isolated
+// callers must do their own halo sync of inputs.
+// =============================================================================
+
+// Set to >0 to dump per-phase diagnostics for the first N calls. Declared here
+// (before the predictor/corrector) so all step functions can read it.
+static int g_nsDebugStepsLeft = 0;
+
+// MARS_PROJ_PROBE=1: measure the discrete projection identity on the reduced
+// periodic path. P1 confirms CG solved A phi = b (|A*phi-b|/|b|). P2/P3 measure
+// whether the corrector's RAW velocity (before any broadcast/halo) is actually
+// divergence-free in the operator-EXACT reduction (fold-then-reverse-halo), so a
+// growing printed div_max can be told apart from a real corrector failure. Off
+// by default => byte-identical behavior.
+static const bool g_projProbe = (std::getenv("MARS_PROJ_PROBE") != nullptr);
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, RealType rho)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const auto& d_conn          = s.domain.getElementToNodeConnectivity();
+    // connPtrs gives NodesPerElem pointers; c4..c7 stay nullptr for tet (the
+    // templated Phase-1 kernels read c0..c3 only when ElementTag==TetTag).
+    auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+    const KeyType* c0 = cp[0]; const KeyType* c1 = cp[1];
+    const KeyType* c2 = cp[2]; const KeyType* c3 = cp[3];
+    const KeyType* c4 = nullptr; const KeyType* c5 = nullptr;
+    const KeyType* c6 = nullptr; const KeyType* c7 = nullptr;
+    if constexpr (std::is_same_v<ElementTag, HexTag>) { c4 = cp[4]; c5 = cp[5]; c6 = cp[6]; c7 = cp[7]; }
+    // OWNED-only per-element scatter (proven-green pattern, commit 5da5d6a).
+    // Looping owned+halo here would DOUBLE-COUNT shared rank-boundary faces
+    // because the halo element on this rank is the same physical element the
+    // owning rank already scatters; reverseExchangeNodeHaloAdd then folds the
+    // ghost-side contribution back to owner, giving 2x at shared faces and 4x
+    // at shared corners.
+    const size_t startElem = s.domain.startIndex();
+    const size_t numLocal  = s.domain.localElementCount();
+    const int nodeBlocks   = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+    const int eBlocks      = numLocal > 0 ? int((numLocal + s.blockSize - 1) / s.blockSize) : 0;
+    const RealType invRho  = RealType(1) / rho;
+
+    using AdvScheme = typename NSStepper<KeyType, RealType, ElementTag>::AdvScheme;
+    const bool   bjMode  = (s.advScheme == AdvScheme::BarthJespersen);
+    // Runtime mode passed to the flux kernel: 0=skew, 1=upwind, 2=Barth-Jespersen.
+    const int    advMode = (s.advScheme == AdvScheme::Skew)   ? 0
+                         : (s.advScheme == AdvScheme::Upwind) ? 1
+                                                              : 2;
+
+    s.domain.exchangeNodeHalo(s.d_u);
+    s.domain.exchangeNodeHalo(s.d_v);
+    s.domain.exchangeNodeHalo(s.d_w);
+    s.domain.exchangeNodeHalo(s.d_p);
+
+    // Periodic: re-broadcast master->slave for u, v, w, p at the START of
+    // each step (before the predictor's grad p and advection scatters read
+    // them). Across steps, even after the post-corrector broadcast and the
+    // halo exchanges, slave-node values can drift slightly from master from
+    // floating-point reduction ordering and the per-node implicit-diffusion
+    // solve. If grad(p) and the advection mdot at periodic faces read
+    // mismatched slave/master values, the discrete operator is asymmetric
+    // and pressure-velocity coupling drifts -- the classic "pressure
+    // doubles every 2-3 steps while KE stays flat" signature.
+    //
+    // EXCEPTION (multi-rank reduced-DOF path): on routeReducedPeriodicCorr the
+    // reduced operator A = P^T D M^-1 D^T P inverted a BARE per-node picture
+    // where the corrector left u[slave] = u**[slave] - (dt/rho) g[slave] with
+    // the slave's OWN bare gradient g[slave] (the g master->slave broadcast is
+    // gated OFF inside the reduced operator). Across a cross-rank seam
+    // g[slave] != g[master], so u[slave] LEGITIMATELY differs from u[master] --
+    // that difference IS the projected solution CG produced. Broadcasting
+    // u[slave]:=u[master] here would clobber it and re-inject
+    // (dt/rho)(g[master]-g[slave]) of divergence on the seam EVERY step (a
+    // divergence CG never zeroed: it zeroed the FOLDED reduced divergence, not
+    // the per-slot one) -> boundary-localized residual -> geometric pressure
+    // growth. So on the reduced path skip the u/v/w broadcast (slaves keep
+    // their projected velocity); pressure is gauge-fixed and stays slave==master,
+    // so broadcast p unconditionally. Single rank: g[slave]==g[master], the
+    // broadcast is a true no-op, so routeReducedPeriodicCorr is false and the
+    // original all-fields broadcast still runs. Mirrors the post-corrector
+    // gate at the velocity-broadcast block below.
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.periodicMap)
+    {
+        const bool routeReducedPeriodicCorr =
+            s.numRanks > 1
+            && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+            && s.solverKind == SolverKind::CG;
+        int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
+        const int* d_partner = s.periodicMap->d_periodicPartner.data();
+        size_t nN            = s.nodeCount;
+        if (!routeReducedPeriodicCorr)
+        {
+            mars::fem::periodicBroadcastKernel<<<grd, blk>>>(d_partner, nN, s.d_u.data());
+            mars::fem::periodicBroadcastKernel<<<grd, blk>>>(d_partner, nN, s.d_v.data());
+            mars::fem::periodicBroadcastKernel<<<grd, blk>>>(d_partner, nN, s.d_w.data());
+        }
+        mars::fem::periodicBroadcastKernel<<<grd, blk>>>(d_partner, nN, s.d_p.data());
+        cudaDeviceSynchronize();
+        if (!routeReducedPeriodicCorr)
+        {
+            s.domain.exchangeNodeHalo(s.d_u);
+            s.domain.exchangeNodeHalo(s.d_v);
+            s.domain.exchangeNodeHalo(s.d_w);
+        }
+        s.domain.exchangeNodeHalo(s.d_p);
+    }
+
+    // grad p^n -> (d_gradPx, d_gradPy, d_gradPz). Default uses div^T (Path A);
+    // --legacy-gradient falls back to the SCS-face gradient.
+    {
+        cstone::DeviceVector<RealType> d_gxAcc(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> d_gyAcc(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> d_gzAcc(s.nodeCount, RealType(0));
+        if (eBlocks > 0)
+        {
+            if (s.useLegacyGradient)
+            {
+                computeGradientPerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    c0, c1, c2, c3, c4, c5, c6, c7,
+                    s.d_p.data(),
+                    s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                    d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
+                    startElem, numLocal);
+            }
+            else
+            {
+                applyDivTransposePerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    c0, c1, c2, c3, c4, c5, c6, c7,
+                    s.d_p.data(),
+                    s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                    d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
+                    startElem, numLocal);
+            }
+            cudaDeviceSynchronize();
+        }
+        s.domain.reverseExchangeNodeHaloAdd(d_gxAcc);
+        s.domain.reverseExchangeNodeHaloAdd(d_gyAcc);
+        s.domain.reverseExchangeNodeHaloAdd(d_gzAcc);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gxAcc);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gyAcc);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gzAcc);
+        normalizeGradientPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
+            s.d_massNode.data(),
+            s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            s.d_gradPx.data(), s.d_gradPy.data(), s.d_gradPz.data(),
+            s.nodeCount);
+        cudaDeviceSynchronize();
+        // applyDivTransposePerNodeKernel integrates to -V*grad (so M^{-1} D^T p
+        // produces -grad p, not +grad p). The predictor kernel expects gradPnq
+        // = +grad p (it computes u* = u^n - dt*(...+ grad(p)/rho - ...)). The
+        // corrector applies the same flip at line 4135. Without this flip the
+        // pressure gradient is added with the wrong sign in the predictor,
+        // which drives the divergence to grow by ~10x per step regardless of
+        // pressure stabilization or time integrator.
+        if (!s.useLegacyGradient)
+        {
+            negateThreeOwnedKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                s.d_gradPx.data(), s.d_gradPy.data(), s.d_gradPz.data(),
+                s.d_node_to_dof.data(), d_nodeOwnership.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+        }
+        s.lastGradPRms = rmsOwnedInterior3<KeyType, RealType, ElementTag>(
+            s, s.d_gradPx, s.d_gradPy, s.d_gradPz);
+    }
+
+    // Node coords for the Barth-Jespersen midpoint reconstruction. Always valid
+    // (read by the BJ flux branch and the limiter); cheap to fetch.
+    const auto& d_bjNodeX = s.domain.getNodeX();
+    const auto& d_bjNodeY = s.domain.getNodeY();
+    const auto& d_bjNodeZ = s.domain.getNodeZ();
+
+    // ---- Barth-Jespersen pre-pass: node velocity gradients ----
+    // Only when advScheme==BarthJespersen; skew/upwind pay zero cost. Build the
+    // per-component node gradient grad(q) = (1/V_i) sum_f q_face*A_f exactly like
+    // the grad(p) block above (SCS-face scatter -> reverse-halo SUM -> periodic
+    // sum -> normalize by lumped mass), then forward-exchange so ghosts carry the
+    // owner gradient. The per-component min/max and limiter phi are computed
+    // inside runPredictor (they depend on qN and this gradient).
+    if (bjMode)
+    {
+        // Lazy-allocate the 9 gradient fields + 3 scratch buffers once.
+        if (s.d_gradUx.size() != s.nodeCount)
+        {
+            s.d_gradUx.resize(s.nodeCount); s.d_gradUy.resize(s.nodeCount); s.d_gradUz.resize(s.nodeCount);
+            s.d_gradVx.resize(s.nodeCount); s.d_gradVy.resize(s.nodeCount); s.d_gradVz.resize(s.nodeCount);
+            s.d_gradWx.resize(s.nodeCount); s.d_gradWy.resize(s.nodeCount); s.d_gradWz.resize(s.nodeCount);
+            s.d_bjQmin.resize(s.nodeCount); s.d_bjQmax.resize(s.nodeCount); s.d_bjPhi.resize(s.nodeCount);
+        }
+
+        // Green-Gauss node gradient grad(q) = (1/V_i) sum_f q_face*A_f, same
+        // pattern as grad(p): SCS-face scatter -> reverse-halo SUM -> periodic
+        // sum -> normalize by lumped mass -> forward-exchange so ghosts carry the
+        // owner gradient. (An edge-stencil LSQ gradient was tried; it did NOT
+        // change the multi-rank behaviour -- the blow-up was an explicit-BJ+EXT2
+        // CFL limit, not a gradient-stencil issue -- so the cheaper Green-Gauss
+        // form is kept.)
+        auto computeNodeGradient = [&] (cstone::DeviceVector<RealType>& qField,
+                                        cstone::DeviceVector<RealType>& gx,
+                                        cstone::DeviceVector<RealType>& gy,
+                                        cstone::DeviceVector<RealType>& gz)
+        {
+            cstone::DeviceVector<RealType> d_gxAcc(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> d_gyAcc(s.nodeCount, RealType(0));
+            cstone::DeviceVector<RealType> d_gzAcc(s.nodeCount, RealType(0));
+            if (eBlocks > 0)
+            {
+                computeGradientPerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    c0, c1, c2, c3, c4, c5, c6, c7,
+                    qField.data(),
+                    s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                    d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
+                    startElem, numLocal);
+                cudaDeviceSynchronize();
+            }
+            s.domain.reverseExchangeNodeHaloAdd(d_gxAcc);
+            s.domain.reverseExchangeNodeHaloAdd(d_gyAcc);
+            s.domain.reverseExchangeNodeHaloAdd(d_gzAcc);
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gxAcc);
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gyAcc);
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gzAcc);
+            normalizeGradientPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
+                s.d_massNode.data(),
+                s.d_node_to_dof.data(), d_nodeOwnership.data(),
+                gx.data(), gy.data(), gz.data(),
+                s.nodeCount);
+            cudaDeviceSynchronize();
+            // Ghosts must carry the owner gradient: the BJ flux branch reads
+            // grad_q[up] where up may be a ghost node on a rank boundary.
+            s.domain.exchangeNodeHalo(gx);
+            s.domain.exchangeNodeHalo(gy);
+            s.domain.exchangeNodeHalo(gz);
+        };
+
+        computeNodeGradient(s.d_u, s.d_gradUx, s.d_gradUy, s.d_gradUz);
+        computeNodeGradient(s.d_v, s.d_gradVx, s.d_gradVy, s.d_gradVz);
+        computeNodeGradient(s.d_w, s.d_gradWx, s.d_gradWy, s.d_gradWz);
+    }
+
+    // Per-component advection scatter + predictor apply. Each scatter writes
+    // into a PERSISTENT advection-accumulator (s.d_advU_n etc.) so it can be
+    // reused as N(u^(n-1)) at step n+1 via EXT2 extrapolation. Predictor
+    // dispatches on s.bdfStep: 0 = BDF1 (Chorin), >=1 = BDF2/EXT2.
+    auto runPredictor = [&] (cstone::DeviceVector<RealType>& qN,
+                              cstone::DeviceVector<RealType>& qNm1,
+                              cstone::DeviceVector<RealType>& qStar,
+                              cstone::DeviceVector<RealType>& advN,
+                              cstone::DeviceVector<RealType>& advNm1,
+                              cstone::DeviceVector<RealType>& gradPnq,
+                              cstone::DeviceVector<RealType>& qTarget,
+                              RealType bodyForce,
+                              cstone::DeviceVector<RealType>& gradQx,
+                              cstone::DeviceVector<RealType>& gradQy,
+                              cstone::DeviceVector<RealType>& gradQz)
+    {
+        // Barth-Jespersen per-component limiter: neighbor min/max over edge
+        // neighbors (owned scatter + reverse MIN/MAX fold for the cross-rank
+        // ring), then phi. Must finish + be published to ghosts BEFORE the flux
+        // kernel reads phi[up]/grad[up] (up may be a ghost on a rank boundary).
+        if (bjMode)
+        {
+            bjSeedMinMaxKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                qN.data(), s.d_bjQmin.data(), s.d_bjQmax.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+            // Scatter over OWNED elements only. An owned boundary node's full
+            // edge-neighbor ring is completed across ranks by the reverse
+            // min/max fold below -- exactly as the gradient/divergence use the
+            // reverse SUM fold. (Looping the cstone element halo here would
+            // STILL miss corner-only off-rank neighbors, so it is both
+            // insufficient and a double-count risk; the reverse fold is the
+            // correct mechanism.)
+            if (eBlocks > 0)
+            {
+                bjNeighborMinMaxScatterKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    c0, c1, c2, c3, c4, c5, c6, c7,
+                    qN.data(), s.d_bjQmin.data(), s.d_bjQmax.data(),
+                    startElem, numLocal);
+                cudaDeviceSynchronize();
+            }
+            // Reduce each owner's bounds across all ranks holding the node as a
+            // ghost (MIN for qmin, MAX for qmax) -- this is the cross-rank
+            // completion the forward exchange cannot do -- THEN publish the
+            // complete owner bounds to ghosts. Without this fold the limiter is
+            // too permissive at rank boundaries and the reconstruction overshoots
+            // (multi-rank blow-up).
+            s.domain.reverseExchangeNodeHaloMin(s.d_bjQmin);
+            s.domain.reverseExchangeNodeHaloMax(s.d_bjQmax);
+            s.domain.exchangeNodeHalo(s.d_bjQmin);
+            s.domain.exchangeNodeHalo(s.d_bjQmax);
+
+            bjSeedPhiKernel<RealType><<<nodeBlocks, s.blockSize>>>(s.d_bjPhi.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+            if (eBlocks > 0)
+            {
+                bjLimiterScatterKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    c0, c1, c2, c3, c4, c5, c6, c7,
+                    qN.data(), s.d_bjQmin.data(), s.d_bjQmax.data(),
+                    gradQx.data(), gradQy.data(), gradQz.data(),
+                    d_bjNodeX.data(), d_bjNodeY.data(), d_bjNodeZ.data(),
+                    s.d_bjPhi.data(), startElem, numLocal);
+                cudaDeviceSynchronize();
+            }
+            // phi is a per-node MIN over incident faces; an owned boundary node's
+            // off-rank faces are folded in with reverse-MIN, then published.
+            s.domain.reverseExchangeNodeHaloMin(s.d_bjPhi);
+            s.domain.exchangeNodeHalo(s.d_bjPhi);
+        }
+
+        // Compute current-step advection into advN.
+        if (advN.size() != s.nodeCount) advN.resize(s.nodeCount);
+        thrust::fill(thrust::device_pointer_cast(advN.data()),
+                     thrust::device_pointer_cast(advN.data() + s.nodeCount),
+                     RealType(0));
+        if (eBlocks > 0)
+        {
+            explicitAdvectionFluxScatterPerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                c0, c1, c2, c3, c4, c5, c6, c7,
+                s.d_u.data(), s.d_v.data(), s.d_w.data(),
+                qN.data(),
+                s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                advN.data(), startElem, numLocal,
+                advMode,
+                s.d_bjPhi.data(),
+                gradQx.data(), gradQy.data(), gradQz.data(),
+                d_bjNodeX.data(), d_bjNodeY.data(), d_bjNodeZ.data());
+            cudaDeviceSynchronize();
+        }
+        s.domain.reverseExchangeNodeHaloAdd(advN);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, advN);
+        // advN[master] is now the full-control-volume advective flux (both half-CVs
+        // summed via the reverse-halo + periodic fold). Under owner-migration the
+        // predictor reads advN ONLY at owned master DOFs (dof<numOwnedDofs); the
+        // cross-rank slave is a ghost it skips, so no master->slave advN broadcast
+        // is needed -- that block was emulation-era scaffolding writing unread slots.
+
+        // DIAGNOSTIC: owned-sum of the (folded) advection term. This is a
+        // rank-count-INVARIANT physical quantity if the advection scatter +
+        // reverse-fold is cross-rank-consistent. If sum(advN[owned]) differs on
+        // 1 vs 4 ranks at the same step, the advection -- the unmeasured
+        // predictor input -- is where the cross-rank inconsistency (div(u*) 17x)
+        // enters. Owned-only sum; compare 1-rank vs 4-rank at the same step.
+        if (g_nsDebugStepsLeft > 0)
+        {
+            const uint8_t* ownPtr = s.ownershipMap().data();
+            const int* dofPtr     = s.d_node_to_dof.data();
+            const RealType* aP    = advN.data();
+            // Skip periodic slaves: the fold above (maybePeriodicSum) summed each
+            // slave's advection onto its master and zeroed the slave slot, so the
+            // slave's advection is already represented in its master (which IS
+            // counted). Skipping keeps the owned-sum rank-invariant.
+            const int* partPtr = s.periodicMap ? s.periodicMap->d_periodicPartner.data() : nullptr;
+            double locSum = thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0),
+                thrust::counting_iterator<size_t>(s.nodeCount),
+                [ownPtr, dofPtr, aP, partPtr] __device__ (size_t i) -> double {
+                    if (ownPtr[i] != 1 || dofPtr[i] < 0) return 0.0;
+                    if (partPtr && partPtr[i] >= 0) return 0.0;  // slave -> counted via master
+                    return double(aP[i]);
+                }, 0.0, thrust::plus<double>());
+            double gSum = 0;
+            MPI_Allreduce(&locSum, &gSum, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+            if (s.rank == 0)
+                std::cout << "    [advN-sum] sum(advN[owned])=" << std::scientific
+                          << std::setprecision(8) << gSum << std::defaultfloat
+                          << " (rank-INVARIANT if advection is cross-rank-consistent)\n";
+        }
+
+        if (s.useBdf2 && s.bdfStep >= 1 && advNm1.size() == s.nodeCount)
+        {
+            applyPredictorBdf2PerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                qStar.data(), qN.data(), qNm1.data(),
+                advN.data(), advNm1.data(),
+                gradPnq.data(), s.d_mass.data(), qTarget.data(),
+                s.d_isBdryDof.data(), s.d_node_to_dof.data(),
+                d_nodeOwnership.data(),
+                dt, invRho, bodyForce, s.nodeCount, s.numOwnedDofs);
+        }
+        else
+        {
+            applyPredictorPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                qStar.data(), qN.data(), advN.data(),
+                gradPnq.data(), s.d_mass.data(), s.d_massNode.data(), qTarget.data(),
+                s.d_isBdryDof.data(), s.d_node_to_dof.data(),
+                d_nodeOwnership.data(),
+                dt, invRho, bodyForce, s.nodeCount, s.numOwnedDofs);
+        }
+        cudaDeviceSynchronize();
+    };
+
+    runPredictor(s.d_u, s.d_u_nm1, s.d_uStar, s.d_advU_n, s.d_advU_nm1, s.d_gradPx, s.d_uTarget, s.bodyForceX,
+                 s.d_gradUx, s.d_gradUy, s.d_gradUz);
+    runPredictor(s.d_v, s.d_v_nm1, s.d_vStar, s.d_advV_n, s.d_advV_nm1, s.d_gradPy, s.d_vTarget, s.bodyForceY,
+                 s.d_gradVx, s.d_gradVy, s.d_gradVz);
+    runPredictor(s.d_w, s.d_w_nm1, s.d_wStar, s.d_advW_n, s.d_advW_nm1, s.d_gradPz, s.d_wTarget, s.bodyForceZ,
+                 s.d_gradWx, s.d_gradWy, s.d_gradWz);
+
+    // Sync ghosts of q* so the implicit RHS / CG warm-start read correct ghosts.
+    s.domain.exchangeNodeHalo(s.d_uStar);
+    s.domain.exchangeNodeHalo(s.d_vStar);
+    s.domain.exchangeNodeHalo(s.d_wStar);
+
+    // Periodic: broadcast master->slave so u* is identical on both sides of
+    // the periodic boundary. Without this, the implicit diffusion RHS sees
+    // a non-periodic u* and produces a non-periodic u**, propagating drift.
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.periodicMap)
+    {
+        int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
+        const int* dp = s.periodicMap->d_periodicPartner.data();
+        size_t nN     = s.nodeCount;
+        mars::fem::periodicBroadcastKernel<<<grd, blk>>>(dp, nN, s.d_uStar.data());
+        mars::fem::periodicBroadcastKernel<<<grd, blk>>>(dp, nN, s.d_vStar.data());
+        mars::fem::periodicBroadcastKernel<<<grd, blk>>>(dp, nN, s.d_wStar.data());
+        cudaDeviceSynchronize();
+        s.domain.exchangeNodeHalo(s.d_uStar);
+        s.domain.exchangeNodeHalo(s.d_vStar);
+        s.domain.exchangeNodeHalo(s.d_wStar);
+    }
+}
+
+// -------------------------------------------------------------------------
+// Step 2: IMPLICIT DIFFUSION. (M/dt + nu K) q** = (M/dt) q*  for each
+// component. The matrix is FROZEN (assembled once at setup); per step we
+// rebuild only the RHS. Velocity Dirichlet lift-off is applied to the RHS
+// for each component using its own qTarget array.
+// -------------------------------------------------------------------------
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void runImplicitDiffusionStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const int nodeBlocks  = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+    // BDF1 (step 0): mass coefficient = 1/dt, matrix = Avel.
+    // BDF2 (step >= 1): mass coefficient = 3/(2*dt), matrix = Avel_bdf2.
+    const bool bdf2Active = (s.useBdf2 && s.bdfStep >= 1 && s.d_valuesVel_bdf2.size() > 0);
+    const RealType invDt  = bdf2Active ? (RealType(3) / (RealType(2) * dt))
+                                       : (RealType(1) / dt);
+
+    cstone::DeviceVector<RealType> b(s.numOwnedDofs);
+    cstone::DeviceVector<RealType> xVec(s.numTotalDofs);
+
+    auto runImplicit = [&] (cstone::DeviceVector<RealType>& qStar,
+                             cstone::DeviceVector<RealType>& qStarStar,
+                             cstone::DeviceVector<RealType>& qTarget) -> int
+    {
+        // RHS = (mass coef) * mass * qStar; coef = 1/dt for BDF1, 3/(2dt) for BDF2.
+        thrust::fill(thrust::device_pointer_cast(b.data()),
+                     thrust::device_pointer_cast(b.data() + s.numOwnedDofs),
+                     RealType(0));
+        buildVelocityImplicitRhsKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            qStar.data(), s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            s.d_mass.data(), invDt, b.data(), s.nodeCount, s.numOwnedDofs);
+        cudaDeviceSynchronize();
+
+        enforceBcRhsFromTargetKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            s.d_isBdryDof.data(), qTarget.data(),
+            s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            b.data(), s.nodeCount, s.numOwnedDofs);
+        cudaDeviceSynchronize();
+
+        // Warm-start x with qStar scattered into DOF order.
+        cudaMemset(xVec.data(), 0, s.numTotalDofs * sizeof(RealType));
+        thrust::for_each(thrust::device,
+                          thrust::counting_iterator<size_t>(0),
+                          thrust::counting_iterator<size_t>(s.nodeCount),
+                          [nodeToDof = s.d_node_to_dof.data(),
+                           src       = qStar.data(),
+                           xOut      = xVec.data()] __device__(size_t i) {
+                              int dof = nodeToDof[i];
+                              if (dof >= 0) xOut[dof] = src[i];
+                          });
+        cudaDeviceSynchronize();
+
+        // Periodic pairs collapse to one owned merged DOF (owner-migration), so
+        // there is no separate slave row/DOF to zero here -- the merged row already
+        // carries the full RHS.
+
+        return solveOneComponent<KeyType, RealType, ElementTag>(
+            s, b, xVec, qStarStar,
+            bdf2Active ? s.Avel_bdf2 : s.Avel);
+    };
+
+    s.lastUIters = runImplicit(s.d_uStar, s.d_uStarStar, s.d_uTarget);
+    s.lastVIters = runImplicit(s.d_vStar, s.d_vStarStar, s.d_vTarget);
+    s.lastWIters = runImplicit(s.d_wStar, s.d_wStarStar, s.d_wTarget);
+
+    // Sync ghosts of q** for the divergence scatter (face donors read q** at
+    // ghost corners on rank boundaries).
+    s.domain.exchangeNodeHalo(s.d_uStarStar);
+    s.domain.exchangeNodeHalo(s.d_vStarStar);
+    s.domain.exchangeNodeHalo(s.d_wStarStar);
+
+    // Periodic: broadcast master->slave so u** is identical on both sides.
+    // The divergence scatter reads u** at face corners; an asymmetric u**
+    // produces an asymmetric div(u**) source, which biases the pressure
+    // solve and feeds the runaway. See mars_periodic_bc.hpp + post-corrector
+    // broadcast for the matching pattern at u^{n+1}.
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.periodicMap)
+    {
+        int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
+        const int* dp = s.periodicMap->d_periodicPartner.data();
+        size_t nN     = s.nodeCount;
+        mars::fem::periodicBroadcastKernel<<<grd, blk>>>(dp, nN, s.d_uStarStar.data());
+        mars::fem::periodicBroadcastKernel<<<grd, blk>>>(dp, nN, s.d_vStarStar.data());
+        mars::fem::periodicBroadcastKernel<<<grd, blk>>>(dp, nN, s.d_wStarStar.data());
+        cudaDeviceSynchronize();
+        s.domain.exchangeNodeHalo(s.d_uStarStar);
+        s.domain.exchangeNodeHalo(s.d_vStarStar);
+        s.domain.exchangeNodeHalo(s.d_wStarStar);
+    }
+}
+
+// addOpeningFluxSourceKernel -- adds the inlet/outlet boundary surface flux that
+// the interior SCS scatter never sees. Up{x,y,z} are PRESCRIBED constants
+// (velocity * outward-area-direction), NOT the solved field. Verbatim port
+// from the pump fork.
+template<typename RealType>
+__global__ void addOpeningFluxSourceKernel(
+    RealType Upx, RealType Upy, RealType Upz,
+    const RealType* aVecX, const RealType* aVecY, const RealType* aVecZ,
+    const uint8_t* ownership, RealType* divAccNode, size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    divAccNode[i] += Upx * aVecX[i] + Upy * aVecY[i] + Upz * aVecZ[i];
+}
+
+// Global discrete flux of a constant velocity through a per-node opening
+// area-vector field: sum_owned(v . aVec) + Allreduce. Same idiom as
+// fluxThroughOwned in the pump fork.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+RealType openingFluxSum(NSStepper<KeyType, RealType, ElementTag>& s,
+                        RealType vx, RealType vy, RealType vz,
+                        const cstone::DeviceVector<RealType>& ax,
+                        const cstone::DeviceVector<RealType>& ay,
+                        const cstone::DeviceVector<RealType>& az)
+{
+    if (ax.size() != s.nodeCount) return RealType(0);
+    const uint8_t* ownPtr = s.domain.getNodeOwnershipMap().data();
+    const RealType* axp = ax.data();
+    const RealType* ayp = ay.data();
+    const RealType* azp = az.data();
+    RealType local = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<size_t>(0),
+        thrust::counting_iterator<size_t>(s.nodeCount),
+        [ownPtr, axp, ayp, azp, vx, vy, vz] __device__ (size_t i) -> RealType {
+            if (ownPtr[i] != 1) return RealType(0);
+            return vx * axp[i] + vy * ayp[i] + vz * azp[i];
+        }, RealType(0), thrust::plus<RealType>());
+    RealType global = 0;
+    auto mt = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+    MPI_Allreduce(&local, &global, 1, mt, MPI_SUM, MPI_COMM_WORLD);
+    return global;
+}
+
+// -------------------------------------------------------------------------
+// Step 3: PRESSURE POISSON. K phi = (rho/dt) div(u**). The un-normalized
+// divAccNode is exactly the integrated source f_i*V_i, so the lumped RHS is
+// rhs[dof] = (rho/dt) * divAccNode[node(dof)] -- no separate
+// normalize-then-multiply-by-V chain. Enforce the pin (single Dirichlet DOF
+// at the chosen corner) on the RHS each step.
+//
+// Can be called in isolation with a pre-populated (s.d_uStarStar,
+// s.d_vStarStar, s.d_wStarStar) and ghosts in sync. Useful for reproducing
+// the DDT bug without the surrounding momentum solve.
+// -------------------------------------------------------------------------
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, RealType rho)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const auto& d_conn          = s.domain.getElementToNodeConnectivity();
+    // connPtrs gives NodesPerElem pointers; c4..c7 stay nullptr for tet (the
+    // templated Phase-1 kernels read c0..c3 only when ElementTag==TetTag).
+    auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+    const KeyType* c0 = cp[0]; const KeyType* c1 = cp[1];
+    const KeyType* c2 = cp[2]; const KeyType* c3 = cp[3];
+    const KeyType* c4 = nullptr; const KeyType* c5 = nullptr;
+    const KeyType* c6 = nullptr; const KeyType* c7 = nullptr;
+    if constexpr (std::is_same_v<ElementTag, HexTag>) { c4 = cp[4]; c5 = cp[5]; c6 = cp[6]; c7 = cp[7]; }
+    // OWNED-only per-element scatter (proven-green pattern, commit 5da5d6a).
+    // Looping owned+halo here would DOUBLE-COUNT shared rank-boundary faces
+    // because the halo element on this rank is the same physical element the
+    // owning rank already scatters; reverseExchangeNodeHaloAdd then folds the
+    // ghost-side contribution back to owner, giving 2x at shared faces and 4x
+    // at shared corners.
+    const size_t startElem = s.domain.startIndex();
+    const size_t numLocal  = s.domain.localElementCount();
+    const int nodeBlocks   = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+    const int eBlocks      = numLocal > 0 ? int((numLocal + s.blockSize - 1) / s.blockSize) : 0;
+    const RealType invDt   = RealType(1) / dt;
+
+    cstone::DeviceVector<RealType> b(s.numOwnedDofs);
+    cstone::DeviceVector<RealType> xVec(s.numTotalDofs);
+
+    cstone::DeviceVector<RealType> d_divAccNode(s.nodeCount, RealType(0));
+    if (eBlocks > 0)
+    {
+        // Rhie-Chow corrected divergence: adds the compact pressure-velocity
+        // coupling term that suppresses the checkerboard pressure mode on
+        // Q1-Q1 co-located grids. Standard CVFEM/co-located-FV stabilization
+        // (Nalu-Wind, OpenFOAM). Element-generic via scsLR<ElementTag> +
+        // ElemTraits<ElementTag>::ScsPerElem. tau auto = dt/rho.
+        bool useRC = s.useRhieChow;
+        if (useRC)
+        {
+            RealType tauRC = s.rhieChowTau;
+            if (tauRC <= 0) tauRC = dt / rho;
+            const auto& d_x = s.domain.getNodeX();
+            const auto& d_y = s.domain.getNodeY();
+            const auto& d_z = s.domain.getNodeZ();
+            computeDivergenceRhieChowKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                c0, c1, c2, c3, c4, c5, c6, c7,
+                s.d_uStarStar.data(), s.d_vStarStar.data(), s.d_wStarStar.data(),
+                s.d_p.data(),
+                s.d_gradPx.data(), s.d_gradPy.data(), s.d_gradPz.data(),
+                d_x.data(), d_y.data(), d_z.data(),
+                s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                tauRC,
+                d_divAccNode.data(), startElem, numLocal);
+        }
+        else
+        {
+            computeDivergencePerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                c0, c1, c2, c3, c4, c5, c6, c7,
+                s.d_uStarStar.data(), s.d_vStarStar.data(), s.d_wStarStar.data(),
+                s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                d_divAccNode.data(), startElem, numLocal);
+        }
+        cudaDeviceSynchronize();
+    }
+    // CRITICAL: the RHS divergence D u** must use the SAME periodic reduction,
+    // IN THE SAME ORDER, as the reduced operator's P^T -- else the projection
+    // identity D(u** - dt/rho M^-1 D^T phi)=0 cannot close (RHS-D != operator-D
+    // -> div grows instead of -> 0). The reduced operator (applyDDTPerNode,
+    // reducedPeriodicFold) does: D -> periodicFoldToMasterKernel (fold every
+    // slave onto its partner incl. cross-rank master-ghost, no gate) -> THEN
+    // reverseExchangeNodeHaloAdd. So the RHS must match: fold BEFORE reverse-halo.
+    // maybePeriodicSum (ownership-gated same-rank + broadcastBack=false cross-rank,
+    // and applied AFTER the reverse-halo here) is a different reduction in the
+    // wrong order -> the mismatch that made div grow ~2x/step. Off the reduced
+    // path the node-path operator also uses reverse-halo-then-maybePeriodicSum,
+    // so keep that exactly there.
+    {
+        const bool routeReducedRhs =
+            s.numRanks > 1
+            && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+            && s.solverKind == SolverKind::CG;
+        if (routeReducedRhs && s.periodicMap)
+        {
+            int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
+            mars::fem::periodicFoldToMasterKernel<RealType><<<grd, blk>>>(
+                s.periodicMap->d_periodicPartner.data(), s.nodeCount, d_divAccNode.data());
+            cudaDeviceSynchronize();
+            s.domain.reverseExchangeNodeHaloAdd(d_divAccNode);
+        }
+        else
+        {
+            s.domain.reverseExchangeNodeHaloAdd(d_divAccNode);
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_divAccNode);
+        }
+    }
+
+    // Balanced opening-flux source (pump-fork port). Added AFTER the reverse-
+    // halo (owned values final, no double-count via halo folding) and BEFORE
+    // the RHS build so both K- and DDT-paths see it. adjustPhi: measure the
+    // discrete inlet & outlet boundary flux of the PRESCRIBED velocities and
+    // rescale the outlet so the net added source is machine-zero by IEEE
+    // (oScale*Qout == -Qin to the last bit) -- else the FP imbalance scaled by
+    // rho/dt in the RHS build explodes the system.
+    if (s.useOpeningFluxSource)
+    {
+        const RealType Qin_raw = openingFluxSum<KeyType, RealType, ElementTag>(s,
+            s.openInletVel[0], s.openInletVel[1], s.openInletVel[2],
+            s.d_openInAreaX, s.d_openInAreaY, s.d_openInAreaZ);
+        const RealType Qout_raw = openingFluxSum<KeyType, RealType, ElementTag>(s,
+            s.openOutletVel[0], s.openOutletVel[1], s.openOutletVel[2],
+            s.d_openOutAreaX, s.d_openOutAreaY, s.d_openOutAreaZ);
+        const RealType oScale = (std::fabs(Qout_raw) > RealType(0)) ? (-Qin_raw / Qout_raw)
+                                                                    : RealType(0);
+        int ofsBlocks = int((s.nodeCount + s.blockSize - 1) / s.blockSize);
+        addOpeningFluxSourceKernel<RealType><<<ofsBlocks, s.blockSize>>>(
+            s.openInletVel[0], s.openInletVel[1], s.openInletVel[2],
+            s.d_openInAreaX.data(), s.d_openInAreaY.data(), s.d_openInAreaZ.data(),
+            d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
+        addOpeningFluxSourceKernel<RealType><<<ofsBlocks, s.blockSize>>>(
+            oScale * s.openOutletVel[0], oScale * s.openOutletVel[1], oScale * s.openOutletVel[2],
+            s.d_openOutAreaX.data(), s.d_openOutAreaY.data(), s.d_openOutAreaZ.data(),
+            d_nodeOwnership.data(), d_divAccNode.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+    }
+
+    // Source-of-NaN trace: count non-finite divAccNode over ALL owned nodes and
+    // over the owned-BOUNDARY subset separately. The interior diagnostic below
+    // (maxOwnedInteriorAbs) excludes boundary DOFs, so a boundary NaN is
+    // invisible to it -- this catches it. Gated behind env, free in production.
+    if (std::getenv("MARS_DDT_RHS_TRACE"))
+    {
+        const uint8_t* ownPtr = s.domain.getNodeOwnershipMap().data();
+        const int*     dofPtr = s.d_node_to_dof.data();
+        const uint8_t* bndPtr = s.d_isBdryDof.data();
+        const RealType* dP    = d_divAccNode.data();
+        size_t nN = s.nodeCount;
+        long long locBadAll = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(nN),
+            [ownPtr, dofPtr, dP] __device__ (size_t i) -> long long {
+                if (ownPtr[i] != 1 || dofPtr[i] < 0) return 0LL;
+                return isfinite(static_cast<double>(dP[i])) ? 0LL : 1LL;
+            }, 0LL, thrust::plus<long long>());
+        long long locBadBnd = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(nN),
+            [ownPtr, dofPtr, bndPtr, dP] __device__ (size_t i) -> long long {
+                if (ownPtr[i] != 1) return 0LL;
+                int dof = dofPtr[i];
+                if (dof < 0 || !bndPtr[dof]) return 0LL;
+                return isfinite(static_cast<double>(dP[i])) ? 0LL : 1LL;
+            }, 0LL, thrust::plus<long long>());
+        long long gBadAll = 0, gBadBnd = 0;
+        MPI_Allreduce(&locBadAll, &gBadAll, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&locBadBnd, &gBadBnd, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+        if (s.rank == 0)
+            std::cout << "  [DDT-rhs] post-divexch divAccNode owned: nonfinite(all)="
+                      << gBadAll << " nonfinite(boundary)=" << gBadBnd << "\n";
+    }
+
+    // Diagnostic: |div(u**)| max BEFORE the corrector. This is the source term
+    // the pressure solve must cancel. Compare with lastDivMax (post-corrector)
+    // to see how much the projection actually reduces divergence.
+    //
+    // Also stash the normalized per-node divergence into s.d_divUStar so the
+    // rotational pressure correction in runCorrectorStep can read it without
+    // recomputing the scatter. When rotational correction is off the field is
+    // simply unused.
+    {
+        if (s.d_divUStar.size() != s.nodeCount) s.d_divUStar.resize(s.nodeCount);
+        thrust::fill(thrust::device_pointer_cast(s.d_divUStar.data()),
+                     thrust::device_pointer_cast(s.d_divUStar.data() + s.nodeCount),
+                     RealType(0));
+        normalizeDivergencePerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            d_divAccNode.data(), s.d_massNode.data(),
+            s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            s.d_divUStar.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+        s.lastDivMaxPre = maxOwnedInteriorAbs<KeyType, RealType, ElementTag>(s, s.d_divUStar);
+    }
+
+    if (s.pressureSolve == PressureSolveKind::K)
+    {
+        // K-path: Galerkin Laplacian (K is for -Δu=f, so RHS = -coef * divAcc).
+        thrust::fill(thrust::device_pointer_cast(b.data()),
+                     thrust::device_pointer_cast(b.data() + s.numOwnedDofs), RealType(0));
+        RealType coef = rho * invDt;
+        buildPressureRhsKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            d_divAccNode.data(), s.d_node_to_dof.data(),
+            d_nodeOwnership.data(), coef, b.data(), s.nodeCount, s.numOwnedDofs);
+        cudaDeviceSynchronize();
+        // Pressure BC RHS: cavity zeroes the single pin DOF; channel zeroes
+        // every owned Dirichlet-pressure DOF on the outflow face.
+        if (s.pressurePinDof >= 0)
+        {
+            enforcePinRhsKernel<RealType><<<1, 1>>>(s.pressurePinDof, b.data());
+            cudaDeviceSynchronize();
+        }
+        if (s.d_isPressureBdryDof.size() > 0)
+        {
+            int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+            enforcePressureBcRhsKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                s.d_isPressureBdryDof.data(), b.data(), s.numOwnedDofs);
+            cudaDeviceSynchronize();
+        }
+        // Periodic: project the RHS onto range(K) by subtracting its global
+        // mean. The pure-Neumann Laplacian K has a constant-mode null space,
+        // so K phi = b is solvable only when sum(b) = 0. Without this, CG hits
+        // pAp <= 0 on the null-space direction and bails.
+        if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.numOwnedDofs > 0)
+        {
+            auto bp = thrust::device_pointer_cast(b.data());
+            RealType localSum = thrust::reduce(thrust::device, bp, bp + s.numOwnedDofs,
+                                                RealType(0), thrust::plus<RealType>());
+            RealType globalSum = 0;
+            long long localN = s.numOwnedDofs, globalN = 0;
+            MPI_Datatype mpiR = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
+            MPI_Allreduce(&localSum, &globalSum, 1, mpiR,        MPI_SUM, MPI_COMM_WORLD);
+            MPI_Allreduce(&localN,   &globalN,   1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+            if (globalN > 0)
+            {
+                RealType mean = globalSum / RealType(globalN);
+                thrust::transform(thrust::device, bp, bp + s.numOwnedDofs, bp,
+                                  [mean] __device__ (RealType v) { return v - mean; });
+            }
+        }
+        // Fresh warm-start: phi is per-step correction, not cumulative.
+        cudaMemset(xVec.data(), 0, s.numTotalDofs * sizeof(RealType));
+        s.lastPressureIters = solveOneComponent<KeyType, RealType, ElementTag>(s, b, xVec, s.d_phi, s.Apre);
+    }
+    else  // DDT: (D M^{-1} D^T) phi = -(rho/dt) D u**
+    {
+        // DDT pressure ALWAYS uses the matrix-free path (the else branch
+        // below). The assembled DDT operator s.AddT holds POSITIVE off-
+        // diagonals at boundary rows (D M^-1 D^T is not an M-matrix),
+        // which BoomerAMG's classical strength-of-connection rejects --
+        // every Hypre Setup attempt on s.AddT returned HYPRE_ERROR_GENERIC
+        // (cg_iter_p=FAIL every step on cube16 cavity). The matrix-free
+        // CG path with Jacobi preconditioning (see solvePressureDDT) is
+        // the working production route. The Hypre wrappers still serve
+        // velocity solves and the K-path pressure solve, both of which
+        // are well-conditioned M-matrices where AMG works as designed.
+        //
+        // The diagnostic env MARS_DDT_USE_ASSEMBLED_CG=1 still runs the
+        // assembled-CG path so we can verify the assembled matrix equals
+        // the matrix-free apply bit-for-bit (useful when changing the
+        // DDT assembler). It only fires when --solver=cg.
+        const char* useAsmEv = std::getenv("MARS_DDT_USE_ASSEMBLED_CG");
+        bool useAssembledCG = (useAsmEv && std::string(useAsmEv) != "0")
+                              && (s.solverKind == SolverKind::CG);
+
+        // Stage 1 -- multi-rank periodic routes DDT through the ASSEMBLED,
+        // DOF-indexed solveOneComponent(s.AddT) instead of the matrix-free
+        // solvePressureDDT. The matrix-free path keeps a NODE-indexed both-slots
+        // emulation (P on input + P^T via maybePeriodicSum) that is provably
+        // asymmetric across a CROSS-RANK periodic seam (the documented ~4% op
+        // asymmetry + mass double-count -> converge-then-diverge CG). The
+        // assembled path is genuinely DOF-indexed: same-rank periodic slaves
+        // already share the master's DOF (collapse in setupNSStepper), so their
+        // rows merge automatically. Cross-rank slaves keep their own owned DOF;
+        // their AddT row is the incomplete (asymmetric) row, so Stage 2 makes it
+        // a Dirichlet identity (x[slave]=0) and recovers x[slave]:=x[master] from
+        // the master-owner post-solve (crossRankPeriodicBroadcastDof, just before
+        // the dof->node scatter). The MASTER row is already complete because the
+        // periodic-image halo delivers the slave-side elements to the master-owner
+        // rank, so the assembler emitted the slave-side ghost columns there.
+        //
+        // Gated on solverKind==Hypre: the assembled DDT operator is SPSD with
+        // POSITIVE boundary off-diagonals; the in-house cstone PCG breaks down on
+        // it (this is exactly why the matrix-free Jacobi-CG path exists for
+        // single-rank). Hypre GMRES+BoomerAMG is the route that tolerates it.
+        // Under --solver=cg (the DEFAULT) multi-rank periodic DDT now takes the
+        // reduced P^T A P matrix-free path (routeReducedPeriodic below), NOT this
+        // assembled Hypre detour. Single-rank (numRanks==1) is bit-identical on
+        // the node-indexed matrix-free path (both gates OFF there). Needs the
+        // assembled operator to exist (hex builds s.AddT, nnzDDT>0; tet has none).
+        bool routeMultiRankPeriodic =
+            s.numRanks > 1
+            && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+            && s.solverKind == SolverKind::Hypre
+            && s.nnzDDT > 0;
+
+        // DEFAULT (--solver=cg) multi-rank periodic DDT: the reduced P^T A P
+        // matrix-free CG (solvePressureDDTReduced). Runs in REDUCED DOF space
+        // (one unknown per periodic pair, slave eliminated) so the operator is
+        // symmetric across the cross-rank seam -- the architecturally-correct
+        // fix that replaces the both-slots node-indexed emulation. No Hypre, no
+        // assembled matrix. EXACTLY numRanks>1 (single-rank stays byte-identical
+        // on the proven node-indexed solvePressureDDT in the final else branch).
+        bool routeReducedPeriodic =
+            s.numRanks > 1
+            && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+            && s.solverKind == SolverKind::CG
+            && !useAssembledCG;
+
+        if (useAssembledCG || routeMultiRankPeriodic)
+        {
+            // DDT + (Hypre or assembled-CG): use the assembled DDT matrix
+            // (s.AddT, built at setup). Build per-OWNED-DOF b exactly like the
+            // K path does.
+            thrust::fill(thrust::device_pointer_cast(b.data()),
+                         thrust::device_pointer_cast(b.data() + s.numOwnedDofs),
+                         RealType(0));
+            RealType coef = rho * invDt;
+            buildPressureRhsKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                d_divAccNode.data(), s.d_node_to_dof.data(),
+                d_nodeOwnership.data(), coef, b.data(), s.nodeCount, s.numOwnedDofs);
+            cudaDeviceSynchronize();
+            // Stage 2 -- zero b at cross-rank periodic slave DOFs. Their AddT row
+            // is a Dirichlet identity (x[slave]=0); a nonzero b[slave] would force
+            // a spurious slave value that is then clobbered by the post-solve
+            // master->slave broadcast, leaving an inconsistent residual. The
+            // slave's own divergence is NOT lost: maybePeriodicSum already merged
+            // it onto the master node above, so b[masterDof] (on the master-owner
+            // rank) carries it. No-op when no cross-rank pairs / single rank.
+            if (routeMultiRankPeriodic
+                && s.periodicMap != nullptr
+                && !s.periodicMap->cross_.d_sendOwnedSlaveIds_.empty())
+            {
+                int nSend = int(s.periodicMap->cross_.d_sendOwnedSlaveIds_.size());
+                int blk = (nSend + s.blockSize - 1) / s.blockSize;
+                zeroDofAtCrossRankSlavesKernel<RealType><<<blk, s.blockSize>>>(
+                    s.periodicMap->cross_.d_sendOwnedSlaveIds_.data(),
+                    s.d_node_to_dof.data(), nSend, s.numOwnedDofs, b.data());
+                cudaDeviceSynchronize();
+            }
+            if (s.pressurePinDof >= 0)
+            {
+                enforcePinRhsKernel<RealType><<<1, 1>>>(s.pressurePinDof, b.data());
+                cudaDeviceSynchronize();
+            }
+            if (s.d_isPressureBdryDof.size() > 0)
+            {
+                int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+                enforcePressureBcRhsKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                    s.d_isPressureBdryDof.data(), b.data(), s.numOwnedDofs);
+                cudaDeviceSynchronize();
+            }
+            // RHS finiteness check. A non-finite entry here (e.g. a boundary
+            // node whose divergence went bad upstream) would, if fed into the
+            // SUM-Allreduce below, poison b on EVERY rank and make Hypre return
+            // a generic error. The masked reduce localizes the source instead
+            // of smearing NaN across the whole vector. Gated behind env so it
+            // costs nothing in production.
+            if (s.numOwnedDofs > 0 && std::getenv("MARS_DDT_RHS_TRACE"))
+            {
+                auto bp = thrust::device_pointer_cast(b.data());
+                long long localBad = thrust::transform_reduce(thrust::device,
+                    bp, bp + s.numOwnedDofs,
+                    [] __device__ (RealType v) -> long long {
+                        return isfinite(static_cast<double>(v)) ? 0LL : 1LL;
+                    }, 0LL, thrust::plus<long long>());
+                RealType localMax = thrust::transform_reduce(thrust::device,
+                    bp, bp + s.numOwnedDofs,
+                    [] __device__ (RealType v) -> RealType {
+                        double d = static_cast<double>(v);
+                        return isfinite(d) ? static_cast<RealType>(fabs(d)) : RealType(0);
+                    }, RealType(0), thrust::maximum<RealType>());
+                long long gBad = 0; RealType gMax = 0;
+                MPI_Datatype mpiR = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
+                MPI_Allreduce(&localBad, &gBad, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+                MPI_Allreduce(&localMax, &gMax, 1, mpiR, MPI_MAX, MPI_COMM_WORLD);
+                if (s.rank == 0)
+                    std::cout << "  [DDT-rhs] post-build owned-b: nonfinite=" << gBad
+                              << " |b|max(finite)=" << gMax << "\n";
+            }
+            // Null-space projection: subtract mean(b)*1 so b lies in range(A).
+            // Required ONLY for the pure-Neumann (periodic) operator, whose
+            // constant null mode makes A phi = b solvable iff sum(b)=0. For
+            // cavity (single Dirichlet pin) and channel/pump (Dirichlet outflow
+            // face) the pin/face already removes the constant mode, so the K
+            // path does NOT project there -- we match it exactly. Subtracting a
+            // global mean from a pinned system is both unnecessary and, when an
+            // upstream non-finite entry sneaks in, the mechanism that turned all
+            // of b into NaN on every rank. The sum still uses a finiteness mask
+            // as defense in depth.
+            if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+                && s.numOwnedDofs > 0)
+            {
+                // Periodic pairs collapse to one owned merged DOF per pair
+                // (owner-migration), so there is no slave copy to skip -- the sum
+                // and count run over every owned DOF, matching the canonical-DOF
+                // mean removeMean uses on the K/matrix-free paths.
+                const uint8_t* xrMask = nullptr;
+                RealType localSum = thrust::transform_reduce(thrust::device,
+                    thrust::counting_iterator<int>(0),
+                    thrust::counting_iterator<int>(s.numOwnedDofs),
+                    [bptr = b.data(), xrMask] __device__ (int i) -> RealType {
+                        if (xrMask && xrMask[i]) return RealType(0);
+                        double d = static_cast<double>(bptr[i]);
+                        return isfinite(d) ? static_cast<RealType>(d) : RealType(0);
+                    }, RealType(0), thrust::plus<RealType>());
+                long long localN = thrust::transform_reduce(thrust::device,
+                    thrust::counting_iterator<int>(0),
+                    thrust::counting_iterator<int>(s.numOwnedDofs),
+                    [xrMask] __device__ (int i) -> long long {
+                        return (xrMask && xrMask[i]) ? 0LL : 1LL;
+                    }, 0LL, thrust::plus<long long>());
+                RealType globalSum = 0;
+                long long globalN = 0;
+                MPI_Datatype mpiR = std::is_same<RealType, double>::value
+                                    ? MPI_DOUBLE : MPI_FLOAT;
+                MPI_Allreduce(&localSum, &globalSum, 1, mpiR, MPI_SUM, MPI_COMM_WORLD);
+                MPI_Allreduce(&localN,   &globalN,   1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+                if (globalN > 0)
+                {
+                    RealType mean = globalSum / RealType(globalN);
+                    // Subtract from canonical DOFs only; leave zeroed slave rows at
+                    // 0 so their Dirichlet-identity equation stays x[slave]=0.
+                    thrust::for_each(thrust::device,
+                        thrust::counting_iterator<int>(0),
+                        thrust::counting_iterator<int>(s.numOwnedDofs),
+                        [bptr = b.data(), xrMask, mean] __device__ (int i) {
+                            if (xrMask && xrMask[i]) return;
+                            bptr[i] -= mean;
+                        });
+                }
+            }
+            // Re-enforce the pin (RHS at pin must be 0).
+            if (s.pressurePinDof >= 0)
+            {
+                enforcePinRhsKernel<RealType><<<1, 1>>>(s.pressurePinDof, b.data());
+                cudaDeviceSynchronize();
+            }
+            cudaMemset(xVec.data(), 0, s.numTotalDofs * sizeof(RealType));
+            // DDT operator (D M^-1 D^T) is SPSD with constant null space; Hypre
+            // PCG rejects it (error 1). GMRES tolerates it. Hint passes through
+            // to solveOneComponent which selects HypreGMRESSolver wrapper.
+            s.lastPressureIters = solveOneComponent<KeyType, RealType, ElementTag>(
+                s, b, xVec, s.d_phi, s.AddT, KrylovHint::GMRES);
+            // DIAGNOSTIC: sample WHOLE vectors via D2H, compute max-abs on
+            // host. Lets us see whether the solution actually propagated.
+            // Active only when env MARS_DDT_DIAG_AFTER_HYPRE is set.
+            if (std::getenv("MARS_DDT_DIAG_AFTER_HYPRE") && s.rank == 0
+                && s.numOwnedDofs > 0)
+            {
+                std::vector<RealType> h_b(s.numOwnedDofs), h_x(s.numOwnedDofs);
+                std::vector<RealType> h_phi(s.nodeCount);
+                cudaMemcpy(h_b.data(),   b.data(),       s.numOwnedDofs * sizeof(RealType), cudaMemcpyDeviceToHost);
+                cudaMemcpy(h_x.data(),   xVec.data(),    s.numOwnedDofs * sizeof(RealType), cudaMemcpyDeviceToHost);
+                cudaMemcpy(h_phi.data(), s.d_phi.data(), s.nodeCount   * sizeof(RealType), cudaMemcpyDeviceToHost);
+                RealType bMax = 0, xMax = 0, phiMax = 0;
+                int bMaxIdx = -1, xMaxIdx = -1;
+                for (int i = 0; i < s.numOwnedDofs; ++i) {
+                    if (std::abs(h_b[i]) > bMax) { bMax = std::abs(h_b[i]); bMaxIdx = i; }
+                    if (std::abs(h_x[i]) > xMax) { xMax = std::abs(h_x[i]); xMaxIdx = i; }
+                }
+                for (size_t i = 0; i < s.nodeCount; ++i)
+                    if (std::abs(h_phi[i]) > phiMax) phiMax = std::abs(h_phi[i]);
+                std::cout << "  [DDT-diag] |b|_max=" << bMax << " (at dof " << bMaxIdx << ")"
+                          << "  |xVec|_max=" << xMax << " (at dof " << xMaxIdx << ")"
+                          << "  |d_phi|_max=" << phiMax
+                          << "  iters=" << s.lastPressureIters << "\n";
+            }
+        }
+        else if (routeReducedPeriodic)
+        {
+            // Reduced (P^T A P) matrix-free CG in DOF space. Build the DOF-indexed
+            // RHS directly (buildPressureRhsKernel folds both node slots of each
+            // same-rank pair onto the one DOF, and the cross-rank slave's node
+            // divergence was already summed onto the master by maybePeriodicSum on
+            // d_divAccNode above). Project onto range(A) with the DOF-space mean
+            // removal, solve, then scatter phi_dof -> s.d_phi.
+            thrust::fill(thrust::device_pointer_cast(b.data()),
+                         thrust::device_pointer_cast(b.data() + s.numOwnedDofs),
+                         RealType(0));
+            RealType coef = rho * invDt;
+            buildPressureRhsKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                d_divAccNode.data(), s.d_node_to_dof.data(),
+                d_nodeOwnership.data(), coef, b.data(), s.nodeCount, s.numOwnedDofs);
+            cudaDeviceSynchronize();
+            removeMeanDof<KeyType, RealType, ElementTag>(s, b);
+
+            cstone::DeviceVector<RealType> phi_dof(s.numOwnedDofs, RealType(0));
+            s.lastPressureIters =
+                solvePressureDDTReduced<KeyType, RealType, ElementTag>(s, b, phi_dof);
+
+            if (g_projProbe)
+            {
+                // P1: recompute A*phi with the EXACT reduced operator CG used and
+                // compare to b. reldiff ~1e-7 => CG genuinely solved A phi = b
+                // (so any projection failure is in the corrector, not the solve).
+                const int  n         = s.numOwnedDofs;
+                const int  dofBlocks = (n + s.blockSize - 1) / s.blockSize;
+                const uint8_t* xrMask = nullptr;
+                cstone::DeviceVector<RealType> Aphi(n, RealType(0)), rdif(n, RealType(0));
+                cstone::DeviceVector<RealType> pn(s.nodeCount, RealType(0)), apn(s.nodeCount, RealType(0)),
+                                               g1(s.nodeCount, RealType(0)), g2(s.nodeCount, RealType(0)),
+                                               g3(s.nodeCount, RealType(0));
+                applyDDTReduced<KeyType, RealType, ElementTag>(s, phi_dof, Aphi, pn, apn, g1, g2, g3);
+                axpyDofKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                    rdif.data(), Aphi.data(), b.data(), RealType(-1), n);
+                cudaDeviceSynchronize();
+                RealType nb = std::sqrt(dotDof<RealType>(b,    b,    n, xrMask));
+                RealType nA = std::sqrt(dotDof<RealType>(Aphi, Aphi, n, xrMask));
+                RealType nr = std::sqrt(dotDof<RealType>(rdif, rdif, n, xrMask));
+                if (s.rank == 0)
+                    std::cout << "  [PROJ-P1] |b|=" << nb << " |A*phi|=" << nA
+                              << " |A*phi-b|/|b|=" << (nr / (nb > 0 ? nb : RealType(1)))
+                              << " iters=" << s.lastPressureIters << "\n";
+
+                // MARS_PROJ_FACTOR_PROBE: discriminating ratios per workflow w7jjyq1qc.
+                // Run A_red phi via applyDDTPerNode with applyPeriodic=TRUE on the
+                // converged phi (Option-C operator). Compare to the bare operator
+                // result Aphi already computed. r_op2/r_op tells us how the
+                // Option-C operator's master-DOF value compares to the bare:
+                //   ~1.0 => operator-side fix is irrelevant
+                //   ~2.0 => bare operator MISSED slave-side contribution
+                //   ~0.5 => bare operator DOUBLES what it should
+                // Compute |Aphi - Aphi_with_periodic| / |Aphi| over owned dofs.
+                if (std::getenv("MARS_PROJ_FACTOR_PROBE") != nullptr)
+                {
+                    cstone::DeviceVector<RealType> Aphi2(n, RealType(0));
+                    // Manually mimic applyDDTReduced but with applyPeriodic=true.
+                    // Step P input prolongation: scatter dof->node, halo, broadcast
+                    cstone::DeviceVector<RealType> phiNode2(s.nodeCount, RealType(0));
+                    cstone::DeviceVector<RealType> ApNode2(s.nodeCount, RealType(0));
+                    scatterDofToNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                        phi_dof.data(), s.d_node_to_dof.data(), phiNode2.data(),
+                        s.nodeCount, s.numOwnedDofs);
+                    cudaDeviceSynchronize();
+                    s.domain.exchangeNodeHalo(phiNode2);
+                    if (s.periodicMap) {
+                        int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
+                        mars::fem::periodicBroadcastKernel<<<grd, blk>>>(
+                            s.periodicMap->d_periodicPartner.data(), s.nodeCount,
+                            phiNode2.data());
+                        cudaDeviceSynchronize();
+                    }
+                    cstone::DeviceVector<RealType> gx2(s.nodeCount, RealType(0));
+                    cstone::DeviceVector<RealType> gy2(s.nodeCount, RealType(0));
+                    cstone::DeviceVector<RealType> gz2(s.nodeCount, RealType(0));
+                    applyDDTPerNode<KeyType, RealType, ElementTag>(s, phiNode2,
+                        ApNode2, gx2, gy2, gz2,
+                        /*applyPeriodic=*/true,
+                        /*reducedPeriodicFold=*/true);
+                    thrust::fill(thrust::device_pointer_cast(Aphi2.data()),
+                                 thrust::device_pointer_cast(Aphi2.data() + n),
+                                 RealType(0));
+                    gatherNodeToDofSumKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                        ApNode2.data(), s.d_node_to_dof.data(),
+                        d_nodeOwnership.data(), Aphi2.data(), s.nodeCount, n);
+                    cudaDeviceSynchronize();
+                    // Compute |Aphi2 - Aphi| / |Aphi| over owned DOFs that are also
+                    // seam-master DOFs (partner table has entries pointing to them).
+                    const RealType* a1 = Aphi.data();
+                    const RealType* a2 = Aphi2.data();
+                    RealType locDiff = thrust::transform_reduce(thrust::device,
+                        thrust::counting_iterator<int>(0),
+                        thrust::counting_iterator<int>(n),
+                        [a1, a2] __device__ (int i) -> RealType {
+                            return fabs(a1[i] - a2[i]);
+                        }, RealType(0), thrust::maximum<RealType>());
+                    RealType locMaxA = thrust::transform_reduce(thrust::device,
+                        thrust::counting_iterator<int>(0),
+                        thrust::counting_iterator<int>(n),
+                        [a1] __device__ (int i) -> RealType {
+                            return fabs(a1[i]);
+                        }, RealType(0), thrust::maximum<RealType>());
+                    RealType locMaxB = thrust::transform_reduce(thrust::device,
+                        thrust::counting_iterator<int>(0),
+                        thrust::counting_iterator<int>(n),
+                        [a2] __device__ (int i) -> RealType {
+                            return fabs(a2[i]);
+                        }, RealType(0), thrust::maximum<RealType>());
+                    RealType gDiff = 0, gMaxA = 0, gMaxB = 0;
+                    auto mt = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+                    MPI_Allreduce(&locDiff, &gDiff, 1, mt, MPI_MAX, MPI_COMM_WORLD);
+                    MPI_Allreduce(&locMaxA, &gMaxA, 1, mt, MPI_MAX, MPI_COMM_WORLD);
+                    MPI_Allreduce(&locMaxB, &gMaxB, 1, mt, MPI_MAX, MPI_COMM_WORLD);
+                    if (s.rank == 0)
+                        std::cout << "  [PROJ-FACTOR] max|A_bare|=" << gMaxA
+                                  << "  max|A_periodic|=" << gMaxB
+                                  << "  ratio_max(B/A)=" << (gMaxB / (gMaxA > 0 ? gMaxA : RealType(1)))
+                                  << "  max|B-A|=" << gDiff
+                                  << "  reldiff=" << (gDiff / (gMaxA > 0 ? gMaxA : RealType(1)))
+                                  << "  (~1.0 op-side fix dead; ~2.0 bare missed slave; ~0.5 bare doubles)"
+                                  << std::endl;
+                }
+            }
+
+            // Pin phi (constant null mode) in DOF space, then prolong dof->node so
+            // the rest of the step (gradient, corrector, VTU) reads s.d_phi as a
+            // per-node field. exchangeNodeHalo syncs ghosts for the gradient.
+            removeMeanDof<KeyType, RealType, ElementTag>(s, phi_dof);
+            // dofBound=numOwnedDofs: phi_dof is numOwnedDofs-sized; bound the read
+            // so ghost node slots stay 0 and are filled by the halo below.
+            scatterDofToNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                phi_dof.data(), s.d_node_to_dof.data(), s.d_phi.data(), s.nodeCount,
+                s.numOwnedDofs);
+            cudaDeviceSynchronize();
+            s.domain.exchangeNodeHalo(s.d_phi);
+            // CRITICAL: the corrector reads s.d_phi through D^T, so its input MUST
+            // equal the operator's P*phi (the prolongation A inverted). The reduced
+            // operator's STEP P does scatter -> halo -> periodicBroadcastKernel, so
+            // A saw phi[slave]=phi[master]. But the slave DOF is Dirichlet-zero, so
+            // the scatter above wrote phi[slave]=0 into s.d_phi -- WITHOUT the
+            // broadcast the corrector's D^T reads phi[slave]=0 while A read
+            // phi[slave]=phi[master]. The gradient is then NOT the D^T phi that CG
+            // inverted, so D(u**-G phi)!=0 and the projection removes ~0% of the
+            // divergence (div_in==div_out, pressure grows geometrically). The error
+            // is one element deep around every periodic face, which on a 16^3 mesh
+            // reaches nearly every node -> interior RMS grows too. Run the SAME
+            // periodicBroadcastKernel the operator's P uses so the corrector's phi
+            // is byte-identical to P*phi.
+            if (s.periodicMap)
+            {
+                int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
+                mars::fem::periodicBroadcastKernel<<<grd, blk>>>(
+                    s.periodicMap->d_periodicPartner.data(), s.nodeCount, s.d_phi.data());
+                cudaDeviceSynchronize();
+                s.domain.exchangeNodeHalo(s.d_phi);
+            }
+        }
+        else
+        {
+            cstone::DeviceVector<RealType> d_bNode(s.nodeCount, RealType(0));
+            RealType coef = rho * invDt;
+            buildPressureRhsDDTKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                d_divAccNode.data(), s.d_node_to_dof.data(),
+                d_nodeOwnership.data(), coef, d_bNode.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+            // Periodic: D M^{-1} D^T is pure-Neumann with a constant null space.
+            // DOF-weighted mean (partner table) so collapsed periodic DOFs are
+            // not over-counted -> RHS is exactly mean-zero in DOF space.
+            if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic)
+            {
+                const int* partnerPtr = s.periodicMap
+                                        ? s.periodicMap->d_periodicPartner.data() : nullptr;
+                mars::fem::removeMean<RealType>(s.domain, d_bNode, MPI_COMM_WORLD, partnerPtr);
+            }
+            s.lastPressureIters = solvePressureDDT<KeyType, RealType, ElementTag>(s, d_bNode, s.d_phi);
+        }
+    }
+
+    // Periodic: pure-Neumann pressure has a constant-mode null space. Subtract
+    // the DOF-space mean so phi is uniquely defined (and the constant doesn't
+    // drift step over step). Partner table => collapsed DOFs counted once.
+    //
+    // DO NOT refactor this shared NODE-space removeMean to use removeMeanDof:
+    // this call operates on the per-node s.d_phi (partner-weighted node counting)
+    // and is shared by the K path, the single-rank matrix-free path, and the new
+    // reduced path. removeMeanDof is DOF-space and is used ONLY inside the reduced
+    // path on b_dof/phi_dof. Routing this through it would change the K and
+    // single-rank numbers (different array layout + counting rule).
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic)
+    {
+        const int* partnerPtr = s.periodicMap
+                                ? s.periodicMap->d_periodicPartner.data() : nullptr;
+        mars::fem::removeMean<RealType>(s.domain, s.d_phi, MPI_COMM_WORLD, partnerPtr);
+    }
+
+    // Sync ghosts of phi -- needed by both the gradient (face donors) and the
+    // pressure update on owned nodes that read ghost slots only for VTU.
+    s.domain.exchangeNodeHalo(s.d_phi);
+
+    // Periodic: broadcast phi master->slave so the corrector's grad(phi) reads
+    // a periodic field. Without this, grad(phi) is asymmetric at the periodic
+    // boundary, the corrector produces a non-divergence-free u^{n+1}, and the
+    // next pressure source is correspondingly biased.
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.periodicMap)
+    {
+        int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
+        mars::fem::periodicBroadcastKernel<<<grd, blk>>>(
+            s.periodicMap->d_periodicPartner.data(), s.nodeCount, s.d_phi.data());
+        cudaDeviceSynchronize();
+        s.domain.exchangeNodeHalo(s.d_phi);
+
+        // MARS_DDT_PHIREC: measure whether phi[slave]==phi[master] after recovery.
+        // For a cross-rank slave, partner is the master's local ghost slot; this
+        // checks the recovery actually landed. Large max-diff => recovery broken
+        // (the |phi| blowup cause); ~0 => recovery works, blowup is elsewhere.
+        if (std::getenv("MARS_DDT_PHIREC"))
+        {
+            std::vector<int> hPart(s.nodeCount);
+            std::vector<RealType> hPhi(s.nodeCount);
+            cudaMemcpy(hPart.data(), s.periodicMap->d_periodicPartner.data(),
+                       s.nodeCount * sizeof(int), cudaMemcpyDeviceToHost);
+            cudaMemcpy(hPhi.data(), s.d_phi.data(),
+                       s.nodeCount * sizeof(RealType), cudaMemcpyDeviceToHost);
+            double maxdiff = 0.0; int npairs = 0, badpart = 0;
+            for (int i = 0; i < int(s.nodeCount); ++i) {
+                int m = hPart[i];
+                if (m < 0) continue;
+                ++npairs;
+                if (m >= int(s.nodeCount)) { ++badpart; continue; }
+                double d = std::abs(double(hPhi[i]) - double(hPhi[m]));
+                if (d > maxdiff) maxdiff = d;
+            }
+            std::cout << "  [DDT-phirec rank " << s.rank << "] pairs=" << npairs
+                      << " max|phi[slave]-phi[master]|=" << maxdiff
+                      << " badPartnerIdx=" << badpart << "\n" << std::flush;
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// Step 4: CORRECTOR + pressure update + divergence diagnostic.
+//   q^{n+1} = q** - (dt/rho) (grad phi)_q  on interior
+//   q^{n+1} = qTarget                       on boundary (already correct)
+// Divergence of the Rhie-Chow-CORRECTED face flux, not the plain nodal flux.
+// This is the operator the pressure solve actually drives to zero when RC is on.
+// The plain divMaxAndRmsOwned still "sees" the checkerboard mode that RC has
+// decoupled from the flux, so it can stay O(1) even when RC works -- use THIS
+// to tell whether RC is doing its job. tau matches the solve (s.rhieChowTau or
+// dt/rho). Returns roundoff-level max when the projection is consistent.
+template<typename KeyType, typename RealType, typename ElementTag>
+inline void divMaxRhieChowOwned(NSStepper<KeyType, RealType, ElementTag>& s,
+                                RealType dt, RealType rho,
+                                RealType& outMax, RealType& outRms)
+{
+    const auto& d_own  = s.domain.getNodeOwnershipMap();
+    const auto& d_conn = s.domain.getElementToNodeConnectivity();
+    auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+    const KeyType* c0 = cp[0]; const KeyType* c1 = cp[1];
+    const KeyType* c2 = cp[2]; const KeyType* c3 = cp[3];
+    const KeyType* c4 = nullptr; const KeyType* c5 = nullptr;
+    const KeyType* c6 = nullptr; const KeyType* c7 = nullptr;
+    if constexpr (std::is_same_v<ElementTag, HexTag>) { c4 = cp[4]; c5 = cp[5]; c6 = cp[6]; c7 = cp[7]; }
+    size_t startElem = s.domain.startIndex();
+    size_t numLocal  = s.domain.localElementCount();
+    int eBlocks = numLocal > 0 ? int((numLocal + s.blockSize - 1) / s.blockSize) : 0;
+    int nodeBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+
+    RealType tauRC = s.rhieChowTau;
+    if (tauRC <= 0) tauRC = dt / rho;
+    const auto& d_x = s.domain.getNodeX();
+    const auto& d_y = s.domain.getNodeY();
+    const auto& d_z = s.domain.getNodeZ();
+
+    cstone::DeviceVector<RealType> d_divAcc(s.nodeCount, RealType(0));
+    if (eBlocks > 0) {
+        computeDivergenceRhieChowKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+            c0, c1, c2, c3, c4, c5, c6, c7,
+            s.d_u.data(), s.d_v.data(), s.d_w.data(),
+            s.d_p.data(),
+            s.d_gradPx.data(), s.d_gradPy.data(), s.d_gradPz.data(),
+            d_x.data(), d_y.data(), d_z.data(),
+            s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+            tauRC, d_divAcc.data(), startElem, numLocal);
+        cudaDeviceSynchronize();
+    }
+    s.domain.reverseExchangeNodeHaloAdd(d_divAcc);
+    cstone::DeviceVector<RealType> d_divNorm(s.nodeCount, RealType(0));
+    normalizeDivergencePerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+        d_divAcc.data(), s.d_massNode.data(),
+        s.d_node_to_dof.data(), d_own.data(),
+        d_divNorm.data(), s.nodeCount);
+    cudaDeviceSynchronize();
+    outMax = maxOwnedInteriorAbs<KeyType, RealType, ElementTag>(s, d_divNorm);
+    outRms = rmsOwnedInterior1<KeyType, RealType, ElementTag>(s, d_divNorm);
+}
+
+//   p^{n+1} = p^n + phi
+// grad(phi) computed once via the same B.4 kernel, applied per-component.
+// Writes s.lastDivMax for monitoring.
+// -------------------------------------------------------------------------
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void runCorrectorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, RealType rho)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const auto& d_conn          = s.domain.getElementToNodeConnectivity();
+    // connPtrs gives NodesPerElem pointers; c4..c7 stay nullptr for tet (the
+    // templated Phase-1 kernels read c0..c3 only when ElementTag==TetTag).
+    auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+    const KeyType* c0 = cp[0]; const KeyType* c1 = cp[1];
+    const KeyType* c2 = cp[2]; const KeyType* c3 = cp[3];
+    const KeyType* c4 = nullptr; const KeyType* c5 = nullptr;
+    const KeyType* c6 = nullptr; const KeyType* c7 = nullptr;
+    if constexpr (std::is_same_v<ElementTag, HexTag>) { c4 = cp[4]; c5 = cp[5]; c6 = cp[6]; c7 = cp[7]; }
+    // OWNED-only per-element scatter (proven-green pattern, commit 5da5d6a).
+    // Looping owned+halo here would DOUBLE-COUNT shared rank-boundary faces
+    // because the halo element on this rank is the same physical element the
+    // owning rank already scatters; reverseExchangeNodeHaloAdd then folds the
+    // ghost-side contribution back to owner, giving 2x at shared faces and 4x
+    // at shared corners.
+    const size_t startElem = s.domain.startIndex();
+    const size_t numLocal  = s.domain.localElementCount();
+    const int nodeBlocks   = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+    const int eBlocks      = numLocal > 0 ? int((numLocal + s.blockSize - 1) / s.blockSize) : 0;
+    const RealType invRho  = RealType(1) / rho;
+    // BDF2: corrector projection scaling matches the predictor's effective dt.
+    // BDF1: u^{n+1} = u** - (dt/rho) grad(phi)
+    // BDF2: u^{n+1} = u** - (2*dt/(3*rho)) grad(phi)
+    const bool bdf2ActiveCorr = (s.useBdf2 && s.bdfStep >= 1 && s.d_valuesVel_bdf2.size() > 0);
+    const RealType dtEff      = bdf2ActiveCorr ? (RealType(2) * dt / RealType(3)) : dt;
+
+    // Chorin closes div(u^{n+1})=0 ONLY if the corrector subtracts the SAME
+    // discrete M^-1 D^T phi that the pressure operator A = D M^-1 D^T inverted
+    // (correct with the transpose of what you solved). On the multi-rank
+    // periodic CG path the pressure solve uses the REDUCED P^T A P operator
+    // (routeReducedPeriodic in runPressureSolveStep): its intermediate
+    // g = M^-1 D^T phi is computed BARE -- D^T scatter, cstone reverse-halo,
+    // per-node-mass normalize, forward halo -- with NO maybePeriodicSum on g
+    // and NO gradPhi master->slave broadcast (those are gated off there because
+    // the reduced operator carries the single P/P^T on its in/out, not on g).
+    // So on that path the corrector must build grad(phi) with the IDENTICAL
+    // bare sequence; the periodic-sum + broadcast sequence below is a DIFFERENT
+    // operator and would leave div(u^{n+1}) != 0 (it grew ~10x/step). Mirror the
+    // exact gate the pressure solver uses (numRanks>1 && Periodic && CG).
+    // Multi-rank periodic CG corrector: take the REDUCED branch by default,
+    // which (combined with MARS_CORR_FOLD_G=1, the next default below) gives
+    // the empirically best PROJ-P3 closure. Variance-checked on cube8/cube64:
+    // baseline 0.85/1.31 -> reduced+FOLD_G 0.64/0.76 (real >5sigma improvement).
+    // MARS_USE_ELSE_CORR=1 opts back to the else-branch for A/B comparison.
+    const char* envElseCorr = std::getenv("MARS_USE_ELSE_CORR");
+    const bool  forceElse   = envElseCorr && std::string(envElseCorr) != "0";
+    const bool routeReducedPeriodicCorr =
+        !forceElse
+        && s.numRanks > 1
+        && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+        && s.solverKind == SolverKind::CG;
+    {
+        cstone::DeviceVector<RealType> d_gxAcc(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> d_gyAcc(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> d_gzAcc(s.nodeCount, RealType(0));
+        // DDT mode MUST use the divT gradient (= literal D^T) to keep the
+        // projection identity D u^{n+1} = 0 algebraically exact. K mode keeps
+        // the legacy SCS gradient unless --experimental-divT overrides.
+        const bool useDivT = (s.pressureSolve == PressureSolveKind::DDT) || !s.useLegacyGradient;
+        if (routeReducedPeriodicCorr)
+        {
+            // Reduced-periodic corrector gradient: replicate applyDDTPerNode's
+            // steps a+b VERBATIM (the operator's g = M^-1 D^T phi). Input is the
+            // already-prolonged node field s.d_phi (P phi: scatter+halo+local
+            // broadcast happened post-solve in runPressureSolveStep), so D^T
+            // reads the correct node-space phi. Bare sequence, matching the
+            // reduced operator exactly: NO maybePeriodicSum, NO gradPhi
+            // master->slave broadcast. Always divT here (DDT is the only
+            // pressure mode on this route).
+
+            // MARS_PHI_SEAM_PROBE: at corrector entry to D^T, measure
+            // |phi[i] - phi[partner[i]]| split by cross-rank vs same-rank pair.
+            // xr_max > 1e-6 => phi prolongation broken at cross-rank slaves.
+            if constexpr (std::is_same_v<ElementTag, HexTag>) {
+                if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+                    && s.periodicMap
+                    && std::getenv("MARS_PHI_SEAM_PROBE") != nullptr)
+                {
+                    const int* dp = s.periodicMap->d_periodicPartner.data();
+                    const uint8_t* dOwn = d_nodeOwnership.data();
+                    const RealType* dPhi = s.d_phi.data();
+                    const size_t nN = s.nodeCount;
+                    auto begIt = thrust::counting_iterator<size_t>(0);
+                    auto endIt = thrust::counting_iterator<size_t>(nN);
+                    auto pickXr = [dp, dOwn, dPhi, nN] __device__ (size_t i) -> double {
+                        int j = dp[i];
+                        if (j < 0 || j >= int(nN)) return 0.0;
+                        bool xr = (dOwn[i] != dOwn[j]);
+                        if (!xr) return 0.0;
+                        double d = double(dPhi[i]) - double(dPhi[j]);
+                        return d < 0 ? -d : d;
+                    };
+                    auto pickSr = [dp, dOwn, dPhi, nN] __device__ (size_t i) -> double {
+                        int j = dp[i];
+                        if (j < 0 || j >= int(nN)) return 0.0;
+                        bool xr = (dOwn[i] != dOwn[j]);
+                        if (xr) return 0.0;
+                        double d = double(dPhi[i]) - double(dPhi[j]);
+                        return d < 0 ? -d : d;
+                    };
+                    double locXr = thrust::transform_reduce(thrust::device, begIt, endIt,
+                        pickXr, 0.0, thrust::maximum<double>());
+                    double locSr = thrust::transform_reduce(thrust::device, begIt, endIt,
+                        pickSr, 0.0, thrust::maximum<double>());
+                    double loc[2] = {locXr, locSr};
+                    double glb[2] = {0.0, 0.0};
+                    MPI_Allreduce(loc, glb, 2, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+                    if (s.rank == 0) {
+                        std::cout << "  [MARS_PHI_SEAM_PROBE]"
+                                  << " xr_max_|phi[s]-phi[m]|=" << glb[0]
+                                  << " sr_max_|phi[s]-phi[m]|=" << glb[1] << "\n";
+                    }
+                }
+            }
+
+            if (eBlocks > 0)
+            {
+                applyDivTransposePerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    c0, c1, c2, c3, c4, c5, c6, c7,
+                    s.d_phi.data(),
+                    s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                    d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
+                    startElem, numLocal);
+                cudaDeviceSynchronize();
+            }
+            // MARS_GRADTRACE_PROBE: snapshot d_gxAcc at FIRST owned cross-rank
+            // slave PRE-reverseExchange (only this rank's owned-element scatter).
+            if (s.periodicMap && std::getenv("MARS_GRADTRACE_PROBE") != nullptr) {
+                const int* partnerP = s.periodicMap->d_periodicPartner.data();
+                const uint8_t* ownP = d_nodeOwnership.data();
+                const size_t N = s.nodeCount;
+                long long localFirst = thrust::transform_reduce(thrust::device,
+                    thrust::counting_iterator<size_t>(0),
+                    thrust::counting_iterator<size_t>(N),
+                    [partnerP, ownP, N] __device__ (size_t i) -> long long {
+                        if (ownP[i] != 1) return (long long)N;
+                        int m = partnerP[i];
+                        if (m < 0 || ownP[m] == 1) return (long long)N;
+                        return (long long)i;
+                    }, (long long)N, thrust::minimum<long long>());
+                if (localFirst < (long long)N) {
+                    size_t i = (size_t)localFirst;
+                    int h_m;
+                    RealType h_gS[3], h_gM[3];
+                    cudaMemcpy(&h_m, partnerP + i, sizeof(int), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gS[0], d_gxAcc.data() + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gS[1], d_gyAcc.data() + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gS[2], d_gzAcc.data() + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gM[0], d_gxAcc.data() + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gM[1], d_gyAcc.data() + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gM[2], d_gzAcc.data() + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                    std::cout << "  [GRADTRACE-PRE-RHALO r" << s.rank << "] i=" << i << " m=" << h_m
+                              << "  gAccS=(" << h_gS[0] << "," << h_gS[1] << "," << h_gS[2] << ")"
+                              << "  gAccM=(" << h_gM[0] << "," << h_gM[1] << "," << h_gM[2] << ")" << std::endl;
+                }
+            }
+            // Step a halo: owner sees neighbor ranks' corner-only contributions.
+            s.domain.reverseExchangeNodeHaloAdd(d_gxAcc);
+            s.domain.reverseExchangeNodeHaloAdd(d_gyAcc);
+            s.domain.reverseExchangeNodeHaloAdd(d_gzAcc);
+            // MARS_GRADTRACE_PROBE: same snapshot POST-reverseExchange (after
+            // ghost contributions added from neighbor ranks).
+            if (s.periodicMap && std::getenv("MARS_GRADTRACE_PROBE") != nullptr) {
+                const int* partnerP = s.periodicMap->d_periodicPartner.data();
+                const uint8_t* ownP = d_nodeOwnership.data();
+                const size_t N = s.nodeCount;
+                long long localFirst = thrust::transform_reduce(thrust::device,
+                    thrust::counting_iterator<size_t>(0),
+                    thrust::counting_iterator<size_t>(N),
+                    [partnerP, ownP, N] __device__ (size_t i) -> long long {
+                        if (ownP[i] != 1) return (long long)N;
+                        int m = partnerP[i];
+                        if (m < 0 || ownP[m] == 1) return (long long)N;
+                        return (long long)i;
+                    }, (long long)N, thrust::minimum<long long>());
+                if (localFirst < (long long)N) {
+                    size_t i = (size_t)localFirst;
+                    int h_m;
+                    RealType h_gS[3], h_gM[3];
+                    cudaMemcpy(&h_m, partnerP + i, sizeof(int), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gS[0], d_gxAcc.data() + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gS[1], d_gyAcc.data() + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gS[2], d_gzAcc.data() + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gM[0], d_gxAcc.data() + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gM[1], d_gyAcc.data() + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                    cudaMemcpy(&h_gM[2], d_gzAcc.data() + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                    std::cout << "  [GRADTRACE-POST-RHALO r" << s.rank << "] i=" << i << " m=" << h_m
+                              << "  gAccS=(" << h_gS[0] << "," << h_gS[1] << "," << h_gS[2] << ")"
+                              << "  gAccM=(" << h_gM[0] << "," << h_gM[1] << "," << h_gM[2] << ")" << std::endl;
+                }
+            }
+            // MARS_CORR_FOLD_G=1 (default OFF): pre-normalize fold of unnormalized
+            // gAcc[slave] onto gAcc[master], then broadcast the merged value back
+            // master->slave after normalize. Probe data (GRADTRACE+GRADDUMP) shows
+            // gAcc at slot S = slave-side unnormalized contribution only; gAcc at
+            // slot M = master-side unnormalized contribution only. m_M = m_S =
+            // m_merged after seam mass mirror. Without fold, gradPhi[M] =
+            // master-side-unnormalized / m_merged ≈ half the physical gradient,
+            // same for slot S. Folding gives gradPhi = (g_M + g_S) / m_merged at
+            // both slots = full physical gradient. The corrector then subtracts
+            // the full gradient at both M and S. This DIFFERS from the bare
+            // operator (NS:5234-5242 normalizes without fold) -- if SYMPROBE
+            // still rel=0, the operator's A_red did not include the fold either
+            // and the projection identity required the corrector to subtract the
+            // per-slot HALF gradients, not the full one. If PROJ-P3 closes, the
+            // operator's effective A_red treats the seam pair as merged-CV and
+            // the corrector must too.
+            // MARS_CORR_FOLD_G default ON: pre-normalize maybePeriodicSum on g
+            // plus master->slave broadcast post-normalize. Variance-checked on
+            // cube8/cube64: baseline 0.85/1.31 -> with-fold 0.64/0.76 PROJ-P3.
+            // MARS_CORR_FOLD_G=0 opts out (kept for ablation tests).
+            // MARS_TGV_H2 default ON: per-slot g (NO fold/broadcast on g) on
+            // the corrector gradient. Algebra (workflow wibaxuy3q): with
+            // g[S]_n ~ -g[M]_n at periodic-axis-normal (OP_GRADDUMP confirmed),
+            // per-slot corrector gives u^{n+1}_M ~ u^{n+1}_S = (u**_M+u**_S)/2,
+            // which when scattered with D_slave ~ -D_master gives D_folded ~ 0.
+            // Empirical: cube64 PROJ-P3 1.31 -> 0.43, |Du^{n+1}| drops 3x.
+            // Paired with u-broadcast before PROJ-P3 probe (search for tgvH2).
+            // MARS_TGV_H2=0 reverts to FOLD_G default for ablation.
+            const char* h2env = std::getenv("MARS_TGV_H2");
+            const bool tgvH2 = !(h2env && std::string(h2env) == "0");
+            const char* corrFoldGEnv = std::getenv("MARS_CORR_FOLD_G");
+            const bool  corrFoldG    = !tgvH2 && !(corrFoldGEnv && std::string(corrFoldGEnv) == "0");
+            if (corrFoldG && s.periodicMap)
+            {
+                maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gxAcc);
+                maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gyAcc);
+                maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gzAcc);
+            }
+            // Step b: g <- M^-1 g (per-node mass).
+            normalizeGradientPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
+                s.d_massNode.data(),
+                s.d_node_to_dof.data(), d_nodeOwnership.data(),
+                s.d_gradPhix.data(), s.d_gradPhiy.data(), s.d_gradPhiz.data(),
+                s.nodeCount);
+            cudaDeviceSynchronize();
+            // MARS_CORR_FOLD_G=1: after normalize, broadcast master->slave so
+            // both seam slots carry the same merged gradient before the
+            // corrector subtracts it (otherwise the slave slot would be 0 from
+            // maybePeriodicSum's zero-after-fold). Same-rank and cross-rank.
+            if (corrFoldG && s.periodicMap)
+            {
+                const int* dpart = s.periodicMap->d_periodicPartner.data();
+                int gblk = 256, ggrd = int((s.nodeCount + gblk - 1) / gblk);
+                mars::fem::periodicBroadcastSameRankKernel<RealType><<<ggrd, gblk>>>(
+                    dpart, d_nodeOwnership.data(), s.nodeCount, s.d_gradPhix.data());
+                mars::fem::periodicBroadcastSameRankKernel<RealType><<<ggrd, gblk>>>(
+                    dpart, d_nodeOwnership.data(), s.nodeCount, s.d_gradPhiy.data());
+                mars::fem::periodicBroadcastSameRankKernel<RealType><<<ggrd, gblk>>>(
+                    dpart, d_nodeOwnership.data(), s.nodeCount, s.d_gradPhiz.data());
+                cudaDeviceSynchronize();
+                if (s.numRanks > 1)
+                {
+                    mars::fem::crossRankPeriodicBroadcast<KeyType, RealType>(*s.periodicMap, s.d_gradPhix);
+                    mars::fem::crossRankPeriodicBroadcast<KeyType, RealType>(*s.periodicMap, s.d_gradPhiy);
+                    mars::fem::crossRankPeriodicBroadcast<KeyType, RealType>(*s.periodicMap, s.d_gradPhiz);
+                }
+            }
+            // Forward halo (always, matches operator's post-normalize halo on g).
+            s.domain.exchangeNodeHalo(s.d_gradPhix);
+            s.domain.exchangeNodeHalo(s.d_gradPhiy);
+            s.domain.exchangeNodeHalo(s.d_gradPhiz);
+
+            // MARS_GRADSLOT_PROBE: over owned CROSS-rank periodic slaves
+            // (partner ghost on a different rank), compare gradPhi at slave slot
+            // S vs gradPhi at master ghost partner[S]. The reduced-periodic
+            // corrector path does NOT broadcast master->slave on gradPhi; if
+            // slot-S grad already equals master-ghost grad, broadcast would be
+            // a no-op (slot-grad hypothesis falsified). Hex+Periodic+env-gated.
+            if constexpr (std::is_same_v<ElementTag, HexTag>) {
+                if (s.periodicMap
+                    && std::getenv("MARS_GRADSLOT_PROBE") != nullptr) {
+                    const RealType* gxP = s.d_gradPhix.data();
+                    const RealType* gyP = s.d_gradPhiy.data();
+                    const RealType* gzP = s.d_gradPhiz.data();
+                    const int* partnerP = s.periodicMap->d_periodicPartner.data();
+                    const uint8_t* ownP = d_nodeOwnership.data();
+                    const size_t N = s.nodeCount;
+                    auto relK = [gxP,gyP,gzP,partnerP,ownP] __device__ (size_t i) -> RealType {
+                        if (ownP[i] != 1) return RealType(0);
+                        int m = partnerP[i];
+                        if (m < 0) return RealType(0);
+                        if (ownP[m] == 1) return RealType(0); // same-rank: skip
+                        RealType dx = gxP[i]-gxP[m], dy = gyP[i]-gyP[m], dz = gzP[i]-gzP[m];
+                        RealType nd = sqrt(dx*dx + dy*dy + dz*dz);
+                        RealType nS = sqrt(gxP[i]*gxP[i] + gyP[i]*gyP[i] + gzP[i]*gzP[i]);
+                        RealType nM = sqrt(gxP[m]*gxP[m] + gyP[m]*gyP[m] + gzP[m]*gzP[m]);
+                        RealType den = nS > nM ? nS : nM;
+                        if (den < RealType(1e-30)) return RealType(0);
+                        return nd / den;
+                    };
+                    auto absSk = [gxP,gyP,gzP,partnerP,ownP] __device__ (size_t i) -> RealType {
+                        if (ownP[i] != 1) return RealType(0);
+                        int m = partnerP[i]; if (m < 0 || ownP[m] == 1) return RealType(0);
+                        return sqrt(gxP[i]*gxP[i]+gyP[i]*gyP[i]+gzP[i]*gzP[i]);
+                    };
+                    auto absDk = [gxP,gyP,gzP,partnerP,ownP] __device__ (size_t i) -> RealType {
+                        if (ownP[i] != 1) return RealType(0);
+                        int m = partnerP[i]; if (m < 0 || ownP[m] == 1) return RealType(0);
+                        RealType dx = gxP[i]-gxP[m], dy = gyP[i]-gyP[m], dz = gzP[i]-gzP[m];
+                        return sqrt(dx*dx+dy*dy+dz*dz);
+                    };
+                    auto cit0 = thrust::counting_iterator<size_t>(0);
+                    auto citN = thrust::counting_iterator<size_t>(N);
+                    RealType locMaxRel = thrust::transform_reduce(thrust::device, cit0, citN,
+                        relK, RealType(0), thrust::maximum<RealType>());
+                    RealType locAbsS = thrust::transform_reduce(thrust::device, cit0, citN,
+                        absSk, RealType(0), thrust::maximum<RealType>());
+                    RealType locAbsD = thrust::transform_reduce(thrust::device, cit0, citN,
+                        absDk, RealType(0), thrust::maximum<RealType>());
+                    RealType loc[3] = {locMaxRel, locAbsD, locAbsS}, glb[3] = {0,0,0};
+                    auto mt3 = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+                    MPI_Allreduce(loc, glb, 3, mt3, MPI_MAX, MPI_COMM_WORLD);
+                    if (s.rank == 0)
+                        std::cout << "  [PROJ-GRADSLOT] maxRel|gS-gM|/max(|gS|,|gM|)=" << glb[0]
+                                  << "  max|gS-gM|=" << glb[1]
+                                  << "  max|gS|=" << glb[2]
+                                  << "  (owned cross-rank periodic slaves)" << std::endl;
+                }
+                // MARS_GRADDUMP_PROBE: at the FIRST owned cross-rank slave on
+                // each rank, print gS (slot at slave), gM (slot at master ghost
+                // partner) componentwise so we can READ what's there rather than
+                // guess. If gS = -gM the operator's master-DOF couples via a
+                // signed sum that no slot-wise corrector can match. If
+                // gS = gM but magnitudes differ, mass mismatch elsewhere.
+                if (std::getenv("MARS_GRADDUMP_PROBE") != nullptr) {
+                    const RealType* gxP = s.d_gradPhix.data();
+                    const RealType* gyP = s.d_gradPhiy.data();
+                    const RealType* gzP = s.d_gradPhiz.data();
+                    const int* partnerP = s.periodicMap->d_periodicPartner.data();
+                    const uint8_t* ownP = d_nodeOwnership.data();
+                    const RealType* mP  = s.d_massNode.data();
+                    const size_t N = s.nodeCount;
+                    // Search for first i with own[i]==1, partner[i]>=0, own[partner[i]]==0
+                    auto cit0 = thrust::counting_iterator<size_t>(0);
+                    auto citN = thrust::counting_iterator<size_t>(N);
+                    long long localFirst = thrust::transform_reduce(thrust::device, cit0, citN,
+                        [partnerP, ownP, N] __device__ (size_t i) -> long long {
+                            if (ownP[i] != 1) return (long long)N;
+                            int m = partnerP[i];
+                            if (m < 0 || ownP[m] == 1) return (long long)N;
+                            return (long long)i;
+                        }, (long long)N, thrust::minimum<long long>());
+                    if (localFirst < (long long)N) {
+                        size_t i = (size_t)localFirst;
+                        RealType h_gS[3], h_gM[3], h_mS, h_mM;
+                        int h_m;
+                        cudaMemcpy(&h_m, partnerP + i, sizeof(int), cudaMemcpyDeviceToHost);
+                        cudaMemcpy(&h_gS[0], gxP + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                        cudaMemcpy(&h_gS[1], gyP + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                        cudaMemcpy(&h_gS[2], gzP + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                        cudaMemcpy(&h_gM[0], gxP + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                        cudaMemcpy(&h_gM[1], gyP + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                        cudaMemcpy(&h_gM[2], gzP + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                        cudaMemcpy(&h_mS,    mP  + i,    sizeof(RealType), cudaMemcpyDeviceToHost);
+                        cudaMemcpy(&h_mM,    mP  + h_m,  sizeof(RealType), cudaMemcpyDeviceToHost);
+                        std::cout << "  [GRADDUMP r" << s.rank << "] i=" << i << " m=" << h_m
+                                  << "  gS=(" << h_gS[0] << "," << h_gS[1] << "," << h_gS[2] << ")"
+                                  << "  gM=(" << h_gM[0] << "," << h_gM[1] << "," << h_gM[2] << ")"
+                                  << "  gS+gM=(" << (h_gS[0]+h_gM[0]) << "," << (h_gS[1]+h_gM[1]) << "," << (h_gS[2]+h_gM[2]) << ")"
+                                  << "  mS=" << h_mS << " mM=" << h_mM << std::endl;
+                    }
+                }
+            }
+
+            // applyDivTransposePerNodeKernel integrates to -V*grad, so
+            // M^-1 D^T phi = -grad; the corrector kernel wants +grad. Flip sign.
+            negateThreeOwnedKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                s.d_gradPhix.data(), s.d_gradPhiy.data(), s.d_gradPhiz.data(),
+                s.d_node_to_dof.data(), d_nodeOwnership.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+            s.lastGradPhiRms = rmsOwnedInterior3<KeyType, RealType, ElementTag>(
+                s, s.d_gradPhix, s.d_gradPhiy, s.d_gradPhiz);
+        }
+        else
+        {
+        if (eBlocks > 0)
+        {
+            if (!useDivT)
+            {
+                computeGradientPerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    c0, c1, c2, c3, c4, c5, c6, c7,
+                    s.d_phi.data(),
+                    s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                    d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
+                    startElem, numLocal);
+            }
+            else
+            {
+                applyDivTransposePerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    c0, c1, c2, c3, c4, c5, c6, c7,
+                    s.d_phi.data(),
+                    s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                    d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
+                    startElem, numLocal);
+            }
+            cudaDeviceSynchronize();
+        }
+        s.domain.reverseExchangeNodeHaloAdd(d_gxAcc);
+        s.domain.reverseExchangeNodeHaloAdd(d_gyAcc);
+        s.domain.reverseExchangeNodeHaloAdd(d_gzAcc);
+        // MARS_CORR_NO_GFOLD=1 disables the pre-normalize maybePeriodicSum on g
+        // in the else-branch corrector. Per workflow w02rz2t9l hypothesis B
+        // discriminator: the operator (bare CG matvec at NS:5757 applyPeriodic=
+        // false) uses per-slot g_half at master and slave (no fold inside the
+        // matvec), but the corrector folds g pre-normalize and then broadcasts,
+        // so gradPhi=g_full at both slots. The corrector subtracts ~2x what the
+        // operator inverted phi for at the seam, leaving |Du^{n+1}| ~ |Du**|.
+        // With this env on, gradPhi[M]=g_M_half, gradPhi[S]=g_S_half (then
+        // master->slave broadcast makes them equal by periodic symmetry).
+        static const bool corrNoGFold = (std::getenv("MARS_CORR_NO_GFOLD") != nullptr);
+        if (!corrNoGFold) {
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gxAcc);
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gyAcc);
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gzAcc);
+        }
+        normalizeGradientPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
+            s.d_massNode.data(),
+            s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            s.d_gradPhix.data(), s.d_gradPhiy.data(), s.d_gradPhiz.data(),
+            s.nodeCount);
+        cudaDeviceSynchronize();
+        // applyDivTransposePerNodeKernel integrates to -V*grad (validator-
+        // confirmed by mars_amr_ddt.cu --test=sign), so M^{-1} D^T phi = -grad.
+        // The corrector kernel expects gradPhiq = +grad. Flip sign in place.
+        // The SCS-gradient path produces +grad already, so no flip needed there.
+        if (useDivT)
+        {
+            negateThreeOwnedKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                s.d_gradPhix.data(), s.d_gradPhiy.data(), s.d_gradPhiz.data(),
+                s.d_node_to_dof.data(), d_nodeOwnership.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+        }
+        s.lastGradPhiRms = rmsOwnedInterior3<KeyType, RealType, ElementTag>(
+            s, s.d_gradPhix, s.d_gradPhiy, s.d_gradPhiz);
+
+        // Periodic seam: maybePeriodicSum above is P^T (sum-only) -> after
+        // normalize gradPhi[slave]=0, so a periodic slave node would receive NO
+        // pressure correction (q[slave]=q**[slave]-dt/rho*0) and div would not
+        // close at the periodic faces (boundary div ~30x interior -> blowup).
+        // Restore gradPhi[slave]=gradPhi[master] using the SAME deadlock-free
+        // pattern the post-solve phi/velocity consistency uses: a normal
+        // collective halo exchange (master value lands in the slave's ghost
+        // slot) followed by the pure-LOCAL periodicBroadcastKernel (no
+        // point-to-point MPI, no epoch tags -> cannot desync/deadlock). Covers
+        // same-rank AND cross-rank pairs: cross-rank masters arrive via the halo.
+        // No-op off the periodic path (empty partner table).
+        if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+            && s.periodicMap != nullptr)
+        {
+            const int* dpart = s.periodicMap->d_periodicPartner.data();
+            s.domain.exchangeNodeHalo(s.d_gradPhix);
+            s.domain.exchangeNodeHalo(s.d_gradPhiy);
+            s.domain.exchangeNodeHalo(s.d_gradPhiz);
+            mars::fem::periodicBroadcastKernel<<<nodeBlocks, s.blockSize>>>(
+                dpart, s.nodeCount, s.d_gradPhix.data());
+            mars::fem::periodicBroadcastKernel<<<nodeBlocks, s.blockSize>>>(
+                dpart, s.nodeCount, s.d_gradPhiy.data());
+            mars::fem::periodicBroadcastKernel<<<nodeBlocks, s.blockSize>>>(
+                dpart, s.nodeCount, s.d_gradPhiz.data());
+            cudaDeviceSynchronize();
+        }
+        }
+    }
+
+    auto runCorrector = [&] (cstone::DeviceVector<RealType>& qOut,
+                              cstone::DeviceVector<RealType>& qStarStar,
+                              cstone::DeviceVector<RealType>& gradPhiq,
+                              cstone::DeviceVector<RealType>& qTarget)
+    {
+        applyCorrectorPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            qOut.data(), qStarStar.data(), gradPhiq.data(), qTarget.data(),
+            s.d_isBdryDof.data(), s.d_node_to_dof.data(),
+            d_nodeOwnership.data(), dtEff, invRho, s.nodeCount, s.numOwnedDofs);
+        cudaDeviceSynchronize();
+    };
+
+    runCorrector(s.d_u, s.d_uStarStar, s.d_gradPhix, s.d_uTarget);
+    runCorrector(s.d_v, s.d_vStarStar, s.d_gradPhiy, s.d_vTarget);
+    runCorrector(s.d_w, s.d_wStarStar, s.d_gradPhiz, s.d_wTarget);
+
+    // NOTE: the master->slave broadcast on s.d_u/v/w is DEFERRED to AFTER the
+    // PROJ-P3 probe below (see end of this branch). The corrector's slot-wise
+    // output (u^{n+1}_slot = u**_slot - dt/rho * g_slot, with the BARE g of the
+    // reduced operator, not broadcast) is the EXACT field on which the
+    // operator's discrete projection identity D_folded(u^{n+1}) = 0 closes at
+    // every master DOF. Overwriting u^{n+1}_slave := u^{n+1}_master BEFORE the
+    // probe destroys that slot-wise field (the algebra needs
+    // u**_slave - dt/rho*g_slave in the slave slot, not u_master) and is what
+    // made PROJ-P3 read ~1.0. The broadcast IS still needed for the next-step
+    // predictor's per-node flux scatter to see u_slave == u_master, so we run
+    // it AFTER the probe, before updatePressureKernel / the next predictor.
+    // MARS_TGV_H2=1: u-broadcast master->slave BEFORE the probe (workflow
+    // wibaxuy3q H2 algebra: with per-slot g, u^{n+1}_M = u^{n+1}_S already by
+    // symmetry; explicit broadcast guarantees bit-equality even with floating-
+    // point noise). Without H2, the broadcast stays deferred past the probe
+    // (commit 808140e). Gated on Periodic+CG+routeReducedPeriodicCorr because
+    // only that branch keeps the per-slot gradient that H2 requires.
+    {
+        const char* h2env = std::getenv("MARS_TGV_H2");
+        const bool tgvH2 = !(h2env && std::string(h2env) == "0");
+        if (tgvH2 && routeReducedPeriodicCorr && s.periodicMap)
+        {
+            const int* dpart = s.periodicMap->d_periodicPartner.data();
+            int gblk = 256, ggrd = int((s.nodeCount + gblk - 1) / gblk);
+            auto bcastH2 = [&](cstone::DeviceVector<RealType>& d_field) {
+                mars::fem::periodicBroadcastSameRankKernel<RealType><<<ggrd, gblk>>>(
+                    dpart, d_nodeOwnership.data(), s.nodeCount, d_field.data());
+                cudaDeviceSynchronize();
+                if (s.numRanks > 1)
+                    mars::fem::crossRankPeriodicBroadcast<KeyType, RealType>(*s.periodicMap, d_field);
+                s.domain.exchangeNodeHalo(d_field);
+            };
+            bcastH2(s.d_u);
+            bcastH2(s.d_v);
+            bcastH2(s.d_w);
+        }
+    }
+
+    if (g_projProbe
+        && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+        && s.solverKind == SolverKind::CG)
+    {
+        // P2/P3: does the projection actually reduce divergence? Measure ||D u**||
+        // (in) and ||D u^{n+1}|| of the RAW corrected velocity (out, before any
+        // periodic broadcast/halo -- those are gated off on this path so s.d_u/v/w
+        // are the corrector's true output) in the OPERATOR-EXACT reduction
+        // (scatter -> periodicFoldToMasterKernel -> reverseExchangeNodeHaloAdd ->
+        // M^-1 normalize, the same fold-before-reverse-halo as the operator and
+        // RHS). ratio ~0 => projection works (and a growing printed div_max is a
+        // diagnostic reduction-order artifact); ratio ~1 => corrector's D really
+        // is not the D CG inverted.
+        cstone::DeviceVector<RealType> divAcc(s.nodeCount, RealType(0)),
+                                       divNorm(s.nodeCount, RealType(0));
+        auto opDiv = [&](cstone::DeviceVector<RealType>& U,
+                         cstone::DeviceVector<RealType>& V,
+                         cstone::DeviceVector<RealType>& W) -> RealType {
+            thrust::fill(thrust::device_pointer_cast(divAcc.data()),
+                         thrust::device_pointer_cast(divAcc.data() + s.nodeCount), RealType(0));
+            if (eBlocks > 0) {
+                computeDivergencePerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    c0, c1, c2, c3, c4, c5, c6, c7, U.data(), V.data(), W.data(),
+                    s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                    divAcc.data(), startElem, numLocal);
+                cudaDeviceSynchronize();
+            }
+            if (s.periodicMap) {
+                int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
+                mars::fem::periodicFoldToMasterKernel<RealType><<<grd, blk>>>(
+                    s.periodicMap->d_periodicPartner.data(), s.nodeCount, divAcc.data());
+                cudaDeviceSynchronize();
+            }
+            s.domain.reverseExchangeNodeHaloAdd(divAcc);
+            thrust::fill(thrust::device_pointer_cast(divNorm.data()),
+                         thrust::device_pointer_cast(divNorm.data() + s.nodeCount), RealType(0));
+            normalizeDivergencePerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                divAcc.data(), s.d_massNode.data(), s.d_node_to_dof.data(),
+                d_nodeOwnership.data(), divNorm.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+            return maxOwnedInteriorAbs<KeyType, RealType, ElementTag>(s, divNorm);
+        };
+        // Forward halo u/v/w so opDiv's per-element scatter reads the corrector's
+        // u^{n+1} at GHOST corners, not the previous step's u^n. The corrector
+        // writes owned slots only; without this halo, owned elements touching
+        // a ghost read stale ghost values and the scatter produces wrong D.
+        // u** already has a fresh halo from upstream (predictor/diffusion).
+        s.domain.exchangeNodeHalo(s.d_u);
+        s.domain.exchangeNodeHalo(s.d_v);
+        s.domain.exchangeNodeHalo(s.d_w);
+        RealType dIn  = opDiv(s.d_uStarStar, s.d_vStarStar, s.d_wStarStar);
+        RealType dOut = opDiv(s.d_u,         s.d_v,         s.d_w);
+
+        // MARS_WHEREMAX_PROBE: where does |Du^{n+1}|_max live? divNorm now
+        // holds D(u^{n+1}) per-node, post-fold, post-mass-normalize. Print the
+        // OWNED INTERIOR node index of the global max, its position (x,y,z),
+        // whether it's a periodic-pair node, and the abs divergence value.
+        // Tells us if PROJ-P3 leak is concentrated at seam nodes (periodic-
+        // collapse bug) or interior nodes (different bug entirely).
+        if (std::getenv("MARS_WHEREMAX_PROBE") != nullptr)
+        {
+            // Find max abs and its index over owned interior nodes
+            const RealType* dN = divNorm.data();
+            const uint8_t* ownP = d_nodeOwnership.data();
+            const int* n2dP = s.d_node_to_dof.data();
+            const RealType* xN = s.domain.getNodeX().data();
+            const RealType* yN = s.domain.getNodeY().data();
+            const RealType* zN = s.domain.getNodeZ().data();
+            const int* partnerP = s.periodicMap
+                                  ? s.periodicMap->d_periodicPartner.data() : nullptr;
+            const size_t N = s.nodeCount;
+            auto cit0 = thrust::counting_iterator<size_t>(0);
+            auto citN = thrust::counting_iterator<size_t>(N);
+            // First pass: max abs value
+            RealType locMaxAbs = thrust::transform_reduce(thrust::device, cit0, citN,
+                [dN, ownP, n2dP] __device__ (size_t i) -> RealType {
+                    if (ownP[i] != 1) return RealType(0);
+                    if (n2dP[i] < 0)  return RealType(0);
+                    return fabs(dN[i]);
+                }, RealType(0), thrust::maximum<RealType>());
+            RealType gMaxAbs = 0;
+            auto mt3 = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+            MPI_Allreduce(&locMaxAbs, &gMaxAbs, 1, mt3, MPI_MAX, MPI_COMM_WORLD);
+            // Each rank: does it own the global max? If yes, find index.
+            long long localIdx = -1;
+            if (locMaxAbs >= gMaxAbs - RealType(1e-15)) {
+                localIdx = thrust::transform_reduce(thrust::device, cit0, citN,
+                    [dN, ownP, n2dP, gMaxAbs, N] __device__ (size_t i) -> long long {
+                        if (ownP[i] != 1 || n2dP[i] < 0) return (long long)N;
+                        return (fabs(dN[i]) >= gMaxAbs - RealType(1e-15))
+                               ? (long long)i : (long long)N;
+                    }, (long long)N, thrust::minimum<long long>());
+                if (localIdx >= (long long)N) localIdx = -1;
+            }
+            // Only one rank should now have localIdx >= 0; print from there.
+            if (localIdx >= 0) {
+                size_t i = (size_t)localIdx;
+                RealType h_div, h_x, h_y, h_z;
+                int h_partner = -2;
+                cudaMemcpy(&h_div, dN + i, sizeof(RealType), cudaMemcpyDeviceToHost);
+                cudaMemcpy(&h_x,   xN + i, sizeof(RealType), cudaMemcpyDeviceToHost);
+                cudaMemcpy(&h_y,   yN + i, sizeof(RealType), cudaMemcpyDeviceToHost);
+                cudaMemcpy(&h_z,   zN + i, sizeof(RealType), cudaMemcpyDeviceToHost);
+                if (partnerP)
+                    cudaMemcpy(&h_partner, partnerP + i, sizeof(int), cudaMemcpyDeviceToHost);
+                const RealType eps = RealType(1e-4);
+                bool onSeam = (h_x < eps || h_x > RealType(1) - eps
+                            || h_y < eps || h_y > RealType(1) - eps
+                            || h_z < eps || h_z > RealType(1) - eps);
+                std::cout << "  [WHEREMAX r" << s.rank << "] i=" << i
+                          << " div=" << h_div
+                          << " pos=(" << h_x << "," << h_y << "," << h_z << ")"
+                          << " partner=" << h_partner
+                          << " onPeriodicSeam=" << (onSeam ? "YES" : "no")
+                          << std::endl;
+            }
+            // All ranks print a one-liner globally; ensures rank 0 always emits
+            // even if it doesn't own the max.
+            if (s.rank == 0)
+                std::cout << "  [WHEREMAX] global_max_abs_div=" << gMaxAbs << std::endl;
+        }
+
+        // DISAMBIGUATOR 1: did the corrector actually change the velocity? Expect
+        // ~dt/rho*|gradPhi| ~ 3e-4. If ~0, the corrector is a no-op (and ratio=1.0
+        // is trivial); if ~3e-4, ratio=1.0 means the probe's D can't see the
+        // correction -> real operator/adjoint mismatch.
+        cstone::DeviceVector<RealType> dudiff(s.nodeCount, RealType(0));
+        {
+            const RealType* uP = s.d_u.data(); const RealType* uS = s.d_uStarStar.data();
+            RealType* dP = dudiff.data();
+            thrust::for_each(thrust::device, thrust::counting_iterator<size_t>(0),
+                thrust::counting_iterator<size_t>(s.nodeCount),
+                [uP, uS, dP] __device__ (size_t i){ dP[i] = uP[i] - uS[i]; });
+            cudaDeviceSynchronize();
+        }
+        RealType duMax = maxOwnedInteriorAbs<KeyType, RealType, ElementTag>(s, dudiff);
+
+        // DISAMBIGUATOR 3: seam velocity mismatch. Over owned periodic pairs
+        // (partner>=0), max|u[slave]-u[master]| (and v,w). If LARGE (~3e-4), the
+        // corrector left the seam velocity field inconsistent (slave != master
+        // though they are one physical point) -> the post-corrector velocity
+        // broadcast (currently gated off on the reduced path) IS needed and the
+        // bare-D residual is that seam jump. If ~0, the seam is already consistent
+        // and the broadcast is a no-op -> the residual is elsewhere.
+        RealType seamMax;
+        {
+            const RealType* uP = s.d_u.data(); const RealType* vP = s.d_v.data();
+            const RealType* wP = s.d_w.data();
+            const int* partnerP = s.periodicMap ? s.periodicMap->d_periodicPartner.data() : nullptr;
+            const uint8_t* ownP = d_nodeOwnership.data();
+            RealType localMax = thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0),
+                thrust::counting_iterator<size_t>(s.nodeCount),
+                [uP, vP, wP, partnerP, ownP] __device__ (size_t i) -> RealType {
+                    if (!partnerP || partnerP[i] < 0 || ownP[i] != 1) return RealType(0);
+                    int m = partnerP[i];
+                    RealType du = fabs(uP[i] - uP[m]);
+                    RealType dv = fabs(vP[i] - vP[m]);
+                    RealType dw = fabs(wP[i] - wP[m]);
+                    RealType r = du > dv ? du : dv; return r > dw ? r : dw;
+                }, RealType(0), thrust::maximum<RealType>());
+            RealType g = 0; auto mt = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+            MPI_Allreduce(&localMax, &g, 1, mt, MPI_MAX, MPI_COMM_WORLD);
+            seamMax = g;
+        }
+
+        // DISAMBIGUATOR 2: recompute dOut WITHOUT the periodic fold (bare reduced D,
+        // the D the corrector's gradient is the adjoint of). If dOutNoFold < dIn but
+        // dOut(with fold)==dIn, the fold is exactly what hides the correction.
+        RealType dOutNoFold;
+        {
+            thrust::fill(thrust::device_pointer_cast(divAcc.data()),
+                         thrust::device_pointer_cast(divAcc.data() + s.nodeCount), RealType(0));
+            if (eBlocks > 0) {
+                computeDivergencePerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                    c0, c1, c2, c3, c4, c5, c6, c7, s.d_u.data(), s.d_v.data(), s.d_w.data(),
+                    s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                    divAcc.data(), startElem, numLocal);
+                cudaDeviceSynchronize();
+            }
+            s.domain.reverseExchangeNodeHaloAdd(divAcc);  // NO periodicFold
+            thrust::fill(thrust::device_pointer_cast(divNorm.data()),
+                         thrust::device_pointer_cast(divNorm.data() + s.nodeCount), RealType(0));
+            normalizeDivergencePerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+                divAcc.data(), s.d_massNode.data(), s.d_node_to_dof.data(),
+                d_nodeOwnership.data(), divNorm.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+            dOutNoFold = maxOwnedInteriorAbs<KeyType, RealType, ElementTag>(s, divNorm);
+        }
+
+        if (s.rank == 0) {
+            const auto oldPrec = std::cout.precision();
+            std::cout.precision(12);
+            std::cout << "  [PROJ-P2] |Du**|=" << dIn << " |Du^{n+1}|=" << dOut
+                      << "  [PROJ-P3] ratio=" << (dOut / (dIn > 0 ? dIn : RealType(1)))
+                      << "  |dOut-dIn|=" << std::abs(dOut - dIn)
+                      << "  | max|u-u**|=" << duMax
+                      << "  |Du^{n+1}|noFold=" << dOutNoFold
+                      << "  seam|u_s-u_m|=" << seamMax << "\n";
+            std::cout.precision(oldPrec);
+        }
+    }
+
+    // Reduced-DOF periodic seam: BROADCAST master->slave on the corrected
+    // velocity. Deferred to HERE (after the PROJ-P3 probe) so the probe reads
+    // the corrector's slot-wise output -- the EXACT field on which the
+    // operator's discrete projection identity D_folded(u^{n+1}) = 0 closes at
+    // every master DOF. Running this BEFORE the probe (the previous order)
+    // overwrote u^{n+1}_slave := u^{n+1}_master, replacing the
+    // u**_slave - dt/rho * g_slave value that closes the identity in the
+    // slave slot -- PROJ-P3 then read ~1.0. The broadcast itself is still
+    // required for the NEXT-step predictor's per-element flux scatter (which
+    // reads node values, not DOFs) to see u_slave == u_master.
+    // Gated to reduced-periodic multi-rank CG (numRanks>1 && Periodic && CG).
+    // Pump/Cavity (BCKind::Pump, periodicMap=nullptr) bypass entirely.
+    if (routeReducedPeriodicCorr && s.periodicMap)
+    {
+        const int* dpart = s.periodicMap->d_periodicPartner.data();
+        int gblk = 256, ggrd = int((s.nodeCount + gblk - 1) / gblk);
+        auto broadcastMasterToSlave = [&](cstone::DeviceVector<RealType>& d_field)
+        {
+            mars::fem::periodicBroadcastSameRankKernel<RealType><<<ggrd, gblk>>>(
+                dpart, d_nodeOwnership.data(), s.nodeCount, d_field.data());
+            cudaDeviceSynchronize();
+            if (s.numRanks > 1)
+                mars::fem::crossRankPeriodicBroadcast<KeyType, RealType>(*s.periodicMap, d_field);
+            s.domain.exchangeNodeHalo(d_field);
+        };
+        broadcastMasterToSlave(s.d_u);
+        broadcastMasterToSlave(s.d_v);
+        broadcastMasterToSlave(s.d_w);
+    }
+
+    // Pressure update + ghost sync (next step's predictor needs ghost p^{n+1}).
+    // Standard incremental Chorin: p^{n+1} = p^n + phi.
+    updatePressureKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+        s.d_p.data(), s.d_phi.data(),
+        s.d_node_to_dof.data(), d_nodeOwnership.data(),
+        s.nodeCount);
+    cudaDeviceSynchronize();
+
+    // Periodic: re-anchor pressure gauge after each cumulative incremental
+    // update. The pressure equation has a constant-mode null space; phi has
+    // its mean removed each step, but tiny floating-point residual means
+    // accumulate through p^{n+1} = p^n + phi, biasing grad(p) in the next
+    // predictor and producing an exponential pressure runaway (~1.5x per step
+    // observed on cube16 TGV). Removing the mean of p here, once per step,
+    // breaks the feedback.
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic)
+    {
+        // DOF-weighted (partner table): a same-rank periodic slave aliases its
+        // master's DOF, so counting it would weight the re-anchor mean by the
+        // face multiplicity and re-bias p every step -- the same gauge drift
+        // this re-anchor is meant to kill. Counted once per DOF instead.
+        const int* partnerPtr = s.periodicMap
+                                ? s.periodicMap->d_periodicPartner.data() : nullptr;
+        mars::fem::removeMean<RealType>(s.domain, s.d_p, MPI_COMM_WORLD, partnerPtr);
+    }
+
+    // Rotational pressure correction (Timmermans 1996, Guermond & Quartapelle 2000):
+    //   p^{n+1} = p^n + phi - nu * div(u**)
+    // The -nu*div(u**) term cures Chorin's O(dt^{1/2}) splitting error at boundaries
+    // and periodic copies, raising pressure accuracy to O(dt^{3/2}). Strongly
+    // recommended for periodic NS, where ordinary incremental Chorin is unstable
+    // (no wall dissipation to absorb the splitting error).
+    if (s.rotationalPressureCorrection && s.d_divUStar.size() == s.nodeCount)
+    {
+        const RealType nu = s.nuCached;
+        RealType* pPtr            = s.d_p.data();
+        const RealType* divPtr    = s.d_divUStar.data();
+        const int* dofPtr2        = s.d_node_to_dof.data();
+        const uint8_t* ownPtr2    = d_nodeOwnership.data();
+        thrust::for_each(thrust::device,
+                         thrust::counting_iterator<size_t>(0),
+                         thrust::counting_iterator<size_t>(s.nodeCount),
+                         [pPtr, divPtr, dofPtr2, ownPtr2, nu] __device__ (size_t i) {
+                             if (ownPtr2[i] != 1) return;
+                             int dof = dofPtr2[i];
+                             if (dof < 0) return;
+                             pPtr[i] -= nu * divPtr[i];
+                         });
+        cudaDeviceSynchronize();
+    }
+
+    s.domain.exchangeNodeHalo(s.d_u);
+    s.domain.exchangeNodeHalo(s.d_v);
+    s.domain.exchangeNodeHalo(s.d_w);
+    s.domain.exchangeNodeHalo(s.d_p);
+
+    // Periodic broadcast: per-NODE fields drift between slave and master
+    // every step because the corrector and pressure update write each owned
+    // node independently (DOF compaction makes the linear algebra unique but
+    // not the per-node storage). Without this broadcast, slave-side grad(p)
+    // in the next predictor reads a drifted pressure, generates an asymmetric
+    // pressure-gradient force, and the system blows up around step 30.
+    if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.periodicMap)
+    {
+        int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
+        const int* d_partner = s.periodicMap->d_periodicPartner.data();
+        size_t nN            = s.nodeCount;
+        // Under owner-migration the periodic pair is ONE DOF, so u^{n+1}[slave]
+        // should equal u^{n+1}[master]. Broadcasting it master->slave here was
+        // tested (commit bea6d38) and did NOT fix the seam blow-up (div_max still
+        // 3.5@40, 12@50), so seam VELOCITY drift is not the cause -- re-gated to
+        // the pre-collapse behavior to keep the known-good collapse-only state
+        // while the real seam term is found. The slave value is consistent enough
+        // for the projection; the residual is elsewhere (advection flux input).
+        if (!routeReducedPeriodicCorr)
+        {
+            mars::fem::periodicBroadcastKernel<<<grd, blk>>>(d_partner, nN, s.d_u.data());
+            mars::fem::periodicBroadcastKernel<<<grd, blk>>>(d_partner, nN, s.d_v.data());
+            mars::fem::periodicBroadcastKernel<<<grd, blk>>>(d_partner, nN, s.d_w.data());
+        }
+        mars::fem::periodicBroadcastKernel<<<grd, blk>>>(d_partner, nN, s.d_p.data());
+        cudaDeviceSynchronize();
+        s.domain.exchangeNodeHalo(s.d_u);
+        s.domain.exchangeNodeHalo(s.d_v);
+        s.domain.exchangeNodeHalo(s.d_w);
+        s.domain.exchangeNodeHalo(s.d_p);
+    }
+
+    // -------------------------------------------------------------------------
+    // div_max diagnostic over interior OWNED DOFs. Computes div(u^{n+1}); the
+    // projection step's algebraic guarantee is div_max ~ roundoff every step.
+    // -------------------------------------------------------------------------
+    {
+        cstone::DeviceVector<RealType> d_divAccPost(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> d_divNorm(s.nodeCount, RealType(0));
+        if (eBlocks > 0)
+        {
+            computeDivergencePerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                c0, c1, c2, c3, c4, c5, c6, c7,
+                s.d_u.data(), s.d_v.data(), s.d_w.data(),
+                s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                d_divAccPost.data(), startElem, numLocal);
+            cudaDeviceSynchronize();
+        }
+        s.domain.reverseExchangeNodeHaloAdd(d_divAccPost);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_divAccPost);
+        normalizeDivergencePerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            d_divAccPost.data(), s.d_massNode.data(),
+            s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            d_divNorm.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+
+        // Take max |div| over interior owned DOFs (skip boundary -- the boundary
+        // divergence picks up the non-zero through-flux of u_lid and is not
+        // expected to be zero pointwise). Also skip pressure-Dirichlet DOFs
+        // (channel outflow mask): the matrix-free SpMV's identity-row at those
+        // slots breaks the local D u = 0 identity by design, so leaving them
+        // in the metric reports a meaningless cross-boundary flux that does
+        // NOT indicate the interior projection is wrong.
+        const uint8_t* ownPtr = d_nodeOwnership.data();
+        const int* dofPtr     = s.d_node_to_dof.data();
+        const uint8_t* bnd    = s.d_isBdryDof.data();
+        const uint8_t* pmask  = (s.d_isPressureBdryDof.size() > 0)
+                                ? s.d_isPressureBdryDof.data() : nullptr;
+        const RealType* dPtr  = d_divNorm.data();
+        RealType localMax = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0),
+            thrust::counting_iterator<size_t>(s.nodeCount),
+            [ownPtr, dofPtr, bnd, pmask, dPtr] __device__ (size_t i) -> RealType {
+                if (ownPtr[i] != 1) return RealType(0);
+                int dof = dofPtr[i];
+                if (dof < 0)                       return RealType(0);
+                if (bnd[dof])                      return RealType(0);
+                if (pmask != nullptr && pmask[dof]) return RealType(0);
+                return fabs(dPtr[i]);
+            }, RealType(0), thrust::maximum<RealType>());
+
+        auto mpiType = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+        RealType globalMax = 0;
+        MPI_Allreduce(&localMax, &globalMax, 1, mpiType, MPI_MAX, MPI_COMM_WORLD);
+        s.lastDivMax = globalMax;
+        // Bulk-interior RMS divergence: dominated by the body of the domain,
+        // not the 1-cell ring next to Dirichlet pressure outflow that dominates
+        // max. Channel-flow with a wide pressure mask shows RMS << max if the
+        // projection is doing its job.
+        s.lastDivRms = rmsOwnedInterior1<KeyType, RealType, ElementTag>(s, d_divNorm);
+
+        // [div-global]: GLOBAL (MPI_Allreduce) signed and abs sum of div(u^{n+1})
+        // over owned-non-slave nodes. This is the TRUE rank-invariance test the
+        // per-rank [advN-sum] lines cannot give. Discriminates the residual seam
+        // leak: signed_sum MUST be ~0 and rank-invariant (1==4 ranks). If signed~0
+        // but abs_sum GROWS with step => a sign-canceling seam DIPOLE (projection
+        // closure leak). If signed_sum DRIFTS from 0 / differs 1 vs 4 ranks => the
+        // cross-rank fold is non-telescoping (coverage/double-count). Gated to the
+        // debug window so production is unaffected.
+        if (g_nsDebugStepsLeft > 0)
+        {
+            const uint8_t* ownP = d_nodeOwnership.data();
+            const int* dofP     = s.d_node_to_dof.data();
+            const int* partP    = s.periodicMap ? s.periodicMap->d_periodicPartner.data() : nullptr;
+            const RealType* dP  = d_divNorm.data();
+            auto signedOf = [ownP, dofP, partP, dP] __device__ (size_t i) -> double {
+                if (ownP[i] != 1 || dofP[i] < 0) return 0.0;
+                if (partP && partP[i] >= 0)      return 0.0;
+                return double(dP[i]);
+            };
+            auto absOf = [ownP, dofP, partP, dP] __device__ (size_t i) -> double {
+                if (ownP[i] != 1 || dofP[i] < 0) return 0.0;
+                if (partP && partP[i] >= 0)      return 0.0;
+                return fabs(double(dP[i]));
+            };
+            double locS = thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+                signedOf, 0.0, thrust::plus<double>());
+            double locA = thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(s.nodeCount),
+                absOf, 0.0, thrust::plus<double>());
+            double gS = 0, gA = 0;
+            MPI_Allreduce(&locS, &gS, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+            MPI_Allreduce(&locA, &gA, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+            if (s.rank == 0)
+                std::cout << "    [div-global] signed_sum=" << std::scientific << std::setprecision(8)
+                          << gS << " abs_sum=" << gA << std::defaultfloat
+                          << " (signed~0&rank-inv expected; signed~0&abs grows=>closure dipole;"
+                          << " signed drifts=>fold non-telescoping)\n";
+        }
+
+        // DIAGNOSTIC: split div RMS into RANK-BOUNDARY-owned vs INTERIOR-owned
+        // nodes. If the multi-rank divergence excess is boundary-localized, the
+        // boundary RMS >> interior RMS => a cross-rank halo-completeness bug at
+        // shared nodes. If both are inflated equally => a global issue. Builds a
+        // per-node boundary mask from the node-halo topology's sendNodeIds_
+        // (owned nodes shared with a peer). Runs only when g_nsDebugStepsLeft>0.
+        if (s.numRanks > 1 && g_nsDebugStepsLeft > 0)
+        {
+            cstone::DeviceVector<uint8_t> d_isBndNode(s.nodeCount, uint8_t(0));
+            const auto& topo = s.domain.getNodeHaloTopology();
+            size_t nSend = topo.sendNodeIds_.size();
+            if (nSend > 0)
+            {
+                const int* snd = topo.sendNodeIds_.data();
+                uint8_t* bnd = d_isBndNode.data();
+                size_t nn = s.nodeCount;
+                thrust::for_each(thrust::device,
+                    thrust::counting_iterator<size_t>(0),
+                    thrust::counting_iterator<size_t>(nSend),
+                    [snd, bnd, nn] __device__ (size_t k) {
+                        int nid = snd[k];
+                        if (nid >= 0 && size_t(nid) < nn) bnd[nid] = uint8_t(1);
+                    });
+                cudaDeviceSynchronize();
+            }
+            const uint8_t* ownPtr = s.ownershipMap().data();
+            const int* dofPtr     = s.d_node_to_dof.data();
+            const uint8_t* bndPtr = d_isBndNode.data();
+            const RealType* dP    = d_divNorm.data();
+            // (sumSq, count) for boundary and interior separately.
+            auto accum = [&] (bool wantBoundary) {
+                RealType locSq = thrust::transform_reduce(thrust::device,
+                    thrust::counting_iterator<size_t>(0),
+                    thrust::counting_iterator<size_t>(s.nodeCount),
+                    [ownPtr, dofPtr, bndPtr, dP, wantBoundary] __device__ (size_t i) -> RealType {
+                        if (ownPtr[i] != 1) return RealType(0);
+                        if (dofPtr[i] < 0)  return RealType(0);
+                        bool isB = (bndPtr[i] != 0);
+                        if (isB != wantBoundary) return RealType(0);
+                        RealType q = dP[i]; return q * q;
+                    }, RealType(0), thrust::plus<RealType>());
+                long long locCnt = thrust::transform_reduce(thrust::device,
+                    thrust::counting_iterator<size_t>(0),
+                    thrust::counting_iterator<size_t>(s.nodeCount),
+                    [ownPtr, dofPtr, bndPtr, wantBoundary] __device__ (size_t i) -> long long {
+                        if (ownPtr[i] != 1) return 0LL;
+                        if (dofPtr[i] < 0)  return 0LL;
+                        bool isB = (bndPtr[i] != 0);
+                        return (isB == wantBoundary) ? 1LL : 0LL;
+                    }, 0LL, thrust::plus<long long>());
+                auto mt = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+                RealType gSq = 0; long long gCnt = 0;
+                MPI_Allreduce(&locSq, &gSq, 1, mt, MPI_SUM, MPI_COMM_WORLD);
+                MPI_Allreduce(&locCnt, &gCnt, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+                RealType rms = (gCnt > 0) ? std::sqrt(gSq / RealType(gCnt)) : RealType(0);
+                return std::make_pair(rms, gCnt);
+            };
+            auto bRms = accum(true);
+            auto iRms = accum(false);
+            if (s.rank == 0)
+                std::cout << "    [div-split] boundary RMS=" << std::scientific << std::setprecision(3)
+                          << bRms.first << " (" << bRms.second << " nodes)  interior RMS="
+                          << iRms.first << " (" << iRms.second << " nodes)  ratio="
+                          << (iRms.first > 0 ? bRms.first / iRms.first : RealType(0))
+                          << std::defaultfloat << "\n";
+        }
+    }
+    // When RC is on, also report the divergence of the RC-corrected flux -- the
+    // operator the pressure solve drives to zero. The plain lastDivMax above can
+    // stay O(1) (it still resolves the checkerboard mode RC decoupled from the
+    // flux), so lastDivRC is the honest "is RC working" signal.
+    if (s.useRhieChow)
+    {
+        RealType rcMax = 0, rcRms = 0;
+        divMaxRhieChowOwned<KeyType, RealType, ElementTag>(s, dt, rho, rcMax, rcRms);
+        s.lastDivRC = rcMax;
+    }
+}
+
+// =============================================================================
+// Top-level: chain the four sub-steps. nu is captured by the implicit matrix
+// (assembled once at setup time), not used here directly -- but the parameter
+// remains for API stability with the original signature.
+// =============================================================================
+// Max absolute value of an owned-portion device vector (skip NaN; report
+// Inf-equivalent if found). Diagnostic only.
+template<typename RealType>
+inline RealType maxAbsOwned(const cstone::DeviceVector<RealType>& v, size_t n)
+{
+    if (n == 0) return RealType(0);
+    auto bp = thrust::device_pointer_cast(v.data());
+    auto mm = thrust::transform_reduce(
+        thrust::device, bp, bp + n,
+        [] __device__ (RealType x) -> RealType {
+            return isnan(x) ? RealType(-1) : fabs(x);
+        },
+        RealType(0), thrust::maximum<RealType>());
+    return mm;
+}
+
+// Kinetic energy over owned nodes weighted by lumped mass. Consistent
+// with the projection step's L^2 inner product on the velocity space.
+// Returns 0.5 * sum_(i in owned) m_i * (u_i^2 + v_i^2 + w_i^2).
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+inline RealType keOwned(NSStepper<KeyType, RealType, ElementTag>& s,
+                        const cstone::DeviceVector<RealType>& du,
+                        const cstone::DeviceVector<RealType>& dv,
+                        const cstone::DeviceVector<RealType>& dw)
+{
+    const auto& d_own = s.domain.getNodeOwnershipMap();
+    size_t n = s.nodeCount;
+    RealType local = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<size_t>(0),
+        thrust::counting_iterator<size_t>(n),
+        [own = d_own.data(), n2d = s.d_node_to_dof.data(),
+         mass = s.d_mass.data(), nOwn = s.numOwnedDofs,
+         u = du.data(), v = dv.data(), w = dw.data()] __device__ (size_t i) -> RealType {
+            if (own[i] != 1) return RealType(0);
+            int dof = n2d[i];
+            if (dof < 0 || dof >= nOwn) return RealType(0);
+            RealType uu = u[i], vv = v[i], ww = w[i];
+            return RealType(0.5) * mass[dof] * (uu * uu + vv * vv + ww * ww);
+        }, RealType(0), thrust::plus<RealType>());
+    RealType global = 0;
+    MPI_Datatype mpi_r = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
+    MPI_Allreduce(&local, &global, 1, mpi_r, MPI_SUM, MPI_COMM_WORLD);
+    return global;
+}
+
+// Sum of an owned-node device vector (e.g. divergence accumulator). Used to
+// check the consistency condition int(div u) = 0 for periodic NS.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+inline RealType sumOwned(NSStepper<KeyType, RealType, ElementTag>& s,
+                         const cstone::DeviceVector<RealType>& v)
+{
+    const auto& d_own = s.domain.getNodeOwnershipMap();
+    size_t n = s.nodeCount;
+    RealType local = thrust::transform_reduce(thrust::device,
+        thrust::counting_iterator<size_t>(0),
+        thrust::counting_iterator<size_t>(n),
+        [own = d_own.data(), n2d = s.d_node_to_dof.data(),
+         nOwn = s.numOwnedDofs, vp = v.data()] __device__ (size_t i) -> RealType {
+            if (own[i] != 1) return RealType(0);
+            int dof = n2d[i];
+            if (dof < 0 || dof >= nOwn) return RealType(0);
+            return vp[i];
+        }, RealType(0), thrust::plus<RealType>());
+    RealType global = 0;
+    MPI_Datatype mpi_r = std::is_same<RealType, double>::value ? MPI_DOUBLE : MPI_FLOAT;
+    MPI_Allreduce(&local, &global, 1, mpi_r, MPI_SUM, MPI_COMM_WORLD);
+    return global;
+}
+
+// Compute div(u, v, w) lumped per node, return (max_abs, RMS) over owned
+// interior nodes. Used to inspect divergence of intermediate velocity fields.
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+inline void divMaxAndRmsOwned(NSStepper<KeyType, RealType, ElementTag>& s,
+                              const cstone::DeviceVector<RealType>& d_u,
+                              const cstone::DeviceVector<RealType>& d_v,
+                              const cstone::DeviceVector<RealType>& d_w,
+                              RealType& outMax, RealType& outRms)
+{
+    const auto& d_own = s.domain.getNodeOwnershipMap();
+    const auto& d_conn = s.domain.getElementToNodeConnectivity();
+    // connPtrs gives NodesPerElem pointers; c4..c7 stay nullptr for tet (the
+    // templated Phase-1 kernels read c0..c3 only when ElementTag==TetTag).
+    auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+    const KeyType* c0 = cp[0]; const KeyType* c1 = cp[1];
+    const KeyType* c2 = cp[2]; const KeyType* c3 = cp[3];
+    const KeyType* c4 = nullptr; const KeyType* c5 = nullptr;
+    const KeyType* c6 = nullptr; const KeyType* c7 = nullptr;
+    if constexpr (std::is_same_v<ElementTag, HexTag>) { c4 = cp[4]; c5 = cp[5]; c6 = cp[6]; c7 = cp[7]; }
+    // OWNED-only per-element scatter (proven-green pattern, commit 5da5d6a).
+    // Looping owned+halo would double-count shared rank-boundary faces because
+    // reverseExchangeNodeHaloAdd is called right after the kernel.
+    size_t startElem = s.domain.startIndex();
+    size_t numLocal  = s.domain.localElementCount();
+    int eBlocks = numLocal > 0 ? int((numLocal + s.blockSize - 1) / s.blockSize) : 0;
+    int nodeBlocks = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+
+    cstone::DeviceVector<RealType> d_divAcc(s.nodeCount, RealType(0));
+    if (eBlocks > 0) {
+        computeDivergencePerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+            c0, c1, c2, c3, c4, c5, c6, c7,
+            d_u.data(), d_v.data(), d_w.data(),
+            s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+            d_divAcc.data(), startElem, numLocal);
+        cudaDeviceSynchronize();
+    }
+    s.domain.reverseExchangeNodeHaloAdd(d_divAcc);
+    cstone::DeviceVector<RealType> d_divNorm(s.nodeCount, RealType(0));
+    normalizeDivergencePerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+        d_divAcc.data(), s.d_massNode.data(),
+        s.d_node_to_dof.data(), d_own.data(),
+        d_divNorm.data(), s.nodeCount);
+    cudaDeviceSynchronize();
+    outMax = maxOwnedInteriorAbs<KeyType, RealType, ElementTag>(s, d_divNorm);
+    outRms = rmsOwnedInterior1<KeyType, RealType, ElementTag>(s, d_divNorm);
+}
+
+// =============================================================================
+// Per-node vorticity magnitude |omega| = |curl(u)|. Three SCS-gradient passes
+// (one per velocity component) give the 9-component velocity gradient tensor;
+// the curl is then assembled per node. Uses the same scatter -> reverse-halo
+// -> periodic-pair-sum -> normalize-by-mass pipeline as the predictor's
+// grad(p), so it inherits the periodic and ghost handling automatically.
+// d_omegaMag is resized to nodeCount and overwritten; owned-node values are
+// the true vorticity magnitude; ghost slots are zeroed by the normalize step.
+// =============================================================================
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void computeVorticityMagnitudePerNode(NSStepper<KeyType, RealType, ElementTag>& s,
+                                      cstone::DeviceVector<RealType>& d_u,
+                                      cstone::DeviceVector<RealType>& d_v,
+                                      cstone::DeviceVector<RealType>& d_w,
+                                      cstone::DeviceVector<RealType>& d_omegaMag)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    const auto& d_conn          = s.domain.getElementToNodeConnectivity();
+    // connPtrs gives NodesPerElem pointers; c4..c7 stay nullptr for tet (the
+    // templated Phase-1 kernels read c0..c3 only when ElementTag==TetTag).
+    auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+    const KeyType* c0 = cp[0]; const KeyType* c1 = cp[1];
+    const KeyType* c2 = cp[2]; const KeyType* c3 = cp[3];
+    const KeyType* c4 = nullptr; const KeyType* c5 = nullptr;
+    const KeyType* c6 = nullptr; const KeyType* c7 = nullptr;
+    if constexpr (std::is_same_v<ElementTag, HexTag>) { c4 = cp[4]; c5 = cp[5]; c6 = cp[6]; c7 = cp[7]; }
+    // OWNED-only per-element scatter (proven-green pattern, commit 5da5d6a).
+    // Looping owned+halo would double-count shared rank-boundary faces because
+    // reverseExchangeNodeHaloAdd is called right after the kernel.
+    const size_t startElem = s.domain.startIndex();
+    const size_t numLocal  = s.domain.localElementCount();
+    const int nodeBlocks   = (s.nodeCount + s.blockSize - 1) / s.blockSize;
+    const int eBlocks      = numLocal > 0 ? int((numLocal + s.blockSize - 1) / s.blockSize) : 0;
+
+    if (d_omegaMag.size() != s.nodeCount) d_omegaMag.resize(s.nodeCount);
+
+    auto gradScalar = [&] (const RealType* qNode,
+                           cstone::DeviceVector<RealType>& gx,
+                           cstone::DeviceVector<RealType>& gy,
+                           cstone::DeviceVector<RealType>& gz)
+    {
+        cstone::DeviceVector<RealType> gxAcc(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> gyAcc(s.nodeCount, RealType(0));
+        cstone::DeviceVector<RealType> gzAcc(s.nodeCount, RealType(0));
+        if (eBlocks > 0)
+        {
+            computeGradientPerNodeKernel<KeyType, RealType, ElementTag><<<eBlocks, s.blockSize>>>(
+                c0, c1, c2, c3, c4, c5, c6, c7, qNode,
+                s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                gxAcc.data(), gyAcc.data(), gzAcc.data(),
+                startElem, numLocal);
+            cudaDeviceSynchronize();
+        }
+        s.domain.reverseExchangeNodeHaloAdd(gxAcc);
+        s.domain.reverseExchangeNodeHaloAdd(gyAcc);
+        s.domain.reverseExchangeNodeHaloAdd(gzAcc);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, gxAcc);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, gyAcc);
+        maybePeriodicSum<KeyType, RealType, ElementTag>(s, gzAcc);
+        normalizeGradientPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            gxAcc.data(), gyAcc.data(), gzAcc.data(),
+            s.d_massNode.data(),
+            s.d_node_to_dof.data(), d_nodeOwnership.data(),
+            gx.data(), gy.data(), gz.data(),
+            s.nodeCount);
+        cudaDeviceSynchronize();
+    };
+
+    // Ghosts of u/v/w must be current before SCS scatters read q_f = 1/2(q[L]+q[R]).
+    s.domain.exchangeNodeHalo(d_u);
+    s.domain.exchangeNodeHalo(d_v);
+    s.domain.exchangeNodeHalo(d_w);
+
+    cstone::DeviceVector<RealType> dudx(s.nodeCount), dudy(s.nodeCount), dudz(s.nodeCount);
+    cstone::DeviceVector<RealType> dvdx(s.nodeCount), dvdy(s.nodeCount), dvdz(s.nodeCount);
+    cstone::DeviceVector<RealType> dwdx(s.nodeCount), dwdy(s.nodeCount), dwdz(s.nodeCount);
+    gradScalar(d_u.data(), dudx, dudy, dudz);
+    gradScalar(d_v.data(), dvdx, dvdy, dvdz);
+    gradScalar(d_w.data(), dwdx, dwdy, dwdz);
+
+    // omega = (dwdy - dvdz, dudz - dwdx, dvdx - dudy); |omega| per node.
+    const RealType* aP = dudy.data(); const RealType* bP = dudz.data();
+    const RealType* cP = dvdx.data(); const RealType* dP = dvdz.data();
+    const RealType* eP = dwdx.data(); const RealType* fP = dwdy.data();
+    RealType* outP = d_omegaMag.data();
+    thrust::for_each(thrust::device,
+        thrust::counting_iterator<size_t>(0),
+        thrust::counting_iterator<size_t>(s.nodeCount),
+        [aP, bP, cP, dP, eP, fP, outP] __device__ (size_t i) {
+            RealType wx = fP[i] - dP[i];
+            RealType wy = bP[i] - eP[i];
+            RealType wz = cP[i] - aP[i];
+            outP[i] = sqrt(wx * wx + wy * wy + wz * wz);
+        });
+    cudaDeviceSynchronize();
+}
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+void runNsStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, RealType nu, RealType rho)
+{
+    s.nuCached = nu;
+    bool dbg = (g_nsDebugStepsLeft > 0);
+
+    // ENTRY: state of u^n, p^n before the step.
+    // IMPORTANT: keOwned / divMaxAndRmsOwned / computeWeightedL2Norm all do an
+    // MPI_Allreduce internally. They MUST be called on EVERY rank or the
+    // collective deadlocks. Compute on all ranks; print only on rank 0.
+    // (maxAbsOwned is a local thrust reduce -- no collective -- so it can stay
+    // inside the rank-0 print.)
+    if (dbg)
+    {
+        RealType KE_n      = keOwned<KeyType, RealType, ElementTag>(s, s.d_u, s.d_v, s.d_w);
+        RealType div_n_max = 0, div_n_rms = 0;
+        divMaxAndRmsOwned<KeyType, RealType, ElementTag>(s, s.d_u, s.d_v, s.d_w, div_n_max, div_n_rms);
+        if (s.rank == 0)
+            std::cout << "    [ns-dbg ENTRY] KE_n=" << std::scientific << std::setprecision(6) << KE_n
+                      << " |u_n|max=" << maxAbsOwned(s.d_u, s.nodeCount)
+                      << " |p_n|max=" << maxAbsOwned(s.d_p, s.nodeCount)
+                      << " div(u_n)max=" << div_n_max
+                      << " div(u_n)rms=" << div_n_rms << "\n";
+    }
+
+    runPredictorStep<KeyType, RealType, ElementTag>(s, dt, rho);
+    if (dbg)
+    {
+        RealType KE_star      = keOwned<KeyType, RealType, ElementTag>(s, s.d_uStar, s.d_vStar, s.d_wStar);
+        RealType div_star_max = 0, div_star_rms = 0;
+        divMaxAndRmsOwned<KeyType, RealType, ElementTag>(s, s.d_uStar, s.d_vStar, s.d_wStar, div_star_max, div_star_rms);
+        if (s.rank == 0)
+            std::cout << "    [ns-dbg PRED ] KE*=" << KE_star
+                      << " |u*|max="    << maxAbsOwned(s.d_uStar, s.nodeCount)
+                      << " |gP|max="    << maxAbsOwned(s.d_gradPx, s.nodeCount)
+                      << " div(u*)max=" << div_star_max
+                      << " div(u*)rms=" << div_star_rms << "\n";
+    }
+
+    runImplicitDiffusionStep<KeyType, RealType, ElementTag>(s, dt);
+    if (dbg)
+    {
+        RealType KE_ss      = keOwned<KeyType, RealType, ElementTag>(s, s.d_uStarStar, s.d_vStarStar, s.d_wStarStar);
+        RealType div_ss_max = 0, div_ss_rms = 0;
+        divMaxAndRmsOwned<KeyType, RealType, ElementTag>(s, s.d_uStarStar, s.d_vStarStar, s.d_wStarStar, div_ss_max, div_ss_rms);
+        if (s.rank == 0)
+            std::cout << "    [ns-dbg DIFF ] KE**=" << KE_ss
+                      << " |u**|max="    << maxAbsOwned(s.d_uStarStar, s.nodeCount)
+                      << " div(u**)max=" << div_ss_max
+                      << " div(u**)rms=" << div_ss_rms
+                      << " cg_uvw="      << s.lastUIters << "/" << s.lastVIters << "/" << s.lastWIters << "\n";
+    }
+
+    runPressureSolveStep<KeyType, RealType, ElementTag>(s, dt, rho);
+    if (dbg && s.rank == 0)
+    {
+        std::cout << "    [ns-dbg POIS ] |phi|max=" << maxAbsOwned(s.d_phi, s.nodeCount)
+                  << " cg_p=" << s.lastPressureIters << "\n";
+    }
+
+    // BDF2 velocity-history shuffle: snapshot u^n into u_{n-1} BEFORE the
+    // corrector overwrites s.d_u with u^{n+1}. The advection-history copy
+    // (advN -> advNm1) happens after the corrector since the advection slots
+    // are only consumed by next step's predictor.
+    if (s.useBdf2
+        && s.d_u_nm1.size() == s.d_u.size()
+        && s.d_v_nm1.size() == s.d_v.size()
+        && s.d_w_nm1.size() == s.d_w.size())
+    {
+        thrust::copy(thrust::device, s.d_u.begin(), s.d_u.end(), s.d_u_nm1.begin());
+        thrust::copy(thrust::device, s.d_v.begin(), s.d_v.end(), s.d_v_nm1.begin());
+        thrust::copy(thrust::device, s.d_w.begin(), s.d_w.end(), s.d_w_nm1.begin());
+    }
+
+    runCorrectorStep<KeyType, RealType, ElementTag>(s, dt, rho);
+    if (dbg)
+    {
+        RealType KE_np1 = keOwned<KeyType, RealType, ElementTag>(s, s.d_u, s.d_v, s.d_w);   // collective: all ranks
+        if (s.rank == 0)
+        {
+            std::cout << "    [ns-dbg CORR ] KE_(n+1)=" << KE_np1
+                      << " |u_(n+1)|max=" << maxAbsOwned(s.d_u, s.nodeCount)
+                      << " |p_(n+1)|max=" << maxAbsOwned(s.d_p, s.nodeCount)
+                      << " div_max=" << s.lastDivMax << "\n";
+            std::cout << std::defaultfloat;
+        }
+    }
+
+    // BDF2 advection-history shuffle + bootstrap promotion.
+    //   step 0  (BDF1): produces N(u^0) in advN. Save -> advNm1 for step 1.
+    //   step >=1 (BDF2): produces N(u^n) in advN. Save -> advNm1 for step n+1.
+    // After the shuffle advance bdfStep so the NEXT runNsStep call uses BDF2.
+    if (s.useBdf2
+        && s.d_advU_n.size() == s.nodeCount
+        && s.d_advU_nm1.size() == s.nodeCount)
+    {
+        thrust::copy(thrust::device, s.d_advU_n.begin(), s.d_advU_n.end(), s.d_advU_nm1.begin());
+        thrust::copy(thrust::device, s.d_advV_n.begin(), s.d_advV_n.end(), s.d_advV_nm1.begin());
+        thrust::copy(thrust::device, s.d_advW_n.begin(), s.d_advW_n.end(), s.d_advW_nm1.begin());
+        if (s.bdfStep < 1) s.bdfStep = 1;
+    }
+
+    if (g_nsDebugStepsLeft > 0) --g_nsDebugStepsLeft;
+}
+
+// =============================================================================
+// L2 norm over owned interior+boundary DOFs (volume-weighted by lumped mass).
+// Used for per-step |u|, |v|, |w|, |p| logging.
+// =============================================================================
+
+template<typename KeyType, typename RealType, typename ElementTag = HexTag>
+RealType computeWeightedL2Norm(NSStepper<KeyType, RealType, ElementTag>& s,
+                               const cstone::DeviceVector<RealType>& d_q)
+{
+    const auto& d_nodeOwnership = s.ownershipMap();
+    cstone::DeviceVector<RealType> d_sq(s.numOwnedDofs, RealType(0));
+    const int numOwnedDofs = s.numOwnedDofs;
+    thrust::for_each(thrust::device,
+                      thrust::counting_iterator<size_t>(0),
+                      thrust::counting_iterator<size_t>(s.nodeCount),
+                      [nodeToDof = s.d_node_to_dof.data(),
+                       ownPtr    = d_nodeOwnership.data(),
+                       mass      = s.d_mass.data(),
+                       q         = d_q.data(),
+                       out       = d_sq.data(),
+                       numOwnedDofs] __device__(size_t i)
+                      {
+                          if (ownPtr[i] != 1) return;
+                          int dof = nodeToDof[i];
+                          if (dof < 0 || dof >= numOwnedDofs) return;
+                          out[dof] = q[i] * q[i] * mass[dof];
+                      });
+    cudaDeviceSynchronize();
+    auto sp = thrust::device_pointer_cast(d_sq.data());
+    RealType localSum = thrust::reduce(thrust::device, sp, sp + s.numOwnedDofs, RealType(0));
+    RealType globalSum = 0;
+    auto mpiType = std::is_same_v<RealType, double> ? MPI_DOUBLE : MPI_FLOAT;
+    MPI_Allreduce(&localSum, &globalSum, 1, mpiType, MPI_SUM, MPI_COMM_WORLD);
+    return std::sqrt(globalSum);
+}

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -2251,6 +2251,13 @@ struct NSStepper
     // used as the Jacobi preconditioner by solvePressureDDT. Extracted once
     // at setup after BC enforcement + optional shift.
     cstone::DeviceVector<RealType> d_diagDDT;
+    // Per-NODE operator-diagonal floor for the matrix-free DDT. A sliver cell (tiny
+    // SCS face areas) gives a tiny true operator diagonal -> phi spikes there -> the
+    // projection blows up. shift_i = max(0, epsFloor - diag_i) raises ONLY those
+    // degenerate rows to epsFloor (0 on the healthy bulk -> byte-identical there).
+    // Added inside applyDDTPerNode as out[i] += shift_i*phi[i] (a positive diagonal
+    // add -> keeps the operator SPD). Distinct from the Jacobi clip (preconditioner only).
+    cstone::DeviceVector<RealType> d_shiftDDTNode;   // size nodeCount; 0 where diag>=epsFloor
     // Floor for the clipped Jacobi preconditioner: z = r / max(diag, eps).
     // Default is 1e-3 * max(diag), computed at the setup-time cache build.
     // Env MARS_DDT_JACOBI_CLIP_FRAC overrides the 1e-3 fraction.
@@ -4687,6 +4694,60 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
                       << "; floors tiny boundary-layer diagonals)\n";
             std::cout.flags(oldFlags);
         }
+
+        // OPERATOR floor (distinct from the Jacobi-clip preconditioner above): a
+        // sliver cell gives a tiny TRUE operator diagonal -> phi spikes there -> the
+        // projection blows up. Raise ONLY those degenerate rows to epsFloor in the
+        // matrix-free operator via a per-node shift; 0 on the healthy bulk so it is
+        // byte-identical there. Env MARS_DDT_OP_FLOOR_FRAC=F sets epsFloor=F*max_diag.
+        RealType opFrac = RealType(0.05);
+        const char* evF = std::getenv("MARS_DDT_OP_FLOOR_FRAC");
+        if (evF) { double v = std::atof(evF); if (v >= 0) opFrac = RealType(v); }
+        RealType epsFloor = opFrac * globalMax;
+        s.d_shiftDDTNode.resize(s.nodeCount);
+        thrust::fill(thrust::device,
+                     thrust::device_pointer_cast(s.d_shiftDDTNode.data()),
+                     thrust::device_pointer_cast(s.d_shiftDDTNode.data() + s.nodeCount),
+                     RealType(0));
+        if (epsFloor > RealType(0))
+        {
+            const RealType* diagP = s.d_diagDDT.data();
+            const int* n2dP       = s.d_node_to_dof.data();
+            const uint8_t* ownP   = d_nodeOwnership.data();
+            const uint8_t* maskP  = (s.d_isPressureBdryDof.size() > 0)
+                                    ? s.d_isPressureBdryDof.data() : nullptr;
+            int pinD = s.pressurePinDof;
+            int nOwn = s.numOwnedDofs;
+            RealType* shiftP = s.d_shiftDDTNode.data();
+            thrust::for_each(thrust::device,
+                thrust::counting_iterator<size_t>(0),
+                thrust::counting_iterator<size_t>(s.nodeCount),
+                [diagP, n2dP, ownP, maskP, pinD, nOwn, epsFloor, shiftP] __device__ (size_t i) {
+                    if (ownP[i] != 1) return;
+                    int dof = n2dP[i];
+                    if (dof < 0 || dof >= nOwn) return;
+                    // Pinned/masked rows are forced to identity (out=phi) later; no shift.
+                    if (dof == pinD) return;
+                    if (maskP != nullptr && maskP[dof] != 0) return;
+                    RealType d = diagP[dof];
+                    if (d < epsFloor) shiftP[i] = epsFloor - d;
+                });
+            // Keep the Jacobi preconditioner consistent with the floored operator.
+            RealType* diagW = s.d_diagDDT.data();
+            thrust::transform(thrust::device,
+                thrust::device_pointer_cast(diagW),
+                thrust::device_pointer_cast(diagW + s.numOwnedDofs),
+                thrust::device_pointer_cast(diagW),
+                [epsFloor] __device__ (RealType d) { return d < epsFloor ? epsFloor : d; });
+            if (s.rank == 0)
+            {
+                auto oldFlags = std::cout.flags();
+                std::cout << std::scientific << std::setprecision(4)
+                          << "  [DDT-op-floor] epsFloor = " << epsFloor
+                          << " (= " << opFrac << " * max_diag; raises sliver-cell operator rows)\n";
+                std::cout.flags(oldFlags);
+            }
+        }
     }
     pt.lap("DDT diagonal cache (for Jacobi PCG)");
 
@@ -5610,6 +5671,27 @@ void applyDDTPerNode(NSStepper<KeyType, RealType, ElementTag>& s,
         {
             maybePeriodicSum<KeyType, RealType, ElementTag>(s, outAcc);
         }
+    }
+
+    // Operator-diagonal floor: out[i] += shift_i * phi[i] on the degenerate (sliver)
+    // rows so their effective diagonal is epsFloor, not the tiny native value. 0 on
+    // the healthy bulk (built in setup) so the operator is byte-identical there. Must
+    // run BEFORE the identity-row enforcement so pinned/masked rows stay diag=1.
+    if (s.d_shiftDDTNode.size() == s.nodeCount)
+    {
+        const RealType* shiftP = s.d_shiftDDTNode.data();
+        const RealType* phPtr  = phi.data();
+        RealType* outPtr       = outAcc.data();
+        const uint8_t* ownPtr2 = d_nodeOwnership.data();
+        thrust::for_each(thrust::device,
+            thrust::counting_iterator<size_t>(0),
+            thrust::counting_iterator<size_t>(s.nodeCount),
+            [shiftP, phPtr, outPtr, ownPtr2] __device__ (size_t i) {
+                if (ownPtr2[i] != 1) return;
+                RealType sh = shiftP[i];
+                if (sh != RealType(0)) outPtr[i] += sh * phPtr[i];
+            });
+        cudaDeviceSynchronize();
     }
 
     // Identity-row enforcement on pinned pressure DOFs (cavity: single corner;

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -4700,6 +4700,25 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
                 s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
                 s.d_massNode.data(), d_diagAccNode.data(), startElem, numLocal);
             cudaDeviceSynchronize();
+            // PSPG diagonal: the matrix-free solve runs (A + tau*L) when usePSPG,
+            // so the Jacobi diagonal must include tau*L's diagonal or the
+            // preconditioner no longer matches the operator and CG stalls (the
+            // mismatch grows with tau). Add tau*Vol*|dNdx_i|^2 per node into the
+            // SAME accumulator, BEFORE the reverse-halo/periodic fold below, so it
+            // sums across rank/periodic incidence exactly as the operator does.
+            if constexpr (std::is_same_v<ElementTag, TetTag>)
+            if (s.usePSPG)
+            {
+                RealType tauL = (s.pspgTau > RealType(0)) ? s.pspgTau : s.pspgTauAuto;
+                if (tauL > RealType(0))
+                {
+                    computeTetPSPGDiagonalKernel<KeyType, RealType><<<eBlocks, s.blockSize>>>(
+                        c0, c1, c2, c3,
+                        s.domain.getNodeX().data(), s.domain.getNodeY().data(), s.domain.getNodeZ().data(),
+                        tauL, d_diagAccNode.data(), startElem, numLocal);
+                    cudaDeviceSynchronize();
+                }
+            }
         }
         // Sum cross-rank / periodic incident-face contributions exactly as the
         // operator does for its accumulators.

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -2257,7 +2257,6 @@ struct NSStepper
     // degenerate rows to epsFloor (0 on the healthy bulk -> byte-identical there).
     // Added inside applyDDTPerNode as out[i] += shift_i*phi[i] (a positive diagonal
     // add -> keeps the operator SPD). Distinct from the Jacobi clip (preconditioner only).
-    cstone::DeviceVector<RealType> d_shiftDDTNode;   // size nodeCount; 0 where diag>=epsFloor
     // Floor for the clipped Jacobi preconditioner: z = r / max(diag, eps).
     // Default is 1e-3 * max(diag), computed at the setup-time cache build.
     // Env MARS_DDT_JACOBI_CLIP_FRAC overrides the 1e-3 fraction.
@@ -3152,6 +3151,42 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
         }
         s.domain.reverseExchangeNodeHaloAdd(s.d_massNode);
         maybePeriodicSum<KeyType, RealType, ElementTag>(s, s.d_massNode);
+        // Identity-safe sliver fix: floor the lumped mass M_i up to a small
+        // fraction of the max so a degenerate sliver cell (tiny V_i -> huge 1/V_i)
+        // cannot blow up grad(p)/the DDT diagonal. Because A = D M^-1 D^T and the
+        // CORRECTOR also applies M^-1 from this SAME d_massNode, flooring the mass
+        // changes operator AND corrector by the same M^-1 -> div(u^{n+1})=0 is
+        // PRESERVED (unlike an operator-diagonal floor, which only the operator
+        // sees -> leaves an un-projected divergence residual -> smooth blowup).
+        // Done on the halo-exchanged mass BEFORE the DDT diagonal cache + corrector
+        // read it. Env MARS_MASS_FLOOR_FRAC (default 1e-3*max; 0 disables).
+        {
+            RealType locMax = thrust::reduce(thrust::device,
+                thrust::device_pointer_cast(s.d_massNode.data()),
+                thrust::device_pointer_cast(s.d_massNode.data() + s.nodeCount),
+                RealType(0), thrust::maximum<RealType>());
+            RealType gMax = locMax;
+            if (s.numRanks > 1) {
+                MPI_Datatype mr = std::is_same<RealType,double>::value ? MPI_DOUBLE : MPI_FLOAT;
+                MPI_Allreduce(&locMax, &gMax, 1, mr, MPI_MAX, MPI_COMM_WORLD);
+            }
+            RealType mfrac = RealType(1e-3);
+            const char* evM = std::getenv("MARS_MASS_FLOOR_FRAC");
+            if (evM) { double v = std::atof(evM); if (v >= 0) mfrac = RealType(v); }
+            RealType mFloor = mfrac * gMax;
+            if (mFloor > RealType(0)) {
+                thrust::transform(thrust::device,
+                    thrust::device_pointer_cast(s.d_massNode.data()),
+                    thrust::device_pointer_cast(s.d_massNode.data() + s.nodeCount),
+                    thrust::device_pointer_cast(s.d_massNode.data()),
+                    [mFloor] __device__ (RealType m) { return m < mFloor ? mFloor : m; });
+                if (s.rank == 0)
+                    std::cout << "  [mass-floor] M_i floored to " << std::scientific << mFloor
+                              << " (= " << mfrac << " * max_mass; identity-safe sliver fix)"
+                              << std::defaultfloat << "\n";
+            }
+        }
+
         // Forward halo: ghost slots get owner-rank V values so DDT assembler
         // can read s.d_massNode[ghostNode] and get the correct V.
         s.domain.exchangeNodeHalo(s.d_massNode);
@@ -4695,59 +4730,10 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
             std::cout.flags(oldFlags);
         }
 
-        // OPERATOR floor (distinct from the Jacobi-clip preconditioner above): a
-        // sliver cell gives a tiny TRUE operator diagonal -> phi spikes there -> the
-        // projection blows up. Raise ONLY those degenerate rows to epsFloor in the
-        // matrix-free operator via a per-node shift; 0 on the healthy bulk so it is
-        // byte-identical there. Env MARS_DDT_OP_FLOOR_FRAC=F sets epsFloor=F*max_diag.
-        RealType opFrac = RealType(0.05);
-        const char* evF = std::getenv("MARS_DDT_OP_FLOOR_FRAC");
-        if (evF) { double v = std::atof(evF); if (v >= 0) opFrac = RealType(v); }
-        RealType epsFloor = opFrac * globalMax;
-        s.d_shiftDDTNode.resize(s.nodeCount);
-        thrust::fill(thrust::device,
-                     thrust::device_pointer_cast(s.d_shiftDDTNode.data()),
-                     thrust::device_pointer_cast(s.d_shiftDDTNode.data() + s.nodeCount),
-                     RealType(0));
-        if (epsFloor > RealType(0))
-        {
-            const RealType* diagP = s.d_diagDDT.data();
-            const int* n2dP       = s.d_node_to_dof.data();
-            const uint8_t* ownP   = d_nodeOwnership.data();
-            const uint8_t* maskP  = (s.d_isPressureBdryDof.size() > 0)
-                                    ? s.d_isPressureBdryDof.data() : nullptr;
-            int pinD = s.pressurePinDof;
-            int nOwn = s.numOwnedDofs;
-            RealType* shiftP = s.d_shiftDDTNode.data();
-            thrust::for_each(thrust::device,
-                thrust::counting_iterator<size_t>(0),
-                thrust::counting_iterator<size_t>(s.nodeCount),
-                [diagP, n2dP, ownP, maskP, pinD, nOwn, epsFloor, shiftP] __device__ (size_t i) {
-                    if (ownP[i] != 1) return;
-                    int dof = n2dP[i];
-                    if (dof < 0 || dof >= nOwn) return;
-                    // Pinned/masked rows are forced to identity (out=phi) later; no shift.
-                    if (dof == pinD) return;
-                    if (maskP != nullptr && maskP[dof] != 0) return;
-                    RealType d = diagP[dof];
-                    if (d < epsFloor) shiftP[i] = epsFloor - d;
-                });
-            // Keep the Jacobi preconditioner consistent with the floored operator.
-            RealType* diagW = s.d_diagDDT.data();
-            thrust::transform(thrust::device,
-                thrust::device_pointer_cast(diagW),
-                thrust::device_pointer_cast(diagW + s.numOwnedDofs),
-                thrust::device_pointer_cast(diagW),
-                [epsFloor] __device__ (RealType d) { return d < epsFloor ? epsFloor : d; });
-            if (s.rank == 0)
-            {
-                auto oldFlags = std::cout.flags();
-                std::cout << std::scientific << std::setprecision(4)
-                          << "  [DDT-op-floor] epsFloor = " << epsFloor
-                          << " (= " << opFrac << " * max_diag; raises sliver-cell operator rows)\n";
-                std::cout.flags(oldFlags);
-            }
-        }
+        // NOTE: the sliver-cell regularization is now done UPSTREAM as a MASS floor
+        // (see [mass-floor] where d_massNode is built). That is identity-safe because
+        // operator AND corrector share M^-1. An operator-diagonal floor here would
+        // break div(u^{n+1})=0 (only the operator sees it) -> smooth blowup; removed.
     }
     pt.lap("DDT diagonal cache (for Jacobi PCG)");
 
@@ -5673,26 +5659,8 @@ void applyDDTPerNode(NSStepper<KeyType, RealType, ElementTag>& s,
         }
     }
 
-    // Operator-diagonal floor: out[i] += shift_i * phi[i] on the degenerate (sliver)
-    // rows so their effective diagonal is epsFloor, not the tiny native value. 0 on
-    // the healthy bulk (built in setup) so the operator is byte-identical there. Must
-    // run BEFORE the identity-row enforcement so pinned/masked rows stay diag=1.
-    if (s.d_shiftDDTNode.size() == s.nodeCount)
-    {
-        const RealType* shiftP = s.d_shiftDDTNode.data();
-        const RealType* phPtr  = phi.data();
-        RealType* outPtr       = outAcc.data();
-        const uint8_t* ownPtr2 = d_nodeOwnership.data();
-        thrust::for_each(thrust::device,
-            thrust::counting_iterator<size_t>(0),
-            thrust::counting_iterator<size_t>(s.nodeCount),
-            [shiftP, phPtr, outPtr, ownPtr2] __device__ (size_t i) {
-                if (ownPtr2[i] != 1) return;
-                RealType sh = shiftP[i];
-                if (sh != RealType(0)) outPtr[i] += sh * phPtr[i];
-            });
-        cudaDeviceSynchronize();
-    }
+    // (The sliver regularization is an identity-safe MASS floor upstream, not an
+    // operator-diagonal add here -- the latter breaks div(u^{n+1})=0. See [mass-floor].)
 
     // Identity-row enforcement on pinned pressure DOFs (cavity: single corner;
     // channel: outflow-face mask). out[i] = phi[i] makes the row act as identity.

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -8160,6 +8160,46 @@ void runNsStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, RealTyp
                   << " cg_p=" << s.lastPressureIters << "\n";
     }
 
+    // [checker] Per-element mean-free pressure RMS = the checkerboard mode (the
+    // exact quantity an inf-sup stabilizer penalizes). Smooth p -> 0; a growing
+    // ratio of mean-free to total |p| is the checkerboard signature. Lets us SEE
+    // a stabilizer kill the mode in a few steps instead of waiting for a blowup.
+    // Tet-only, env-gated (MARS_CHECKER), rank 0.
+    if (std::getenv("MARS_CHECKER") && s.rank == 0
+        && std::is_same<ElementTag, TetTag>::value)
+    {
+        const auto& d_conn = s.domain.getElementToNodeConnectivity();
+        auto cp = connPtrs<ElementTag, KeyType>(d_conn);
+        const KeyType* c0 = cp[0]; const KeyType* c1 = cp[1];
+        const KeyType* c2 = cp[2]; const KeyType* c3 = cp[3];
+        const size_t startElem = s.domain.startIndex();
+        const size_t numLocal  = s.domain.localElementCount();
+        const RealType* pPtr   = s.d_p.data();
+        const uint8_t* ownPtr  = s.domain.getNodeOwnershipMap().data();
+        // sum over owned elements (owner = first node) of sum_i (p_i-meanP)^2,
+        // and the total sum p_i^2, to report the mean-free fraction.
+        auto pr = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(numLocal),
+            [c0,c1,c2,c3,startElem,pPtr,ownPtr] __device__ (size_t k) -> thrust::pair<double,double> {
+                size_t e = startElem + k;
+                KeyType n0=c0[e],n1=c1[e],n2=c2[e],n3=c3[e];
+                if (ownPtr[n0] != 1) return thrust::make_pair(0.0,0.0);  // count each elem once
+                double p0=pPtr[n0],p1=pPtr[n1],p2=pPtr[n2],p3=pPtr[n3];
+                double m=(p0+p1+p2+p3)*0.25;
+                double mf=(p0-m)*(p0-m)+(p1-m)*(p1-m)+(p2-m)*(p2-m)+(p3-m)*(p3-m);
+                double tot=p0*p0+p1*p1+p2*p2+p3*p3;
+                return thrust::make_pair(mf,tot);
+            },
+            thrust::make_pair(0.0,0.0),
+            [] __device__ (thrust::pair<double,double> a, thrust::pair<double,double> b) {
+                return thrust::make_pair(a.first+b.first, a.second+b.second); });
+        double mfRms = std::sqrt(pr.first);
+        double frac  = (pr.second > 0) ? std::sqrt(pr.first / pr.second) : 0.0;
+        std::cout << "    [checker] mean-free p RMS=" << std::scientific << mfRms
+                  << " frac=" << frac << std::defaultfloat
+                  << " (grows -> checkerboard; stabilizer should shrink frac)\n";
+    }
+
     // BDF2 velocity-history shuffle: snapshot u^n into u_{n-1} BEFORE the
     // corrector overwrites s.d_u with u^{n+1}. The advection-history copy
     // (advN -> advNm1) happens after the corrector since the advection slots

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -8176,25 +8176,31 @@ void runNsStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, RealTyp
         const size_t numLocal  = s.domain.localElementCount();
         const RealType* pPtr   = s.d_p.data();
         const uint8_t* ownPtr  = s.domain.getNodeOwnershipMap().data();
-        // sum over owned elements (owner = first node) of sum_i (p_i-meanP)^2,
-        // and the total sum p_i^2, to report the mean-free fraction.
-        auto pr = thrust::transform_reduce(thrust::device,
+        // sum over owned elements (owner = first node) of the mean-free energy
+        // sum_i (p_i-meanP)^2 and the total p_i^2, as TWO scalar reductions (a
+        // pair-returning device lambda needs its return type proclaimed in host
+        // context -- scalar reductions avoid that). frac = sqrt(mf/tot).
+        double mfSum = thrust::transform_reduce(thrust::device,
             thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(numLocal),
-            [c0,c1,c2,c3,startElem,pPtr,ownPtr] __device__ (size_t k) -> thrust::pair<double,double> {
+            [c0,c1,c2,c3,startElem,pPtr,ownPtr] __device__ (size_t k) -> double {
                 size_t e = startElem + k;
                 KeyType n0=c0[e],n1=c1[e],n2=c2[e],n3=c3[e];
-                if (ownPtr[n0] != 1) return thrust::make_pair(0.0,0.0);  // count each elem once
+                if (ownPtr[n0] != 1) return 0.0;
                 double p0=pPtr[n0],p1=pPtr[n1],p2=pPtr[n2],p3=pPtr[n3];
                 double m=(p0+p1+p2+p3)*0.25;
-                double mf=(p0-m)*(p0-m)+(p1-m)*(p1-m)+(p2-m)*(p2-m)+(p3-m)*(p3-m);
-                double tot=p0*p0+p1*p1+p2*p2+p3*p3;
-                return thrust::make_pair(mf,tot);
-            },
-            thrust::make_pair(0.0,0.0),
-            [] __device__ (thrust::pair<double,double> a, thrust::pair<double,double> b) {
-                return thrust::make_pair(a.first+b.first, a.second+b.second); });
-        double mfRms = std::sqrt(pr.first);
-        double frac  = (pr.second > 0) ? std::sqrt(pr.first / pr.second) : 0.0;
+                return (p0-m)*(p0-m)+(p1-m)*(p1-m)+(p2-m)*(p2-m)+(p3-m)*(p3-m);
+            }, 0.0, thrust::plus<double>());
+        double totSum = thrust::transform_reduce(thrust::device,
+            thrust::counting_iterator<size_t>(0), thrust::counting_iterator<size_t>(numLocal),
+            [c0,c1,c2,c3,startElem,pPtr,ownPtr] __device__ (size_t k) -> double {
+                size_t e = startElem + k;
+                KeyType n0=c0[e],n1=c1[e],n2=c2[e],n3=c3[e];
+                if (ownPtr[n0] != 1) return 0.0;
+                double p0=pPtr[n0],p1=pPtr[n1],p2=pPtr[n2],p3=pPtr[n3];
+                return p0*p0+p1*p1+p2*p2+p3*p3;
+            }, 0.0, thrust::plus<double>());
+        double mfRms = std::sqrt(mfSum);
+        double frac  = (totSum > 0) ? std::sqrt(mfSum / totSum) : 0.0;
         std::cout << "    [checker] mean-free p RMS=" << std::scientific << mfRms
                   << " frac=" << frac << std::defaultfloat
                   << " (grows -> checkerboard; stabilizer should shrink frac)\n";

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -2530,6 +2530,14 @@ struct NSStepper
     // no A.dx denominator -> skew-robust. tau reuses rhieChowTau (<=0 => dt/rho).
     bool useVMSStab       = false;
 
+    // IMPLICIT PSPG pressure stabilization (the CORRECT equal-order checkerboard fix):
+    // adds tau*L*phi inside applyDDTPerNode so CG solves (A+tau*L)phi=b. tau is a
+    // LENGTH^2 (~h^2/24), set at setup into pspgTauAuto; pspgTau>0 overrides. Damps
+    // checkerboard at ALL tau>0 (SPD, no CFL bound), unlike the explicit VMS source.
+    bool usePSPG          = false;
+    RealType pspgTau      = -1;   // <=0 => auto (pspgTauAuto)
+    RealType pspgTauAuto  = 0;    // beta*h^2, filled at setup
+
     // Ownership map every kernel uses. Always the domain's cached map -- we no
     // longer demote periodic slaves (see setupNSStepper). Kept as a single
     // accessor so all kernels bind through one place.
@@ -3566,6 +3574,22 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
     MPI_Allreduce(&lzmin, &s.zmin, 1, mpiType, MPI_MIN, MPI_COMM_WORLD);
     MPI_Allreduce(&lzmax, &s.zmax, 1, mpiType, MPI_MAX, MPI_COMM_WORLD);
     s.bboxEps = RealType(1e-10) * std::max({s.xmax - s.xmin, s.ymax - s.ymin, s.zmax - s.zmin});
+
+    // PSPG auto-tau: tau = beta*h^2 (a LENGTH^2), beta=1/24, h = mean cell size =
+    // cbrt(bbox_volume/elementCount). Same h the (dead) BD auto-tau uses. tau is the
+    // implicit-PSPG strength added as tau*L to the DDT operator. Start weak (1/24);
+    // --pspg-tau overrides. Global mean h keeps tau*L a weak, bounded perturbation
+    // of A even on tiny boundary-layer cells (avoids per-cell over-stabilization).
+    {
+        RealType bx = std::max(RealType(1e-30), s.xmax - s.xmin);
+        RealType by = std::max(RealType(1e-30), s.ymax - s.ymin);
+        RealType bz = std::max(RealType(1e-30), s.zmax - s.zmin);
+        RealType h  = std::cbrt((bx * by * bz) / RealType(std::max<size_t>(1, s.elementCount)));
+        s.pspgTauAuto = h * h / RealType(24);
+        if (s.rank == 0 && s.usePSPG)
+            std::cout << "  [pspg] auto tau = " << std::scientific << s.pspgTauAuto
+                      << " (= h^2/24, h=" << h << ")" << std::defaultfloat << "\n";
+    }
     pt.lap("global bbox");
 
     // BC mask + cavity target velocity.
@@ -5583,6 +5607,29 @@ void applyDDTPerNode(NSStepper<KeyType, RealType, ElementTag>& s,
         // One-shot print so we see the gate is active.
         static bool printed = false;
         if (!printed) { std::cerr << "[ddt] periodic-sum DISABLED on Ap" << std::endl; printed = true; }
+    }
+
+    // IMPLICIT PSPG stabilization (tet, opt-in): out += tau*L*phi so CG solves
+    // (A + tau*L) phi = b. This is the CORRECT equal-order checkerboard fix and is
+    // applied to the UNKNOWN phi (SPD, damps at all tau>0), NOT a div-breaking floor
+    // and NOT the explicit VMS source on p^n. Placed AFTER the main operator sum +
+    // halo and BEFORE the identity-row block so pinned/masked rows stay identity.
+    if constexpr (std::is_same_v<ElementTag, TetTag>)
+    if (s.usePSPG && eBlocks > 0)
+    {
+        RealType tauL = (s.pspgTau > RealType(0)) ? s.pspgTau : s.pspgTauAuto;
+        if (tauL > RealType(0))
+        {
+            applyPSPGLaplacianTetKernel<KeyType, RealType><<<eBlocks, s.blockSize>>>(
+                c0, c1, c2, c3, phi.data(),
+                s.domain.getNodeX().data(), s.domain.getNodeY().data(), s.domain.getNodeZ().data(),
+                s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                tauL, outAcc.data(), startElem, numLocal);
+            cudaDeviceSynchronize();
+            s.domain.reverseExchangeNodeHaloAdd(outAcc);
+            if (std::getenv("MARS_DDT_NO_PERIODIC_SUM") == nullptr)
+                maybePeriodicSum<KeyType, RealType, ElementTag>(s, outAcc);
+        }
     }
 
     // NOTE: BD is intentionally NOT applied to the matrix-free DDT operator.

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -4773,6 +4773,41 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
             std::cout.flags(oldFlags);
         }
 
+        // SLIVER PIN: a near-degenerate tet gives a DDT diagonal ~9 OOM below the
+        // bulk (1e-12 vs 6e-3), which the Jacobi-PCG cannot solve (cg_p=-2). The
+        // identity-safe fix is to PIN those rows to p=0 via the existing pressure
+        // mask (the operator forces out[i]=phi[i], the RHS forces b[i]=0) -- one
+        // removed equation, div-safe, exactly like the outflow/pin DOFs. Mask any
+        // owned DOF with diag < MARS_SLIVER_PIN_FRAC * globalMax (default 1e-6).
+        // This makes the pressure system solvable so the real physics (and PSPG)
+        // become readable. Off (frac<=0) restores the old behaviour.
+        if (s.d_isPressureBdryDof.size() == static_cast<size_t>(s.numOwnedDofs))
+        {
+            RealType pinFrac = RealType(1e-6);
+            const char* evS = std::getenv("MARS_SLIVER_PIN_FRAC");
+            if (evS) { double v = std::atof(evS); if (v >= 0) pinFrac = RealType(v); }
+            RealType pinThresh = pinFrac * globalMax;
+            if (pinThresh > RealType(0))
+            {
+                const RealType* diagP = s.d_diagDDT.data();
+                uint8_t* maskP = s.d_isPressureBdryDof.data();
+                int nOwn = s.numOwnedDofs;
+                long long pinned = thrust::transform_reduce(thrust::device,
+                    thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(nOwn),
+                    [diagP, maskP, pinThresh] __device__ (int dof) -> long long {
+                        if (diagP[dof] < pinThresh) { maskP[dof] = 1; return 1LL; }
+                        return 0LL;
+                    }, 0LL, thrust::plus<long long>());
+                long long gPinned = pinned;
+                if (s.numRanks > 1)
+                    MPI_Allreduce(&pinned, &gPinned, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+                if (s.rank == 0)
+                    std::cout << "  [sliver-pin] pinned " << gPinned
+                              << " degenerate DOF(s) with diag < " << std::scientific << pinThresh
+                              << " (= " << pinFrac << " * max_diag)" << std::defaultfloat << "\n";
+            }
+        }
+
         // NOTE: the sliver-cell regularization is now done UPSTREAM as a MASS floor
         // (see [mass-floor] where d_massNode is built). That is identity-safe because
         // operator AND corrector share M^-1. An operator-diagonal floor here would

--- a/backend/distributed/unstructured/fem/mars_vms_pressure_stab.hpp
+++ b/backend/distributed/unstructured/fem/mars_vms_pressure_stab.hpp
@@ -197,3 +197,41 @@ __global__ void applyPSPGLaplacianTetKernel(
         atomicAdd(&outAcc[iR], +s);
     }
 }
+
+// Diagonal of the PSPG operator L above, per node, for the Jacobi preconditioner.
+// The matrix-free solve runs (A + tau*L); without L's diagonal the preconditioner
+// matches only A, so it degrades as tau grows and CG stalls. Derivation: set
+// phi=e_i and feed it through applyPSPGLaplacianTetKernel -- the contribution it
+// scatters back to node i is exactly tau*Vol_e*|dNdx_e[i]|^2 (verified: the
+// L matrix equals the linear-tet stiffness tau*Vol*(dNdx_i . dNdx_j), so its
+// diagonal is tau*Vol*|dNdx_i|^2, strictly positive). Accumulate that per node
+// into the SAME d_diagAccNode the DDT-diagonal kernel fills, BEFORE the
+// reverse-halo + periodic sum + gather, so cross-rank/periodic incidence folds
+// in exactly as the operator's does.
+template<typename KeyType, typename RealType>
+__global__ void computeTetPSPGDiagonalKernel(
+    const KeyType* c0, const KeyType* c1, const KeyType* c2, const KeyType* c3,
+    const RealType* nodeX, const RealType* nodeY, const RealType* nodeZ,
+    RealType tau, RealType* diagAccNode, size_t startElem, size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numLocal) return;
+    size_t e = startElem + k;
+    constexpr int NPE = ElemTraits<TetTag>::NodesPerElem;   // 4
+    const KeyType* cc[4] = {c0, c1, c2, c3};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+    RealType coords[4][3];
+    for (int i = 0; i < NPE; ++i) {
+        coords[i][0] = nodeX[n[i]];
+        coords[i][1] = nodeY[n[i]];
+        coords[i][2] = nodeZ[n[i]];
+    }
+    RealType det, dNdx[4][3];
+    Tet4CVFEM::jacobian_and_dNdx<RealType>(coords, det, dNdx);
+    RealType vol = fabs(det) / RealType(6);
+    for (int i = 0; i < NPE; ++i) {
+        RealType g2 = dNdx[i][0]*dNdx[i][0] + dNdx[i][1]*dNdx[i][1] + dNdx[i][2]*dNdx[i][2];
+        atomicAdd(&diagAccNode[n[i]], tau * vol * g2);
+    }
+}

--- a/backend/distributed/unstructured/fem/mars_vms_pressure_stab.hpp
+++ b/backend/distributed/unstructured/fem/mars_vms_pressure_stab.hpp
@@ -138,3 +138,57 @@ __global__ void computeDivergenceVMSTetKernel(
         atomicAdd(&divAccNode[iR], -flow);
     }
 }
+
+// IMPLICIT PSPG pressure stabilization: apply tau*L*phi (L = discrete -div(grad))
+// INSIDE the matrix-free DDT operator so CG solves (A + tau*L) phi = b. Unlike the
+// EXPLICIT VMS divergence-source above (which lagged on the standing p^n and was an
+// unconditional high-frequency amplifier -> blew up at every tau), this acts on the
+// UNKNOWN phi -> a single SPD operator, damps the checkerboard mode at ALL tau>0
+// (no CFL bound to violate). L = sum_e V_e G^T G is symmetric PSD, shares A's
+// constant null mode (removed by the existing pin). The corrector stays bare
+// M^-1 D^T, so the post-corrector divergence relaxes to ~tau*lap(phi) = O(h^2),
+// a CONSISTENT residual that vanishes under refinement and self-extinguishes as
+// phi->0 -- the textbook equal-order PSPG, NOT the inconsistent BD/floor defect.
+// tau is a LENGTH^2 (~h^2/24), NOT the Rhie-Chow time-scale dt/rho.
+template<typename KeyType, typename RealType>
+__global__ void applyPSPGLaplacianTetKernel(
+    const KeyType* c0, const KeyType* c1, const KeyType* c2, const KeyType* c3,
+    const RealType* phi,
+    const RealType* nodeX, const RealType* nodeY, const RealType* nodeZ,
+    const RealType* areaVecX, const RealType* areaVecY, const RealType* areaVecZ,
+    RealType tau, RealType* outAcc, size_t startElem, size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= numLocal) return;
+    size_t e = startElem + k;
+    constexpr int NPE  = ElemTraits<TetTag>::NodesPerElem;   // 4
+    constexpr int NSCS = ElemTraits<TetTag>::ScsPerElem;     // 6
+    const KeyType* cc[4] = {c0, c1, c2, c3};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+    RealType coords[4][3];
+    for (int i = 0; i < NPE; ++i) {
+        coords[i][0] = nodeX[n[i]];
+        coords[i][1] = nodeY[n[i]];
+        coords[i][2] = nodeZ[n[i]];
+    }
+    RealType det, dNdx[4][3];
+    Tet4CVFEM::jacobian_and_dNdx<RealType>(coords, det, dNdx);
+    // constant element gradient of phi (linear tet)
+    RealType gx = 0, gy = 0, gz = 0;
+    for (int kk = 0; kk < NPE; ++kk) {
+        RealType pk = phi[n[kk]];
+        gx += dNdx[kk][0] * pk;
+        gy += dNdx[kk][1] * pk;
+        gz += dNdx[kk][2] * pk;
+    }
+    #pragma unroll
+    for (int ip = 0; ip < NSCS; ++ip) {
+        int nL, nR; scsLR<TetTag>(ip, nL, nR);
+        KeyType iL = n[nL], iR = n[nR];
+        size_t off = e * NSCS + ip;
+        RealType s = tau * (gx * areaVecX[off] + gy * areaVecY[off] + gz * areaVecZ[off]);
+        atomicAdd(&outAcc[iL], +s);
+        atomicAdd(&outAcc[iR], -s);
+    }
+}

--- a/backend/distributed/unstructured/fem/mars_vms_pressure_stab.hpp
+++ b/backend/distributed/unstructured/fem/mars_vms_pressure_stab.hpp
@@ -182,13 +182,18 @@ __global__ void applyPSPGLaplacianTetKernel(
         gy += dNdx[kk][1] * pk;
         gz += dNdx[kk][2] * pk;
     }
+    // SIGN: the DDT operator A = D M^-1 D^T is SPD-POSITIVE (~ +(-lap), a Gram form).
+    // The divergence D scatters +(v.A) to iL. Reusing that same +(g.A) scatter gives
+    // +tau*div(grad phi) = +tau*lap(phi) = -tau*(-lap)phi, which SUBTRACTS definiteness
+    // (wrong). We need +tau*(-lap)phi = -tau*lap(phi) to ADD positive energy, so scatter
+    // the NEGATED flux: -s to iL, +s to iR.
     #pragma unroll
     for (int ip = 0; ip < NSCS; ++ip) {
         int nL, nR; scsLR<TetTag>(ip, nL, nR);
         KeyType iL = n[nL], iR = n[nR];
         size_t off = e * NSCS + ip;
         RealType s = tau * (gx * areaVecX[off] + gy * areaVecY[off] + gz * areaVecZ[off]);
-        atomicAdd(&outAcc[iL], +s);
-        atomicAdd(&outAcc[iR], -s);
+        atomicAdd(&outAcc[iL], -s);
+        atomicAdd(&outAcc[iR], +s);
     }
 }

--- a/docs/poiseuille_tutorial.md
+++ b/docs/poiseuille_tutorial.md
@@ -1,0 +1,310 @@
+# Poiseuille Channel Flow with MARS — A Validation Tutorial
+
+This tutorial explains the `mars_poiseuille_flow` example: what Poiseuille flow
+is, why it is the standard first validation case for any incompressible CFD
+code, how to build and run it, how to read every line of its output, and the
+one numerical lesson it teaches that generalizes to every inlet-driven flow in
+MARS (including the pump). It assumes no prior CFD knowledge at the start; the
+deeper companion is `docs/pump_cfd_tutorial.md`, which builds the full
+numerical machinery from scratch.
+
+---
+
+## Part 0 — What is Poiseuille flow, and why validate with it?
+
+Push water through a long straight channel between two parallel walls. The
+fluid sticks to the walls (the *no-slip* condition: velocity is exactly zero
+at a wall), so the layers near the walls are slow and the middle is fast.
+Far enough downstream, the velocity settles into a profile that no longer
+changes — and that profile is exactly a **parabola**:
+
+```
+u(y) = U_max * (1 - (2y/H)^2)
+```
+
+where `H` is the channel height, `y` is measured from the centerline, and
+`U_max` is the speed in the middle. This is Hagen–Poiseuille flow (the plane-
+channel variant), one of the very few solutions of the Navier–Stokes
+equations that can be written in closed form.
+
+Two facts about the parabola matter for validation:
+
+1. **`U_max = 1.5 × U_mean`.** If you push fluid in uniformly at speed `U`,
+   mass conservation forces the developed centerline speed to be exactly
+   `1.5 U`. No fitting, no tuning — the number is fixed by the math.
+2. **It is reached after a known distance.** A uniform inflow needs roughly
+   the *entrance length* `Le ≈ 0.05 * Re * H` to relax into the parabola.
+   At Re = 100 and H = 1 that is `Le ≈ 5`, so in our 10-unit channel the
+   profile is fully developed well before the outlet.
+
+Because the exact answer is known, this case can fail loudly. A CFD code that
+produces a parabola with the right `U_max` at the right distance has
+demonstrated, in one run: the advection and diffusion operators, the pressure
+projection, the inlet/outlet/wall boundary conditions, and global mass
+conservation. That is why every CFD code's regression suite starts here, and
+why we compare against a reference solution (`report.html`, produced by FLUYA,
+the STK-based CVFEM code MARS mirrors) with a hard tolerance: **RMS error
+below 6.0e-3**.
+
+---
+
+## Part 1 — The case set-up
+
+### The mesh
+
+`poiseuille_hex_14k_elem.e` (Exodus format): 14,751 hexahedra, 30,000 nodes.
+
+```
+x: -0.5 .. 10.5   streamwise   (~150 node planes)
+y:  0.0 .. 1.0    wall-normal  (~100 node planes)  -> channel height H = 1
+z:  0.0 .. 0.066  ONE element thick                (2 node planes)
+```
+
+The z-direction is a single element: this is a **quasi-2D** mesh. Plane
+Poiseuille flow is two-dimensional, and the thin z-extrusion exists only
+because the solver works in 3D. This has one important consequence (Part 3).
+
+### The physics parameters
+
+```
+density          rho = 1
+kinematic visc.  nu  = 0.01
+inflow speed     U   = 1
+Reynolds number  Re  = U*H/nu = 100   (laminar -- the parabola is stable)
+```
+
+### The boundary conditions (the FLUYA reference configuration)
+
+| Boundary       | Condition                                            |
+|----------------|------------------------------------------------------|
+| inlet (x=xmin) | velocity Dirichlet u=(1,0,0) — uniform plug inflow   |
+| outlet (x=xmax)| pressure Dirichlet p=0, velocity **free**            |
+| walls (y=0, 1) | no-slip u=(0,0,0)                                    |
+| z faces        | symmetry (free) — NOT walls                          |
+
+Two of these are easy to get wrong:
+
+- **The outlet is a pressure condition, not a velocity condition.** The
+  outlet velocity must stay free so the parabola can leave the domain
+  undisturbed; prescribing it over-constrains the exit and the interior flow
+  dies. Pinning p=0 on the whole outlet plane anchors the pressure level and
+  lets mass balance itself through the pressure field.
+- **The thin z faces are symmetry planes, not walls.** On a one-element-thick
+  mesh every single node touches a z face. If z faces are treated as no-slip
+  walls (the default 3D channel marking), every node in the mesh becomes a
+  Dirichlet node and the entire velocity field is frozen — nothing can ever
+  flow. The driver rebuilds the boundary masks so only the y walls are
+  no-slip.
+
+---
+
+## Part 2 — How the solver works (the short version)
+
+Each time step of the Chorin projection method does:
+
+1. **Predict**: move the velocity by advection + old pressure gradient
+   (explicit, BDF2/EXT2).
+2. **Diffuse**: implicit viscous solve, one CG solve per velocity component.
+3. **Project**: compute how much the predicted field violates `div u = 0`,
+   solve a pressure Poisson equation, and correct the velocity so mass is
+   conserved.
+4. **Correct**: update velocity and pressure; re-impose boundary values.
+
+The pressure projection is the heart of incompressible CFD: pressure is
+whatever it must be to keep the velocity divergence-free. The full derivation
+is in `docs/pump_cfd_tutorial.md`. Here the only step that needs detail is
+the projection — because it is where this example's big lesson lives.
+
+---
+
+## Part 3 — The lesson: the opening-flux source
+
+### The bug this example exposed
+
+The discrete divergence in MARS is assembled from **interior** sub-control-
+surface faces only: every internal face between two nodes contributes
+`+flux` to one node and `-flux` to the other, and the sum telescopes — except
+at the domain boundary, where the *opening faces* (inlet, outlet) are never
+integrated.
+
+The consequence is invisible until you run an inlet-driven flow: the
+prescribed inlet velocity **never enters the divergence bookkeeping**, so the
+pressure solve never "sees" any fluid entering. It builds no pressure
+gradient down the channel, the inlet value sits painted on the first node
+plane, and nothing ever flows. Symptoms (all observed before the fix):
+
+- `|u|` frozen at the inlet-sliver value, forever — no downstream propagation
+  even after many flow-through times;
+- `div_max` pinned at a constant (the un-cancellable one-sided boundary
+  residual);
+- with a natural outlet, the pressure CG *stalls* at a residual floor and
+  `div_max` scales like `1/dt` — the fingerprint of a right-hand side the
+  operator cannot represent (smaller dt makes it *worse*, ruling out a
+  time-step problem).
+
+An analogy: a warehouse inventory system that logs every pallet moved between
+aisles but has no scanner at the receiving dock. Trucks unload all day, the
+system shows zero incoming stock, so it never schedules anything to ship out.
+
+This is the same root cause that left the pump's passage dead — the fix below
+was developed for the pump and is validated here against the analytic answer.
+
+### The fix: a balanced opening-flux source
+
+After the interior divergence scatter (and its reverse-halo exchange) and
+before the pressure RHS is built, add the missing opening fluxes directly to
+the divergence accumulator:
+
+```
+divAccNode[i] += U_prescribed . areaVec_outward[i]     (inlet and outlet nodes)
+```
+
+with two non-negotiable details, both learned the hard way:
+
+1. **Use prescribed velocities, never the solved field.** At step 0 the
+   solved outlet velocity is zero, so a solved-field source is one-sided —
+   the system becomes inconsistent and blows up immediately.
+2. **Balance the source to machine zero.** The inlet and outlet
+   contributions must cancel *exactly* — to the last floating-point bit. The
+   RHS multiplies the divergence by `rho/dt` (here 100), so even a tiny
+   numerical imbalance is amplified every step and explodes the solve. The
+   recipe (OpenFOAM's `adjustPhi` idea): measure both discrete fluxes, then
+   rescale the outlet by `oScale = -Qin/Qout` so the sum is zero by
+   construction.
+
+In code: `addOpeningFluxSourceKernel` + the `oScale` block in
+`runPressureSolveStep` of **`mars_ns_channel_solver.hpp`** — a fork of the
+shared `mars_ns_solver.hpp` (same pattern as the pump's fork), so the shared
+solver used by cavity/channel/TGV is untouched. The source is gated behind
+`NSStepper::useOpeningFluxSource`, default off; the driver enables it.
+
+The per-node outward area vectors are built by the driver: for each opening
+plane node, area = (Voronoi interval in y) × (dz/2), which sums exactly to
+the face area `H*dz`. For domain-aligned planes the direction is just `-x`
+(inlet) and `+x` (outlet).
+
+---
+
+## Part 4 — Build and run
+
+Build (the target links only against the `mars` library):
+
+```bash
+make mars_poiseuille_flow -j
+```
+
+Run (single rank; the area lumping assumes the opening planes are rank-local):
+
+```bash
+MARS_NODEHALO_V2=1 srun --account=<acct> --time=00:30:00 \
+  --nodes=1 --ntasks-per-node=1 \
+  ./examples/distributed/unstructured/mars_poiseuille_flow \
+  --mesh=/path/to/poiseuille_hex_14k_elem.e \
+  --uinf=1.0 --nu=0.01 --dt=0.01 --tol=1e-6 --max-iter=4000 --num-steps=1200 \
+  --vtu-output=poiseuille
+```
+
+Notes on the numbers:
+- `--num-steps=1200` (t = 12) is comfortably past convergence (~t = 10).
+- `--max-iter=4000`: the matrix-free DDT pressure solve with Jacobi
+  preconditioning needs ~3600 CG iterations per step on this mesh. That is
+  the price of the un-preconditioned thin-channel Poisson operator (AMG
+  rejects it); it is slow but completely stable.
+- `--tol=1e-6` for the pressure solve is sufficient; 1e-10 is unreachable
+  for Jacobi-PCG here and would FAIL every step.
+- Budget ~25 minutes wall; a 15-minute limit dies around step 1250.
+
+Useful flags:
+
+| Flag | Meaning |
+|------|---------|
+| `--drive=inlet` (default) | FLUYA reference config: velocity inlet + free pressure outlet |
+| `--drive=bodyforce`       | constant streamwise force instead (study mode; needs periodic x to be meaningful) |
+| `--no-opening-flux-source`| disable the Part-3 source — reproduces the dead channel (A/B baseline) |
+| `--no-seed-interior`      | start from rest instead of seeded plug flow (slower development) |
+| `--profile-x=X`           | move the validation plane (default 90% down the channel) |
+| `--cross-axis=y\|z`       | which axis the parabola varies over (default y) |
+
+---
+
+## Part 5 — Reading the output
+
+Per-step line:
+
+```
+Step  500: t=5.0000 |u|=8.167e-01 div_max=2.947e+00 cg_iter_p=3630
+```
+
+- `|u|` — mass-weighted L2 norm of streamwise velocity over the domain. For
+  this mesh (volume 0.6) the developed parabola gives **|u| → 0.849**;
+  watching it rise from the seeded 0.77 and plateau there *is* watching the
+  parabola form. If it is frozen near 0.045 the channel is dead (Part 3).
+- `div_max` — max nodal divergence after projection. It should fall steadily
+  (7.4 → 1.6 over the run). The nonzero floor lives at boundary nodes where
+  the one-sided stencil cannot vanish; the interior is much cleaner.
+- `cg_iter_p` — pressure CG iterations. ~3600 is normal here. `FAIL` means
+  it hit `--max-iter` or a breakdown — see Part 6.
+
+Final validation block:
+
+```
+  probe plane x = 9.0000 ...
+  U_max analytic = 1.5000  (= 1.5*Uinf)
+  RMS error      = 5.781047e-03  (normalized: 3.854031e-03)
+```
+
+The RMS compares solved `u(y)` on the probe plane against the analytic
+parabola. **Pass criterion: RMS < 6.0e-3** (the reference report's
+tolerance). The probe sits at 90% of the channel — past the entrance length,
+upstream of any outlet influence.
+
+Interior-flux probe:
+
+```
+  Q(inlet) = 6.0000e-02
+  Q(25%) = 5.9529e-02  ratio=0.992
+  Q(50%) = 5.9529e-02  ratio=0.992
+  Q(75%) = 6.0377e-02  ratio=1.006
+```
+
+This is the *honest* through-flow diagnostic: the volumetric flux through
+interior cross-sections, computed from the **solved** velocity. It cannot be
+faked by boundary values (a flux measured at a Dirichlet plane just reports
+the BC back at you — a lesson from the pump debugging). Ratios near 1.0 at
+25/50/75% mean real, mass-conserving flow through the whole channel.
+
+### Expected results (the validated run)
+
+| Quantity | Expected |
+|----------|----------|
+| `|u|` plateau | 0.846 (analytic 0.849) |
+| RMS vs parabola | 5.8e-3 raw, 3.9e-3 normalized (tol 6e-3) |
+| flux ratios 25/50/75% | 0.99 – 1.01 |
+| `div_max` at t=12 | ~1.6, still falling |
+| wall time, 1200 steps, 1 GH200 | ~20 min |
+
+---
+
+## Part 6 — Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `|u|` frozen ~0.045, `div_max` constant | opening-flux source off, or all nodes Dirichlet (z faces marked as walls) | default config already handles both; check the `Drive:` and `Opening-flux source:` banner lines |
+| `cg_iter_p=FAIL`, residual stalls ~1e-2..1e-5 | tolerance unreachable for Jacobi-PCG, or `--max-iter` too low | `--tol=1e-6 --max-iter=4000` |
+| `cg_iter_p=FAIL` at iteration 1 (`pAp<=0`) | Jacobi diagonal clip too small for extreme cell-size ratios | `MARS_DDT_JACOBI_CLIP_FRAC=1e-2` (env var, no rebuild) |
+| blows up within a few steps after flow develops | unbalanced opening source (should not happen with `oScale`), or — on harder meshes — the equal-order checkerboard instability | this clean hex mesh does not checkerboard through t=12; for meshes that do, pressure stabilization (PSPG/VMS) is required — active work on the pump side |
+| run dies near step 1250 with no validation block | srun wall-time limit | `--time=00:30:00` |
+
+---
+
+## Part 7 — Where to go next
+
+- `docs/pump_cfd_tutorial.md` — the full from-scratch CFD background: CVFEM,
+  the discrete operators, the projection algebra, stabilization.
+- `examples/distributed/unstructured/mars_poiseuille_flow.cu` — the driver:
+  BC rebuild, area lumping, validation, flux probe. Deliberately small.
+- `backend/distributed/unstructured/fem/mars_ns_channel_solver.hpp` — the
+  channel fork; its only delta vs the shared solver is the opening-flux
+  source (search "Balanced opening-flux source").
+- `report.html` — the FLUYA reference report this case is validated against,
+  including the reference solver's input file.

--- a/examples/distributed/unstructured/CMakeLists.txt
+++ b/examples/distributed/unstructured/CMakeLists.txt
@@ -157,6 +157,16 @@ target_include_directories(mars_amr_ns_projection PRIVATE
 )
 install(TARGETS mars_amr_ns_projection RUNTIME DESTINATION bin/examples)
 
+# Poiseuille flow validation driver: uniform inflow, free pressure outlet,
+# parabolic-profile RMS check against the analytic solution. Uses the channel
+# fork mars_ns_channel_solver.hpp (balanced opening-flux source).
+add_executable(mars_poiseuille_flow mars_poiseuille_flow.cu)
+target_link_libraries(mars_poiseuille_flow PRIVATE mars)
+target_include_directories(mars_poiseuille_flow PRIVATE
+    ${CMAKE_SOURCE_DIR}/backend/distributed/unstructured/amr
+)
+install(TARGETS mars_poiseuille_flow RUNTIME DESTINATION bin/examples)
+
 # Taylor-Green vortex driver. Periodic-cube NS solver + AMR. Currently a
 # skeleton that loads a mesh, builds the periodic node-pair map, applies the
 # TGV initial condition, and writes the IC as VTU. The full projection time

--- a/examples/distributed/unstructured/mars_poiseuille_flow.cu
+++ b/examples/distributed/unstructured/mars_poiseuille_flow.cu
@@ -1,0 +1,675 @@
+// Poiseuille flow validation driver.
+//
+// Channel flow: uniform inflow u=Uinf on x=xmin, no-slip on the lateral walls,
+// free-velocity outflow on x=xmax with pressure pinned to 0 there (the FLUYA
+// reference config from report.html). The long channel lets the flow develop so
+// the downstream cross-section relaxes to the analytic parabolic profile:
+//   u(y) = U_max * (1 - (2y/H)^2),  U_max = 1.5 * Uinf
+// (Hagen-Poiseuille, plane channel).
+//
+// Uses the CHANNEL FORK of the NS solver (mars_ns_channel_solver.hpp), whose
+// one delta is the balanced opening-flux source ported from the pump fork: the
+// interior SCS divergence never sees the boundary opening faces, so without the
+// source the prescribed inlet is invisible to the pressure solve and the
+// channel stays dead (verified: |u| frozen at the inlet-sliver norm, div_max
+// pinned, no downstream propagation over t=7).
+
+#include "backend/distributed/unstructured/fem/mars_ns_channel_solver.hpp"
+#include "backend/distributed/unstructured/utils/mars_vtu_parallel_writer.hpp"
+
+#include <cmath>
+#include <vector>
+#include <algorithm>
+
+// Voronoi-lumped per-node areas of a y-z cross-section plane of this quasi-2D
+// mesh (one cell thick in z, two z node-planes): per node, (Voronoi y-interval)
+// x dz/2. Sums to the exact face area H*dz over a full plane. ys holds the y
+// coordinate of each plane node (parallel to the caller's node-id list).
+// Single-rank assumption: the local node set must cover the full plane.
+static std::vector<double> planeVoronoiAreas(const std::vector<double>& ys, double dz)
+{
+    std::vector<double> yu(ys);
+    std::sort(yu.begin(), yu.end());
+    yu.erase(std::unique(yu.begin(), yu.end(),
+                         [](double a, double b) { return std::abs(a - b) < 1e-12; }),
+             yu.end());
+    std::vector<double> areas(ys.size(), 0.0);
+    if (yu.size() < 2) return areas;
+    for (size_t k = 0; k < ys.size(); ++k)
+    {
+        size_t j = std::lower_bound(yu.begin(), yu.end(), ys[k] - 1e-12) - yu.begin();
+        if (j >= yu.size()) j = yu.size() - 1;
+        double lo = (j == 0) ? yu.front() : 0.5 * (yu[j - 1] + yu[j]);
+        double hi = (j + 1 >= yu.size()) ? yu.back() : 0.5 * (yu[j] + yu[j + 1]);
+        areas[k] = (hi - lo) * dz * 0.5;
+    }
+    return areas;
+}
+
+// Analytic plane-Poiseuille profile, normalized cross-section coordinate
+// eta in [-1, 1] (eta=0 center, |eta|=1 walls). U_max = 1.5 * U_avg.
+struct PoiseuilleProfile
+{
+    double uMax;
+    double wallLo;   // cross-section coordinate at one wall
+    double wallHi;   // cross-section coordinate at the other wall
+
+    double eta(double s) const
+    {
+        double mid  = 0.5 * (wallLo + wallHi);
+        double half = 0.5 * (wallHi - wallLo);
+        return half > 0 ? (s - mid) / half : 0.0;
+    }
+    double analytic(double s) const
+    {
+        double e = eta(s);
+        return uMax * (1.0 - e * e);
+    }
+};
+
+int main(int argc, char** argv)
+{
+    MPI_Init(&argc, &argv);
+
+    int rank, numRanks;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &numRanks);
+
+    int deviceCount = 0;
+    cudaGetDeviceCount(&deviceCount);
+    if (deviceCount > 0) cudaSetDevice(rank % deviceCount);
+
+    using KeyType  = uint64_t;
+    using RealType = double;
+
+    std::string meshFile;
+    CvfemKernelVariant kernelVariant = CvfemKernelVariant::Tensor;
+    int    blockSize  = 256;
+    int    bucketSize = 64;
+    int    maxIter    = 1000;
+    double tolerance  = 1e-10;
+    double rho        = 1.0;
+    double nu         = 0.01;
+    double dt         = 0.01;
+    int    numSteps   = 1000;
+    int    vtuEvery   = 50;
+    std::string vtuPrefix;
+    SolverKind        solverKind    = SolverKind::CG;
+    // DDT (matrix-free D M^-1 D^T + Jacobi-PCG) is the validated channel
+    // pressure path; the K-path on this channel hits pAp<=0 (cg_iter_p=FAIL).
+    PressureSolveKind pressureSolve = PressureSolveKind::DDT;
+    double Uinf       = 1.0;
+
+    // Drive mode. Default is INLET -- the FLUYA reference config (report.html):
+    // velocity-Dirichlet inlet u=Uinf, static-pressure outlet (p=0, velocity
+    // FREE), no-slip walls, symmetry on the thin z-faces. The free pressure
+    // outlet lets mass balance through the pressure field and the parabola
+    // develops downstream. (--drive=bodyforce is the textbook periodic-style
+    // alternative but on this free-in/out mesh the projection cancels the mean
+    // flow -> collapses; kept for study, needs periodic-x to work.)
+    std::string driveMode = "inlet";       // inlet | bodyforce
+    double bodyForceX = -1.0;              // <0 = auto (target U_max = Uinf)
+
+    // Outlet cross-section probe: nodes within xTol of profileX. Default -1
+    // means "auto" = pick a plane 90% down the channel from xmin to xmax.
+    double profileX    = -1.0;
+    double profileXTol = -1.0;   // auto = one element width
+    // Cross-section axis the parabola varies over: "y" or "z" (the wall-normal
+    // direction). The streamwise component is always u (x). Default y.
+    std::string crossAxis = "y";
+    // Seed interior u=Uinf at the IC so the long channel starts full (default
+    // ON). Without it the rest-IC inlet front takes many flow-throughs to fill
+    // an 11-unit channel and the profile never develops in a short run.
+    bool seedInterior = true;
+    // Balanced opening-flux source (the pump-fork fix; channel-fork solver).
+    // Default ON in inlet mode -- without it the inlet is invisible to the
+    // pressure solve. --no-opening-flux-source gives the A/B baseline.
+    bool openingFluxSource = true;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if      (arg.find("--mesh=") == 0)         meshFile   = arg.substr(7);
+        else if (arg.find("--nu=") == 0)           nu         = std::stod(arg.substr(5));
+        else if (arg.find("--dt=") == 0)           dt         = std::stod(arg.substr(5));
+        else if (arg.find("--rho=") == 0)          rho        = std::stod(arg.substr(6));
+        else if (arg.find("--num-steps=") == 0)    numSteps   = std::stoi(arg.substr(12));
+        else if (arg.find("--vtu-every=") == 0)    vtuEvery   = std::stoi(arg.substr(12));
+        else if (arg.find("--vtu-output=") == 0)   vtuPrefix  = arg.substr(13);
+        else if (arg.find("--lid-u=") == 0)        Uinf       = std::stod(arg.substr(8));
+        else if (arg.find("--uinf=") == 0)         Uinf       = std::stod(arg.substr(7));
+        else if (arg.find("--profile-x=") == 0)    profileX   = std::stod(arg.substr(12));
+        else if (arg.find("--profile-xtol=") == 0) profileXTol= std::stod(arg.substr(15));
+        else if (arg.find("--cross-axis=") == 0)   crossAxis  = arg.substr(13);
+        else if (arg.find("--drive=") == 0)        driveMode  = arg.substr(8);
+        else if (arg.find("--body-force-x=") == 0) bodyForceX = std::stod(arg.substr(15));
+        else if (arg == "--no-seed-interior")      seedInterior = false;
+        else if (arg == "--no-opening-flux-source") openingFluxSource = false;
+        else if (arg.find("--block-size=") == 0)   blockSize  = std::stoi(arg.substr(13));
+        else if (arg.find("--bucket-size=") == 0)  bucketSize = std::stoi(arg.substr(14));
+        else if (arg.find("--max-iter=") == 0)     maxIter    = std::stoi(arg.substr(11));
+        else if (arg.find("--tol=") == 0)          tolerance  = std::stod(arg.substr(6));
+        else if (arg == "--kernel=wmma_tensor")    kernelVariant = CvfemKernelVariant::WmmaTensor;
+        else if (arg.find("--solver=") == 0)
+        {
+            std::string v = arg.substr(9);
+            if      (v == "cg")    solverKind = SolverKind::CG;
+            else if (v == "hypre") solverKind = SolverKind::Hypre;
+        }
+        else if (arg.find("--pressure-solve=") == 0)
+        {
+            std::string v = arg.substr(17);
+            if      (v == "K")   pressureSolve = PressureSolveKind::K;
+            else if (v == "DDT") pressureSolve = PressureSolveKind::DDT;
+        }
+        else if (arg[0] != '-' && meshFile.empty()) meshFile = arg;
+    }
+
+    if (meshFile.empty())
+    {
+        if (rank == 0)
+            std::cout << "Usage: " << argv[0] << " --mesh=FILE [options]\n\n"
+                      << "Poiseuille channel flow validation (parabolic profile).\n\n"
+                      << "  --mesh=FILE         Mesh file (.exo / .mesh) [REQUIRED]\n"
+                      << "  --drive=bodyforce|inlet  Flow driver (default bodyforce; textbook plane Poiseuille)\n"
+                      << "                      bodyforce: constant streamwise force G, no-slip y-walls,\n"
+                      << "                                 U_max=G*H^2/(8 rho nu). inlet: prescribed velocity\n"
+                      << "                                 inlet+mass-conserving outlet (study; does not sustain)\n"
+                      << "  --body-force-x=G    Body force value (default: auto = G to hit U_max=Uinf)\n"
+                      << "  --uinf=VALUE        Target U_max (bodyforce) / inflow speed (inlet); default 1.0\n"
+                      << "  --nu=VALUE          Kinematic viscosity (default 0.01)\n"
+                      << "  --dt=VALUE          Timestep (default 0.01)\n"
+                      << "  --rho=VALUE         Density (default 1.0)\n"
+                      << "  --num-steps=N       Time steps (default 1000)\n"
+                      << "  --cross-axis=y|z    Wall-normal axis the parabola varies over (default y)\n"
+                      << "  --no-seed-interior  Start from rest (default seeds interior with mean flow)\n"
+                      << "  --no-opening-flux-source  Disable the balanced opening-flux source (A/B baseline;\n"
+                      << "                      without it the inlet is invisible to the pressure solve)\n"
+                      << "  --profile-x=X       Outlet probe plane x (default: 90% down the channel)\n"
+                      << "  --profile-xtol=TOL  Half-width of the probe plane (default: one element)\n"
+                      << "  --solver=cg|hypre   Linear solver (default cg)\n"
+                      << "  --pressure-solve=K|DDT  Pressure operator (default DDT; K FAILs on this channel)\n"
+                      << "  --vtu-output=PREFIX Write VTU/PVTU/PVD frames\n"
+                      << "  --vtu-every=N       Frame every N steps (default 50)\n"
+                      << "  --tol=VALUE         Solver tolerance (default 1e-10)\n"
+                      << "  --max-iter=N        Solver max iters (default 1000)\n";
+        MPI_Finalize();
+        return 1;
+    }
+
+    if (rank == 0)
+    {
+        const double Re = Uinf * 1.0 / nu;
+        std::cout << "\n========================================\n";
+        std::cout << "MARS Poiseuille channel-flow validation\n";
+        std::cout << "========================================\n";
+        std::cout << "Drive:     " << driveMode
+                  << (driveMode == "bodyforce"
+                          ? " (constant streamwise G, no-slip y-walls)"
+                          : " (prescribed inlet u=Uinf, mass-conserving outlet)") << "\n";
+        std::cout << "rho       = " << rho << "\n";
+        std::cout << "nu        = " << nu  << "\n";
+        std::cout << "dt        = " << dt  << "\n";
+        std::cout << "Re (~L*U/nu, L=1) = " << Re << "\n";
+        std::cout << "numSteps  = " << numSteps << " (T_final = " << numSteps * dt << ")\n";
+        std::cout << "Mesh:    " << meshFile << "\n";
+        std::cout << "Cross-axis (wall-normal): " << crossAxis << "\n";
+        std::cout << "Pressure solve: " << (pressureSolve == PressureSolveKind::K ? "K" : "DDT") << "\n";
+        std::cout << "MPI ranks: " << numRanks << "\n";
+        std::cout << "========================================\n\n";
+    }
+
+    AmrManager<HexTag, KeyType, RealType>::Config amrConfig;
+    amrConfig.maxLevels  = 0;
+    amrConfig.blockSize  = blockSize;
+    amrConfig.bucketSize = bucketSize;
+
+    AmrManager<HexTag, KeyType, RealType> amr(amrConfig);
+    amr.initialize(meshFile, rank, numRanks);
+
+    if (rank == 0)
+    {
+        std::cout << "Mesh: " << amr.domain().getElementCount() << " elements, "
+                  << amr.domain().getNodeCount() << " nodes\n\n";
+    }
+
+    NSStepper<KeyType, RealType> s{amr.domain(), solverKind, blockSize, maxIter,
+                                   RealType(tolerance), rank, numRanks};
+    s.lidU   = RealType(Uinf);
+    s.Uinf   = RealType(Uinf);
+    s.bcKind = NSStepper<KeyType, RealType>::BCKind::Channel;
+    s.useLegacyGradient = true;
+    s.pressureSolve     = pressureSolve;
+
+    setupNSStepper<KeyType, RealType>(s, RealType(nu), RealType(dt), kernelVariant);
+
+    // Body-force drive (textbook plane Poiseuille). The channel height H is the
+    // y-extent; centerline U_max = G*H^2/(8*rho*nu), so to hit a target U_max
+    // (default Uinf) set G = 8*rho*nu*U_max/H^2. Computed after we know the
+    // y-bbox below; stash the target here.
+    const bool useBodyForce = (driveMode == "bodyforce");
+    double targetUMax = Uinf;     // body-force mode aims for this centerline speed
+    //
+    // The shared Channel marker treats ALL six bbox faces' tangential ones as
+    // walls -- including z=zmin/zmax. This mesh is ONE element thick in z (two
+    // node-planes, bbox z extent ~0.066), so EVERY node lies on a z-face and
+    // gets pinned no-slip -> the whole velocity field is Dirichlet -> flow is
+    // frozen and div(u)=0 every step (confirmed: bc-count=all 30000 DOFs).
+    //
+    // Plane Poiseuille is inherently 2D: z is the extrusion (slip/symmetry)
+    // direction, NOT a wall. So we rebuild the velocity BC here, marking:
+    //   - inflow  x=xmin : u=(Uinf,0,0) Dirichlet
+    //   - outflow x=xmax : u=(u_out,0,0) Dirichlet, mass-conserving (see below)
+    //   - y-walls y=ymin,ymax : no-slip (0,0,0)
+    // and leaving z-faces + interior FREE. The w-component is left unconstrained
+    // (free-slip z); for a 1-cell-thick mesh w stays ~0 by symmetry anyway.
+    //
+    // MASS-CONSERVING OUTLET (the load-bearing fix): a velocity-inlet with a
+    // natural (Neumann) outlet leaves the net discrete boundary flux nonzero --
+    // the inlet injects Uinf*A_in that the divergence operator (interior SCS
+    // faces only, no boundary-face term) cannot route to any sink, so the
+    // pressure RHS b = -(rho/dt) div(u**) has a component OUTSIDE range(A).
+    // CG then stalls (residual floors at the out-of-range size) and div_max
+    // scales ~1/dt (the fixed geometric source amplified by rho/dt). Prescribing
+    // u_out = Uinf * (N_in/N_out) on the outflow makes the net boundary flux
+    // zero by construction, so the RHS is consistent and the projection
+    // converges. Keep the p=0 pressure Dirichlet on x=xmax (removes the
+    // constant mode). NOTE: a flat u_out over-constrains the exit, so the
+    // parabola must develop UPSTREAM -- the profile probe stays at 90% down
+    // the channel (its default), never at the outlet plane.
+    {
+        const auto& d_x = amr.domain().getNodeX();
+        const auto& d_y = amr.domain().getNodeY();
+        const auto& d_z = amr.domain().getNodeZ();
+        const auto& d_ownership = s.ownershipMap();
+        size_t n = s.nodeCount;
+
+        std::vector<RealType> hx(n), hy(n), hz(n);
+        std::vector<int>      h_n2d(n);
+        std::vector<uint8_t>  h_own(n);
+        cudaMemcpy(hx.data(),    d_x.data(),              n * sizeof(RealType), cudaMemcpyDeviceToHost);
+        cudaMemcpy(hy.data(),    d_y.data(),              n * sizeof(RealType), cudaMemcpyDeviceToHost);
+        cudaMemcpy(hz.data(),    d_z.data(),              n * sizeof(RealType), cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_n2d.data(), s.d_node_to_dof.data(), n * sizeof(int),      cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_own.data(), d_ownership.data(),     n * sizeof(uint8_t),  cudaMemcpyDeviceToHost);
+
+        // Global bbox for face detection (single-rank: local == global).
+        RealType xMinL = *std::min_element(hx.begin(), hx.end());
+        RealType xMaxL = *std::max_element(hx.begin(), hx.end());
+        RealType yMinL = *std::min_element(hy.begin(), hy.end());
+        RealType yMaxL = *std::max_element(hy.begin(), hy.end());
+        RealType zMinL = *std::min_element(hz.begin(), hz.end());
+        RealType zMaxL = *std::max_element(hz.begin(), hz.end());
+        RealType xMin = xMinL, xMax = xMaxL, yMin = yMinL, yMax = yMaxL;
+        RealType zMin = zMinL, zMax = zMaxL;
+        MPI_Allreduce(&xMinL, &xMin, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(&xMaxL, &xMax, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+        MPI_Allreduce(&yMinL, &yMin, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(&yMaxL, &yMax, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+        MPI_Allreduce(&zMinL, &zMin, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(&zMaxL, &zMax, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+        RealType eps = 1e-4 * std::max(RealType(1), yMax - yMin);
+        double H = static_cast<double>(yMax - yMin);   // channel height
+
+        std::vector<uint8_t>  hostIsBdry(s.numOwnedDofs, 0);
+        std::vector<RealType> hostU(n, 0), hostV(n, 0), hostW(n, 0);
+
+        if (useBodyForce)
+        {
+            // BODY-FORCE mode: ONLY the y-walls are no-slip Dirichlet. The
+            // x-planes (inflow/outflow) are left FREE -- the flow is driven by
+            // the streamwise body force G, not by a prescribed inlet, so there
+            // is no net-boundary-flux trap. The outflow p=0 pressure Dirichlet
+            // (set by setup) anchors the constant pressure mode.
+            long nWall = 0;
+            for (size_t i = 0; i < n; ++i)
+            {
+                bool onYWall = std::abs(hy[i] - yMin) < eps || std::abs(hy[i] - yMax) < eps;
+                if (!onYWall) continue;                 // x-planes + z-faces + interior free
+                hostU[i] = 0; hostV[i] = 0; hostW[i] = 0;
+                if (h_own[i] != 1) continue;
+                int dof = h_n2d[i];
+                if (dof < 0 || dof >= s.numOwnedDofs) continue;
+                hostIsBdry[dof] = 1;
+                ++nWall;
+            }
+            // G = 8 rho nu U_max / H^2 to hit the target centerline speed.
+            double G = (bodyForceX >= 0)
+                ? bodyForceX
+                : 8.0 * rho * nu * targetUMax / (H * H);
+            s.bodyForceX = RealType(G);
+            // Record the achieved analytic U_max for the validation print.
+            targetUMax = G * H * H / (8.0 * rho * nu);
+
+            long nWallG = nWall;
+            MPI_Allreduce(&nWall, &nWallG, 1, MPI_LONG, MPI_SUM, MPI_COMM_WORLD);
+            if (rank == 0)
+                std::cout << "Drive: BODY FORCE G=" << G << " (x), H=" << H
+                          << " -> analytic U_max=G*H^2/(8 rho nu)=" << targetUMax << "\n"
+                          << "Quasi-2D channel BC: y-walls=" << nWallG
+                          << " nodes (no-slip), x-planes + z-faces FREE\n";
+        }
+        else
+        {
+            // INLET mode -- matches the FLUYA reference (report.html input.yml)
+            // that produces the validated parabola: inlet=velocity-Dirichlet
+            // u=(Uinf,0,0), outlet=static-pressure p=0 with velocity FREE,
+            // wall=no-slip, front_back(z)=symmetry/free. The OUTLET VELOCITY IS
+            // NOT PINNED -- it develops freely, and the outflow p=0 Dirichlet
+            // (applied by the shared channel pressure marker, setup) both anchors
+            // the pressure null space and lets mass balance through the pressure
+            // field. This is the reference config; the parabola develops upstream
+            // of the free outlet, so the profile probe stays at 90% down.
+            long nInflow = 0, nWall = 0;
+            for (size_t i = 0; i < n; ++i)
+            {
+                bool onInflow = std::abs(hx[i] - xMin) < eps;
+                bool onYWall  = std::abs(hy[i] - yMin) < eps || std::abs(hy[i] - yMax) < eps;
+                // Outlet (x=xMax) is deliberately NOT tagged -> free velocity.
+                if (!onInflow && !onYWall) continue;     // outlet + z-faces + interior free
+                RealType uT = onInflow ? RealType(Uinf) : RealType(0);  // inlet wins corners
+                hostU[i] = uT; hostV[i] = 0; hostW[i] = 0;
+                if (h_own[i] != 1) continue;
+                int dof = h_n2d[i];
+                if (dof < 0 || dof >= s.numOwnedDofs) continue;
+                hostIsBdry[dof] = 1;
+                if (onInflow) ++nInflow; else ++nWall;
+            }
+            targetUMax = 1.5 * Uinf;   // developed parabola: U_max = 1.5 * mean = 1.5 Uinf
+
+            long nInflowG = nInflow, nWallG = nWall;
+            MPI_Allreduce(&nInflow, &nInflowG, 1, MPI_LONG, MPI_SUM, MPI_COMM_WORLD);
+            MPI_Allreduce(&nWall,   &nWallG,   1, MPI_LONG, MPI_SUM, MPI_COMM_WORLD);
+            if (rank == 0)
+                std::cout << "Drive: INLET (FLUYA-ref) inflow=" << nInflowG << " (u=" << Uinf << "), "
+                          << "outlet=pressure p=0 (velocity FREE), "
+                          << "y-walls=" << nWallG << " (no-slip), z=symmetry/free\n";
+
+            // Balanced opening-flux source wiring: per-node OUTWARD area
+            // vectors for the two opening planes (inlet outward = -x, outlet
+            // outward = +x), Voronoi-lumped from the plane node coordinates.
+            // The prescribed outlet speed is sized for the area ratio; the
+            // solver's per-step oScale then makes the net source exactly zero.
+            if (openingFluxSource)
+            {
+                std::vector<size_t> inIds, outIds;
+                std::vector<double> inYs, outYs;
+                for (size_t i = 0; i < n; ++i)
+                {
+                    if (std::abs(hx[i] - xMin) < eps)
+                    { inIds.push_back(i); inYs.push_back(double(hy[i])); }
+                    else if (std::abs(hx[i] - xMax) < eps)
+                    { outIds.push_back(i); outYs.push_back(double(hy[i])); }
+                }
+                double dz = double(zMax - zMin);
+                auto inAreas  = planeVoronoiAreas(inYs, dz);
+                auto outAreas = planeVoronoiAreas(outYs, dz);
+
+                std::vector<RealType> aInX(n, 0), aZero(n, 0), aOutX(n, 0);
+                double Ain = 0, Aout = 0;
+                for (size_t k = 0; k < inIds.size(); ++k)
+                { aInX[inIds[k]] = RealType(-inAreas[k]); Ain += inAreas[k]; }
+                for (size_t k = 0; k < outIds.size(); ++k)
+                { aOutX[outIds[k]] = RealType(+outAreas[k]); Aout += outAreas[k]; }
+
+                auto upload = [&](cstone::DeviceVector<RealType>& d,
+                                  const std::vector<RealType>& h)
+                {
+                    d.resize(n);
+                    thrust::copy(h.begin(), h.end(), thrust::device_pointer_cast(d.data()));
+                };
+                upload(s.d_openInAreaX, aInX);   upload(s.d_openInAreaY, aZero);
+                upload(s.d_openInAreaZ, aZero);
+                upload(s.d_openOutAreaX, aOutX); upload(s.d_openOutAreaY, aZero);
+                upload(s.d_openOutAreaZ, aZero);
+
+                RealType outletU = (Aout > 0) ? RealType(Uinf * Ain / Aout) : RealType(Uinf);
+                s.openInletVel[0]  = RealType(Uinf);
+                s.openOutletVel[0] = outletU;
+                s.useOpeningFluxSource = true;
+
+                if (rank == 0)
+                {
+                    if (numRanks > 1)
+                        std::cout << "WARNING: opening-flux Voronoi lumping assumes the full plane "
+                                     "is rank-local; multi-rank areas may be wrong at partition cuts\n";
+                    std::cout << "Opening-flux source: Ain=" << Ain << " Aout=" << Aout
+                              << " Qin=" << Uinf * Ain << " outletU=" << outletU
+                              << " (net zeroed per step via oScale)\n";
+                }
+            }
+        }
+
+        thrust::copy(hostIsBdry.begin(), hostIsBdry.end(),
+                     thrust::device_pointer_cast(s.d_isBdryDof.data()));
+        thrust::copy(hostU.begin(), hostU.end(), thrust::device_pointer_cast(s.d_uTarget.data()));
+        thrust::copy(hostV.begin(), hostV.end(), thrust::device_pointer_cast(s.d_vTarget.data()));
+        thrust::copy(hostW.begin(), hostW.end(), thrust::device_pointer_cast(s.d_wTarget.data()));
+        cudaDeviceSynchronize();
+    }
+
+    applyInitialCondition<KeyType, RealType>(s);
+
+    // Seed interior streamwise velocity (default ON) so the channel starts with
+    // flow and relaxes to the parabola quickly instead of growing from rest.
+    // Body-force mode seeds the MEAN velocity (2/3 U_max); inlet mode seeds Uinf.
+    // With the BC rebuilt above, interior nodes are genuinely non-boundary, so
+    // this takes effect.
+    RealType uSeed = useBodyForce ? RealType(2.0 / 3.0 * targetUMax) : RealType(Uinf);
+    if (seedInterior)
+    {
+        const auto& d_ownership = s.ownershipMap();
+        size_t n = s.nodeCount;
+        std::vector<uint8_t> h_bdry(s.numOwnedDofs);
+        std::vector<int>     h_n2d(n);
+        std::vector<uint8_t> h_own(n);
+        std::vector<RealType> hu(n);
+        cudaMemcpy(h_bdry.data(), s.d_isBdryDof.data(),  s.numOwnedDofs * sizeof(uint8_t), cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_n2d.data(),  s.d_node_to_dof.data(), n * sizeof(int),     cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_own.data(),  d_ownership.data(),     n * sizeof(uint8_t), cudaMemcpyDeviceToHost);
+        cudaMemcpy(hu.data(),     s.d_u.data(),           n * sizeof(RealType), cudaMemcpyDeviceToHost);
+        for (size_t i = 0; i < n; ++i)
+        {
+            if (h_own[i] != 1) continue;
+            int dof = h_n2d[i];
+            if (dof < 0 || dof >= s.numOwnedDofs) continue;
+            if (h_bdry[dof]) continue;        // leave wall/inlet Dirichlet values
+            hu[i] = uSeed;
+        }
+        cudaMemcpy(s.d_u.data(), hu.data(), n * sizeof(RealType), cudaMemcpyHostToDevice);
+        cudaDeviceSynchronize();
+        s.domain.exchangeNodeHalo(s.d_u);
+        if (rank == 0)
+            std::cout << "Interior IC: seeded u=" << uSeed << " (channel starts with flow)\n";
+    }
+
+    std::unique_ptr<fem::VTUParallelWriter<KeyType, RealType>> vtuWriterU;
+    std::unique_ptr<fem::VTUParallelWriter<KeyType, RealType>> vtuWriterP;
+    std::unique_ptr<fem::VTUParallelWriter<KeyType, RealType>> vtuWriterUmag;
+    if (!vtuPrefix.empty())
+    {
+        vtuWriterU    = std::make_unique<fem::VTUParallelWriter<KeyType, RealType>>(vtuPrefix + "_u");
+        vtuWriterP    = std::make_unique<fem::VTUParallelWriter<KeyType, RealType>>(vtuPrefix + "_p");
+        vtuWriterUmag = std::make_unique<fem::VTUParallelWriter<KeyType, RealType>>(vtuPrefix + "_umag");
+        if (rank == 0)
+            std::cout << "VTU output enabled: " << vtuPrefix << "_{u,p,umag}_step*.pvtu\n\n";
+    }
+
+    auto writeVtuFrame = [&] (int step, double t)
+    {
+        if (!vtuWriterU) return;
+        vtuWriterU->writeFrame(step, t, amr.domain(), s.d_u, "u");
+        vtuWriterP->writeFrame(step, t, amr.domain(), s.d_p, "p");
+        cstone::DeviceVector<RealType> d_umag(s.nodeCount, RealType(0));
+        const RealType* uPtr = s.d_u.data();
+        const RealType* vPtr = s.d_v.data();
+        const RealType* wPtr = s.d_w.data();
+        RealType* mPtr       = d_umag.data();
+        thrust::for_each(thrust::device,
+            thrust::counting_iterator<size_t>(0),
+            thrust::counting_iterator<size_t>(s.nodeCount),
+            [uPtr, vPtr, wPtr, mPtr] __device__ (size_t i) {
+                RealType u = uPtr[i], v = vPtr[i], w = wPtr[i];
+                mPtr[i] = sqrt(u * u + v * v + w * w);
+            });
+        cudaDeviceSynchronize();
+        vtuWriterUmag->writeFrame(step, t, amr.domain(), d_umag, "umag");
+    };
+
+    if (vtuWriterU) writeVtuFrame(0, 0.0);
+
+    // Step-0 norm: confirms the seeded IC actually populated d_u before any step.
+    {
+        RealType nu0 = computeWeightedL2Norm<KeyType, RealType>(s, s.d_u);
+        if (rank == 0)
+            std::cout << "Step    0: t=0.0000 |u|=" << std::scientific
+                      << std::setprecision(3) << nu0 << " (IC)\n" << std::defaultfloat;
+    }
+
+    for (int step = 1; step <= numSteps; ++step)
+    {
+        runNsStep<KeyType, RealType>(s, RealType(dt), RealType(nu), RealType(rho));
+        double t = step * dt;
+
+        RealType nuN = computeWeightedL2Norm<KeyType, RealType>(s, s.d_u);
+        if (rank == 0)
+        {
+            std::cout << "Step " << std::setw(4) << step
+                      << ": t=" << std::fixed << std::setprecision(4) << t
+                      << " |u|=" << std::scientific << std::setprecision(3) << nuN
+                      << " div_max=" << s.lastDivMax
+                      << " cg_iter_p=";
+            if (s.lastPressureIters == -1)      std::cout << "hypre";
+            else if (s.lastPressureIters == -2) std::cout << "FAIL";
+            else                                std::cout << s.lastPressureIters;
+            std::cout << "\n" << std::defaultfloat;
+        }
+
+        if (vtuWriterU && (step % vtuEvery == 0 || step == numSteps))
+            writeVtuFrame(step, t);
+    }
+
+    // -------------------------------------------------------------------------
+    // Outlet-plane validation against the analytic parabolic profile.
+    // Pull u and node coords to host, gather the probe-plane nodes, fit the
+    // wall extents from the data, and report RMS error vs the analytic parabola.
+    // -------------------------------------------------------------------------
+    {
+        const auto& d_x = amr.domain().getNodeX();
+        const auto& d_y = amr.domain().getNodeY();
+        const auto& d_z = amr.domain().getNodeZ();
+        size_t n = s.nodeCount;
+
+        std::vector<RealType> h_u(n), h_x(n), h_y(n), h_z(n);
+        cudaMemcpy(h_u.data(), s.d_u.data(), n * sizeof(RealType), cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_x.data(), d_x.data(),   n * sizeof(RealType), cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_y.data(), d_y.data(),   n * sizeof(RealType), cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_z.data(), d_z.data(),   n * sizeof(RealType), cudaMemcpyDeviceToHost);
+
+        // Local x-extent -> reduce to global for the auto probe plane.
+        RealType xMinL = *std::min_element(h_x.begin(), h_x.end());
+        RealType xMaxL = *std::max_element(h_x.begin(), h_x.end());
+        RealType xMin = xMinL, xMax = xMaxL;
+        MPI_Allreduce(&xMinL, &xMin, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(&xMaxL, &xMax, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+
+        double xProbe = (profileX >= 0) ? profileX : (xMin + 0.9 * (xMax - xMin));
+        double xTol   = (profileXTol > 0) ? profileXTol : 0.02 * (xMax - xMin);
+
+        const std::vector<RealType>& cross = (crossAxis == "z") ? h_z : h_y;
+
+        std::vector<std::pair<double,double>> plane;   // (cross-coord, u)
+        for (size_t i = 0; i < n; ++i)
+            if (std::abs(h_x[i] - xProbe) < xTol)
+                plane.emplace_back(cross[i], h_u[i]);
+
+        // Wall extents from the gathered plane (reduce min/max across ranks).
+        double sLoL =  1e300, sHiL = -1e300;
+        for (auto& p : plane) { sLoL = std::min(sLoL, p.first); sHiL = std::max(sHiL, p.first); }
+        double sLo = sLoL, sHi = sHiL;
+        MPI_Allreduce(&sLoL, &sLo, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+        MPI_Allreduce(&sHiL, &sHi, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+
+        PoiseuilleProfile prof{targetUMax, sLo, sHi};
+
+        // Local sum of squared error + node count, reduce to global RMS.
+        double sumSqL = 0.0;
+        long   cntL   = 0;
+        for (auto& p : plane)
+        {
+            double err = p.second - prof.analytic(p.first);
+            sumSqL += err * err;
+            ++cntL;
+        }
+        double sumSq = 0.0; long cnt = 0;
+        MPI_Allreduce(&sumSqL, &sumSq, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+        MPI_Allreduce(&cntL,   &cnt,   1, MPI_LONG,   MPI_SUM, MPI_COMM_WORLD);
+
+        double rms = cnt > 0 ? std::sqrt(sumSq / cnt) : -1.0;
+
+        if (rank == 0)
+        {
+            std::cout << "\n========================================\n";
+            std::cout << "Poiseuille profile validation\n";
+            std::cout << "  probe plane x = " << std::fixed << std::setprecision(4) << xProbe
+                      << " (+/- " << xTol << "),  channel x in [" << xMin << ", " << xMax << "]\n";
+            std::cout << "  wall extents on plane: [" << sLo << ", " << sHi << "]  (axis " << crossAxis << ")\n";
+            std::cout << "  U_max analytic = " << prof.uMax
+                      << (useBodyForce ? "  (= G*H^2/(8 rho nu))" : "  (= 1.5*Uinf)") << "\n";
+            std::cout << "  probe nodes    = " << cnt << "\n";
+            std::cout << "  RMS error      = " << std::scientific << std::setprecision(6) << rms
+                      << "  (normalized: " << (rms / prof.uMax) << ")\n";
+            std::cout << "========================================\n";
+        }
+
+        // Interior-flux probe (the honest through-flow diagnostic from the pump
+        // fork): Q(x*) at 25/50/75% of the channel from the SOLVED interior
+        // velocity, vs Qin at the inlet plane. Cannot be faked by BC values --
+        // a dead channel shows ratio ~0 here no matter what the BCs claim.
+        {
+            RealType zMinL2 = *std::min_element(h_z.begin(), h_z.end());
+            RealType zMaxL2 = *std::max_element(h_z.begin(), h_z.end());
+            RealType zMin2 = zMinL2, zMax2 = zMaxL2;
+            MPI_Allreduce(&zMinL2, &zMin2, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+            MPI_Allreduce(&zMaxL2, &zMax2, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+            double dz = double(zMax2 - zMin2);
+
+            // Flux through the mesh x-plane nearest to xTarget: snap to the
+            // closest actual node-plane, then Voronoi-lump that plane's nodes.
+            auto planeFlux = [&](double xTarget) -> double
+            {
+                double xSnap = 1e300;
+                for (size_t i = 0; i < n; ++i)
+                    if (std::abs(h_x[i] - xTarget) < std::abs(xSnap - xTarget)) xSnap = h_x[i];
+                double snapTol = 1e-9 * std::max(1.0, double(xMax - xMin));
+                std::vector<double> ys, us;
+                for (size_t i = 0; i < n; ++i)
+                    if (std::abs(h_x[i] - xSnap) < snapTol)
+                    { ys.push_back(double(h_y[i])); us.push_back(double(h_u[i])); }
+                auto areas = planeVoronoiAreas(ys, dz);
+                double q = 0;
+                for (size_t k = 0; k < us.size(); ++k) q += us[k] * areas[k];
+                return q;
+            };
+
+            double qIn = planeFlux(double(xMin));
+            if (rank == 0)
+            {
+                std::cout << "Interior-flux probe (solved u, Voronoi-lumped):\n";
+                std::cout << "  Q(inlet) = " << std::scientific << std::setprecision(4) << qIn << "\n";
+                for (double f : {0.25, 0.50, 0.75})
+                {
+                    double q = planeFlux(double(xMin) + f * double(xMax - xMin));
+                    std::cout << "  Q(" << std::fixed << std::setprecision(0) << f * 100
+                              << "%) = " << std::scientific << std::setprecision(4) << q
+                              << "  ratio=" << std::fixed << std::setprecision(3)
+                              << (std::abs(qIn) > 0 ? q / qIn : 0.0) << "\n";
+                }
+                std::cout << "========================================\n";
+            }
+        }
+    }
+
+    MPI_Finalize();
+    return 0;
+}

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -955,7 +955,11 @@ int main(int argc, char** argv)
             double dtCfl = (um > 0) ? cflMax * dxMean / um : dtInit;
             double dtNew = std::min(dtCfl, dtInit);
             dtNew = std::min(dtNew, 1.05 * dt);     // grow <=5%/step (BDF2)
-            dtNew = std::max(dtNew, 0.95 * dt);     // shrink <=5%/step (BDF2)
+            // SHRINK can be fast: a CFL violation must be caught THIS step or the
+            // explicit advection runs away (the 5%/step shrink cap was too slow --
+            // u spiked past the limiter and blew up). Allow up to 2x shrink/step.
+            // (Growth stays gentle so BDF2's constant-dt assumption holds in steady.)
+            dtNew = std::max(dtNew, 0.50 * dt);     // shrink <=2x/step (catch CFL fast)
             dtNew = std::max(dtNew, 1e-6 * dtInit); // floor: never collapse dt to ~0
             dt = dtNew;
         }

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -79,6 +79,8 @@ int main(int argc, char** argv)
     bool        useRhieChow = false;   // compact RC is geometrically unsafe on tets (blows up at every tau); --rhie-chow to force on
     RealType    rhieTau    = -1;       // RC strength; <=0 -> auto dt/rho. --rhie-tau= to sweep
     bool        useVMSStab = false;    // Nalu-Wind VMS pressure stab (NOT Rhie-Chow); --vms-stab. EXPERIMENTAL, validate.
+    bool        usePSPG    = false;    // implicit PSPG pressure stab (tau*L in the DDT operator); --pspg. The correct equal-order checkerboard fix.
+    double      pspgTau    = -1;       // <=0 => auto h^2/24; --pspg-tau=V overrides
     std::string inletSS;   // inlet side-set name (required for --bc=pump; pass --inlet-ss=)
     std::string outletSS;  // outlet side-set name (required for --bc=pump; pass --outlet-ss=)
     // Inlet velocity follows each node's OWN local surface normal (area-weighted
@@ -141,6 +143,8 @@ int main(int argc, char** argv)
         else if (a == "--rhie-chow")                 useRhieChow = true;
         else if (a.rfind("--rhie-tau=", 0) == 0)     rhieTau   = std::stod(a.substr(11));
         else if (a == "--vms-stab")                  useVMSStab = true;  // Nalu VMS pressure stab (tet-only, experimental)
+        else if (a == "--pspg")                      usePSPG    = true;  // implicit PSPG (tau*L in DDT operator) -- the correct checkerboard fix
+        else if (a.rfind("--pspg-tau=", 0) == 0)     pspgTau    = std::stod(a.substr(11));
         else if (a.rfind("--inlet-ss=", 0) == 0)     inletSS   = a.substr(11);
         else if (a.rfind("--outlet-ss=", 0) == 0)    outletSS  = a.substr(12);
         else if (a == "--inlet-pernode-normal")      inletPernodeNormal = true;
@@ -184,6 +188,7 @@ int main(int argc, char** argv)
                     "                       V<=0 (default) keeps the mass-conserving velocity outlet.\n"
                     "  --no-inlet-pernode-normal  use one global inlet normal (default: per-node)\n"
                     "  --advection=NAME     skew (default) | upwind | barth-jespersen (--bj)\n"
+                    "  --pspg [--pspg-tau=V] implicit PSPG pressure stabilization (tau*L in DDT operator; the equal-order checkerboard fix; tau auto h^2/24)\n"
                     "  --rho=V --nu=V       physical fluid properties (default water: rho=1000, nu=1e-6)\n"
                     "  --Re=V               LEGACY: override nu = inletU*L_bbox/Re. L_bbox is the\n"
                     "                       whole-geometry diagonal, NOT the passage scale, so this Re\n"
@@ -250,6 +255,8 @@ int main(int argc, char** argv)
                   << (useRhieChow && rhieTau > 0 ? "  (tau=" : "  (tau=auto dt/rho")
                   << (useRhieChow && rhieTau > 0 ? std::to_string(rhieTau) + ")" : ")") << "\n"
                   << "VMS-stab    = " << (useVMSStab ? "ON (Nalu, tet-only, EXPERIMENTAL)" : "OFF") << "\n"
+                  << "PSPG        = " << (usePSPG ? "ON (implicit tau*L in DDT operator)" : "OFF")
+                  << (usePSPG && pspgTau > 0 ? "  (tau=" + std::to_string(pspgTau) + ")" : (usePSPG ? "  (tau=auto h^2/24)" : "")) << "\n"
                   << "MPI ranks   = " << numRanks << "\n"
                   << "========================================\n\n";
     }
@@ -321,6 +328,8 @@ int main(int argc, char** argv)
     s.useBdf2 = useBdf2;
     s.useRhieChow = useRhieChow;
     s.useVMSStab  = useVMSStab;   // Nalu VMS pressure stabilization (tet-only)
+    s.usePSPG     = usePSPG;       // implicit PSPG (tau*L in DDT operator)
+    s.pspgTau     = RealType(pspgTau);
     // Correct through-flow config: mass-conserving outlet + opening-flux-source ON
     // + pumpDp=0 (FIX B off). The prescribed inlet/outlet opening flux balances
     // exactly (sum=0 at step0), so the single-pin Neumann pressure solve is


### PR DESCRIPTION
- **fix(pump): revive the pressure outlet (the REAL through-flow fix). outletU was set unconditionally -> always velocity-Dirichlet outlet -> both-ends-Dirichlet admits a flat-pressure tank-recirculation div=0 solution -> NO flow through the passage (confirmed: 1e-10 pressure solve gave identical flat-p, so it's structural not convergence -- AMG would NOT help). Gate outletU on !outletDoNothing so do-nothing (default) leaves outletU<=0 -> solver masks the WHOLE outlet face p=0 + frees outlet velocity (singlePin=false, solver:4080) -> inlet flux against fixed-p outlet FORCES the outlet->suction gradient -> through-flow. The dead --outlet flag now actually works**
- **fix(pump): default outlet back to MASS-CONSERVING (the correct design). Root cause found: the divergence operator only loops interior faces (sum(div)==0 always), so the pressure solve is NEVER told mass enters at the inlet -> a velocity-inlet + free pressure-outlet is UNPROJECTABLE -> no through-flow (flow dies at inlet, pressure parks in body). The code's own comment (solver:2295) flags this. My prior do-nothing default was backwards: the mass-conserving outlet (vel outflow removes Q + single pin) BALANCES the flux so the projection builds the inlet->outlet gradient that drives flow through the passage. The dead-flag gate stays so do-nothing is still selectable (needs a boundary-flux source term to be correct -- separate work)**
- **pump through-flow: (1) default to do-nothing outlet = whole-face p=0 + FREE outlet velocity (the channel-proven pairing that builds the inlet->outlet pressure head; both-ends-velocity-Dirichlet + single pin gave a flat-pressure dead-passage solution). (2) --inlet-flux-source (GUARDED, off): add the prescribed inlet flux as a boundary divergence source -- the exterior opening flux is in no interior SCS so it's never integrated (verified not a double-count); A/B it. (3) [through-flow] Q_in/Q_out/ratio diagnostic each step so we MEASURE through-flow (ratio->1) instead of eyeballing uMax. mass-conserving still selectable. cavity/channel/TGV unaffected**
- **pump: REMOVE the broken --inlet-flux-source (double-counted the inlet flux already registered via interior SCS scatter; full-opening-area x rho/dt -> instant blowup, ratio=garbage) and revert default to MASS-CONSERVING outlet. Verified high-confidence: the inlet flux is already in the divergence for a velocity-Dirichlet inlet, so the only correct inlet boundary source is ZERO. do-nothing (whole-face p=0 + free outlet) does NOT self-drive a small interior outlet -> ratio=0 (no through-flow); the prior do-nothing-default + comments were disproven by the A/B. mass-conserving (U_out=Uin*Ain/Aout + single pin) forces Q_out=Q_in by construction. Kept the [through-flow] Q diagnostic (correct + useful)**
- **pump through-flow REWORK (verified root cause): the reference flows through the pump with ANY scheme (bj/upwind) so the dead passage is OUR bug, not Re/scheme. TWO real defects fixed: FIX1 --opening-flux-source (GUARDED off): inlet/outlet OPENING faces are exterior, in no interior SCS, so the prescribed opening flux never reaches the pressure RHS -> pressure flat -> no through-flow. Add it as a COMPATIBLE surface integral (u.n)*A_share, SAME scale as interior scatter, NOT x rho/dt (RHS does it), net~0 -- verified NOT a double-count (telescoping interior pairs never touch the opening face). FIX2 --dirichlet-lift (default ON): velocity-diffusion col-zero had no Dirichlet lift -> inlet momentum never diffused inward -> jet died at inlet. Add b-=K[row,bdry]*uTarget. FIX3: replace TAUTOLOGICAL Q_out (relocked to prescribed outletU) with an INTERIOR cut-plane flux probe at 25/50/75% -- measures SOLVED through-flow, can't be faked. old line relabeled [bc-sanity]**
- **pump FIX B: pressure-drop drive via --pump-dp=VALUE (gated, off by default -> existing pump byte-identical). Root cause: the divergence operator integrates only INTERIOR SCS faces, so a VELOCITY prescribed on the interior inlet opening is invisible to the pressure solver (exterior opening face never integrated) + the corrector freezes velocity-Dirichlet nodes -> no through-flow (proven: interior-flux mid-cut=0). FIX B masks BOTH openings as pressure-Dirichlet (p=dP inlet, p=0 outlet), frees both velocities, seeds the dP head in d_p -> flow EMERGES from the interior gradient (SCS-captured, VISIBLE). Startup-safe: two Dirichlet faces make the matrix NONSINGULAR -> no compatibility condition -> no FIX-1 source-blowup. inlet velocity becomes an OUTPUT (tune dP to hit ~0.5 m/s). Keeps interior-flux probe to verify mid-cut goes nonzero**
- **pump FIX B phi-lift (the piece that makes dP actually drive flow). Bug: FIX B seeded a one-node dP spike + pinned the phi increment to 0 at both faces -> interior never relaxed into the inlet->outlet gradient -> dP didn't drive flow (identical tiny flow at dP=1000 vs 30000). FIX: pin the SOLVED pressure to the target via rhs=target-p^n at masked DOFs (clamp to constant, NOT additive -> steady+bounded), so the Poisson solve imposes dP->0 Dirichlet data + relaxes the spanning gradient; the already-live predictor grad(p^n) then drives through-flow. LOAD-BEARING: pump runs DDT matrix-free, so the lift goes in solvePressureDDT's boundary-pin lambda (not the K-path). All gated pumpDp>0; pumpDp<=0 byte-identical (cavity/channel/TGV untouched)**
- **pump THROUGH-FLOW fix: prescribed-balanced opening-flux source (default ON). The verified root cause: a velocity-inlet's opening flux is invisible to the pressure solver (divergence integrates interior SCS only) -> flat passage -> dead passage (proven: interior-flux cut@50%=0). FIX: inject the opening flux into divAccNode so the projection SEES the inflow and builds the inlet->outlet gradient that drives the passage. KEY over the broken FIX 1: use PRESCRIBED GLOBAL-direction velocities (Uinf*inletDir, outletU*outletDir) not the solved u** -> inlet sums to -Q_in, outlet to +Q_in (outletU=Uin*Ain/Aout) -> total=0 EXACTLY every step incl step0 -> single-pin Neumann stays compatible -> CANNOT blow up like FIX 1 (which used u**=0 at the step0 outlet -> one-sided -> phi=1e36). Config: mass-conserving velocity inlet+outlet (sustains the jet) + this source (makes it visible). No removeMean (pin handles it). FIX B (pumpDp) abandoned, gated off**
- **pump: default opening-flux-source back OFF -- the prescribed-balanced source STILL blows up at step0 (phi=1e7->inf, CG residual grows = incompatible, same FLT_MAX as FIX 1). The 'sum=0 by construction' startup-safety proof was WRONG: the discrete per-node area shares evidently do not sum to exactly Q, so sum!=0, x rho/dt=1e6 -> explodes even at step0. Revert to the STABLE mass-conserving default (no through-flow, but runs). The opening-flux-source remains a flag for debugging but is NOT a working fix. Through-flow is UNRESOLVED -- see scratch/pump_throughflow_HANDOFF.md**
- **pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B**
- **Revert "pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B"**
- **debug: MARS_OFS_DBG -- print divAccNode |max| before/after the opening-flux source + the global net source sum, to SEE if the source is a giant localized spike (divAcc max jumps) and whether net is actually ~0. Instrumentation only, gated on env. Investigating the repeated step0 phi=1e7 blowup**
- **debug: print Qin_raw/Qout_raw separately -- the [ofs-dbg] net=-Q_in (one-sided) proves the OUTLET source contributes ZERO. Need to see Qin_raw vs Qout_raw to find why the outlet half does not fire (area-vec sign? outletDir?)**
- **pump: adjustPhi rescale FOUND THE BUG via debug -- the discrete inlet/outlet fluxes differ ~1.5% (Qin_raw=-5.975e-3, Qout_raw=+5.884e-3), NOT roundoff: the per-node area-vectors sum to a different value than the analytic areaIn/areaOut used for outletU. That 9e-5 residual x rho/dt=1e6 -> incompatible RHS -> phi=1e7 blowup. FIX: oScale=-Qin_raw/Qout_raw, rescale the outlet source so it EXACTLY cancels the inlet (net->0). The reductions now always run (not just debug). [ofs-dbg2] prints the net to confirm it goes to ~0**
- **pump: removeMean for the opening-flux source -- THE ACTUAL FIX. Debug PROVED the blowup is NOT flux imbalance: with the adjustPhi rescale the net source is bit-exactly 0 (8.67e-19) and it STILL blew up to phi=1e7 identically. Real cause (the code's own comments flag it: lines 897/2209/3333/5145): the single p=0 pin weakly controls the DDT constant null space; a boundary source excites that mode and Jacobi-PCG loses pAp>0 (residual GROWS 0.98->1.46 then garbage phi=1e7). FIX: removeMean the RHS + phi (project the null-space component out) when opening-flux is on -- the same cure the periodic path uses. Gated on useOpeningFluxSource**
- **debug: removeMean did NOT fix the blowup (phi=1e7 identical) -> null-space theory also wrong. KEY realization: the CG CONVERGES (3e-8), so phi=1e7 is the TRUE solution -- the operator+RHS are fine, the answer is legitimately huge. Add [ofs-dbg3] b|max and [ofs-dbg4] phi|max split by OPENING vs INTERIOR nodes, to decide: is phi huge only at the opening nodes (tiny DDT boundary-layer diagonal, b/diag=1e6*1e-4/1e-5=1e7 LOCAL) or everywhere (global)? That picks the final fix**
- **pump: --source-ramp-steps=N gentle startup for the opening-flux source. ROOT CAUSE (measured): the source WORKS (real through-flow, step1 cut@50% nonzero) but starting from rest at full strength dumps the whole inlet->outlet pressure head onto a near-singular interior node (sliver cell, DDT diag=1e-5, 600x below bulk) -> phi spikes to 6e6 there -> grad(phi) spike -> corrector velocity spike -> advection 950x/step -> blowup. NOT fixable by clip (preconditioner-only, phi is the true solution), CFL (structural per-step amplification), or balance/removeMean (all already correct). FIX: ramp Uinf 0->full over N steps so the head + phi + grad stay small while flow develops gently. Scales the inlet velocity target (from a base snapshot) AND the opening-flux source (reads Uinf live) -> balance preserved at every ramp level**
- **pump: allow dt to shrink up to 2x/step (was 5%/step). With the ramp, the flow develops stably for ~16 steps (phi=1e4, u_max bounded+growing, cut@50% nonzero) then a CFL violation at u~100 ran away because the 5%/step shrink cap could not drop dt fast enough to catch it. Fast shrink catches the violation in one step; growth stays gentle (5%/step) so BDF2's constant-dt assumption holds at steady state**
- **pump: targeted operator-diagonal floor on the matrix-free DDT (the sliver-node fix). MEASURED: the ramp fixes startup (steps 1-16 stable, flow developing, cut@50% nonzero) but one sliver interior node (tiny SCS face areas -> DDT diag=1e-5, 600x below bulk) makes phi spike there -> corrector velocity spike -> diffusion CG breaks (pAp<0, u**>>u*) -> blowup, even at dt=5e-8 (so NOT CFL). Jacobi clip is preconditioner-only (no-op on phi). FIX: raise ONLY the degenerate rows to epsFloor=0.05*max_diag in the TRUE matrix-free operator via per-node shift out[i]+=shift_i*phi[i]; 0 on the healthy bulk -> byte-identical there -> cavity/channel/cube16 untouched. Caps phi at b/3.3e-4 (~31x smaller) -> below blowup threshold. Pure positive diagonal add -> keeps SPD. Preconditioner diag floored to match. Velocity diffusion needs NO floor (M/dt keeps it conditioned; its divergence was downstream of the phi spike). Env MARS_DDT_OP_FLOOR_FRAC**
- **debug: MARS_CHECKER -- per-element mean-free pressure RMS diagnostic (the checkerboard mode an inf-sup stabilizer penalizes). Lets us SEE the checkerboard grow + SEE a stabilizer kill it in a few steps, instead of inferring from a full-run blowup. Confirms/quantifies the LBB decoupling diagnosis. Env-gated, tet-only, rank0, free in production. NOTE: adjudication confirmed BD-on-DDT is WRONG (breaks div=0 identity, accumulating divergence); the identity-safe path is VMS/RC on the divergence SOURCE (needs a phi-vs-d_p fix). Checkerboard fix != through-flow fix (separate defects)**
- **fix: checker diagnostic compile error -- a pair-returning __device__ lambda in transform_reduce needs its return type proclaimed in host context. Split into two scalar (double) reductions (mean-free energy + total) -- avoids the trait error, same result**
- **pump: replace the div-BREAKING operator-diagonal floor with an identity-safe MASS floor. The operator floor (out[i]+=shift*phi in applyDDTPerNode) only the OPERATOR saw, not the corrector -> solving (A+S)phi=b left div(u^{n+1})=(dt/rho)*S*phi un-projected -> accumulating residual -> smooth |p| 1e3->1e34 blowup (the SAME div=0-breaking class the code warns against for BD-on-DDT, lines 5602-5610). FIX: floor the lumped mass d_massNode instead -- A=D M^-1 D^T and the corrector ALSO applies M^-1 from the same d_massNode, so flooring mass changes operator AND corrector consistently -> div=0 PRESERVED. Removed d_shiftDDTNode + its apply + the operator-floor build. Env MARS_MASS_FLOOR_FRAC (default 1e-3*max_mass)**
- **pump: implicit PSPG pressure stabilization (--pspg) -- the CORRECT equal-order checkerboard fix. VERIFIED root cause of the checkerboard blowup: the existing VMS adds tau*(-lap p^n) to the RHS = an EXPLICIT forward-Euler Laplacian-of-p update -> unconditionally amplifies the high-freq mode at ANY tau (why 1e-6/1e-5/1e-3 all blew up). FIX: add tau*L*phi IMPLICITLY inside applyDDTPerNode so CG solves (A+tau*L)phi=b. L=sum_e V_e G^T G is symmetric PSD, shares A's constant null mode (removed by the pin) -> SPD, damps checkerboard at ALL tau>0. Acts on phi (the correction, ->0) so it self-extinguishes; post-corrector div relaxes to ~tau*lap(phi)=O(h^2), a CONSISTENT residual that vanishes under refinement -- the textbook PSPG, NOT the inconsistent div-breaking BD/floor. tau=h^2/24 (a LENGTH^2, not dt/rho). Confirm via MARS_CHECKER: frac must shrink. New kernel applyPSPGLaplacianTetKernel; gated --pspg, tau auto or --pspg-tau**
- **pump PSPG: FIX THE SIGN. The DDT operator outAcc = D M^-1 D^T phi ~ -lap(phi) (SPD-positive; A=-lap, matches b=-coef*div). My PSPG scattered +div(grad phi)=+lap(phi) = OPPOSITE sign -> SUBTRACTED definiteness (made conditioning worse, no damping). Flip: scatter -s to iL / +s to iR so it adds +tau*(-lap)phi = positive energy, same orientation as A. This is why the first PSPG run showed frac still growing + cg_p=-2 (wrong-sign term de-conditioned the operator). NOTE: that run ALSO lost the Jacobi clip (diag=6.5e-12) -- must pass MARS_DDT_JACOBI_CLIP_FRAC for the sliver**
- **pump PSPG: add tau*L diagonal to the Jacobi preconditioner (the REAL bug). Numerically verified (host dense-matrix replica): my PSPG sign was CORRECT (-s/+s -> L=+Vol*G^T*G, same sign as A=-lap, A+tau*L more SPD). The cg_p=-2 failure was the PRECONDITIONER mismatch: operator ran A+tau*L but d_diagDDT was built from A only -> worst on the sliver rows (tiny A-diag, large tau*L-diag) -> CG stalls. FIX: computeTetPSPGDiagonalKernel scatters tau*Vol*|dNdx_i|^2 into d_diagAccNode (before halo/gather) so the preconditioner matches the stabilized operator. Gated usePSPG, tet-only. Sign left unchanged (verified correct)**
- **pump: pin the degenerate sliver DOF(s) -- the identity-safe fix for the unsolvable pressure (cg_p=-2). A near-zero-volume tet gives a DDT diagonal ~9 OOM below bulk (1e-12 vs 6e-3); Jacobi-PCG cannot solve it. FIX: mask any owned DOF with diag < MARS_SLIVER_PIN_FRAC*max_diag (default 1e-6) into d_isPressureBdryDof -> the operator forces out=phi (identity row) AND the RHS forces b=0, exactly like the outflow/pin DOFs (verified both paths check maskPtr). One removed equation, div-safe. Makes the pressure solvable so the real physics + PSPG become readable. The mass floor was the wrong lever (sliver diag is AREA-driven, not mass); this pins the node directly**
- **poiseuille validation example: channel-fork NS solver with balanced opening-flux source; parabola matches analytic profile within reference tolerance (RMS 5.8e-3 < 6e-3, interior flux ratio ~1). Plus tutorial.**
