### PR TITLE
cstone

### DIFF
--- a/backend/distributed/unstructured/fem/mars_element_traits.hpp
+++ b/backend/distributed/unstructured/fem/mars_element_traits.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "backend/distributed/unstructured/domain.hpp"  // HexTag, TetTag
+#include <cuda_runtime.h>
+#include <type_traits>
+
+namespace mars {
+namespace fem {
+
+// Compile-time element geometry constants, keyed on the element tag. The NS
+// solver and assemblers are being templated on ElementTag; these traits
+// replace the literal 8 / 12 / 3 that were scattered through the hex-only
+// code. Anything that is a pure count lives here; anything that needs a
+// per-element formula (volume, area vectors) stays in a tag-dispatched
+// function, not a constant.
+//
+// facesPerCorner is 3 for BOTH hex and tet, but that is a coincidence of the
+// node valence inside one element, NOT a shared table -- the (face, sign)
+// CONTENTS differ. Do not treat the tables as interchangeable.
+template<typename ElementTag>
+struct ElemTraits;
+
+template<>
+struct ElemTraits<HexTag> {
+    static constexpr int NodesPerElem  = 8;
+    static constexpr int ScsPerElem    = 12;   // sub-control surfaces (one per edge)
+    static constexpr int FacesPerCorner = 3;   // SCS faces incident to each corner
+    // Worst-case SCS faces touching one node across all incident elements,
+    // for the DDT per-node assembly register buffer. Hex: ~8 elems/corner * 3.
+    static constexpr int MaxFacesPerNode = 32;
+};
+
+template<>
+struct ElemTraits<TetTag> {
+    static constexpr int NodesPerElem  = 4;
+    static constexpr int ScsPerElem    = 6;
+    static constexpr int FacesPerCorner = 3;   // each tet node is an endpoint of 3 of the 6 edges
+    // Tet meshes have much higher vertex valence than hex (~20-24 elems/node
+    // is common), so the hex bound of 32 silently truncates. Sized generously;
+    // the DDT per-node kernel must guard against overflow regardless.
+    static constexpr int MaxFacesPerNode = 128;
+};
+
+// Device-resident SCS left/right node-pair tables. d_hexLRSCV already lives in
+// mars_cvfem_utils.hpp; d_tetLRSCV is added here so the templated scatter
+// kernels can pick the right table by tag. Layout matches Tet4CVFEM's host
+// lr_pairs: {0,1, 1,2, 0,2, 0,3, 1,3, 2,3}.
+__device__ __constant__ int d_tetLRSCV[12] = {
+    0, 1, 1, 2, 0, 2, 0, 3, 1, 3, 2, 3
+};
+
+} // namespace fem
+} // namespace mars

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -4797,6 +4797,19 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
                 s.pressurePinDof, s.d_rowPtr.data(), s.d_colInd.data(),
                 s.d_diagPtr.data(), s.d_valuesPre.data());
             cudaDeviceSynchronize();
+            // CRITICAL for the assembled DDT (Hypre) path: the pin must ALSO be
+            // enforced into the assembled DDT matrix d_valuesDDT, else s.AddT
+            // stays SINGULAR (SPSD, constant null mode unanchored) and BoomerAMG/
+            // FlexGMRES return the null-space solution = 0 -> phi=0 ("converged in
+            // 2 iters", x=0). The K-path matrix d_valuesPre was pinned above; the
+            // DDT matrix needs the same one-row identity.
+            if (s.nnzDDT > 0)
+            {
+                enforcePinRowKeepDiagKernel<RealType><<<1, 1>>>(
+                    s.pressurePinDof, s.d_rowPtrDDT.data(), s.d_colIndDDT.data(),
+                    s.d_diagPtrDDT.data(), s.d_valuesDDT.data());
+                cudaDeviceSynchronize();
+            }
         }
         if (s.rank == 0)
         {

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -1660,7 +1660,6 @@ __global__ void assembleDDTPerNodeKernel(const KeyType* c0, const KeyType* c1,
 // per-element-per-SCS at offset e*6+gFace. The per-node M^-1 (V[i]) in the
 // middle is why this is node-driven, not per-element: cross-element face pairs
 // that share node i must both contribute to A[*, *] through 1/V[i].
-template<typename KeyType, typename RealType>
 // Assemble the PSPG stabilization tau*L into the SAME DDT CSR. L is the linear-
 // tet stiffness L[i][j] = Vol*(dNdx_i . dNdx_j); we add tau*L[i][j] to A[dof_i,dof_j].
 // Element-driven (one thread per element, 4x4 local stencil) -- mirrors the BD

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -5163,9 +5163,9 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
     }
     wrapIntoSparseMatrix<RealType>(s.Apre, s.numOwnedDofs, s.numTotalDofs, s.nnz,
                                    s.d_rowPtr.data(), s.d_colInd.data(), s.d_valuesPre.data());
-    // AddT only exists when the DDT operator was assembled (hex). For tet,
-    // nnzDDT==0 and the d_*DDT buffers are null/empty -- wrapping them does a
-    // cudaMemcpy on a null pointer (cudaErrorInvalidValue -> poisoned context).
+    // AddT exists when the DDT operator was assembled (hex OR tet now). If the
+    // assembly was skipped (nnzDDT==0) the d_*DDT buffers are null/empty --
+    // wrapping them would cudaMemcpy a null pointer (poisoned context), so guard.
     if (s.nnzDDT > 0)
         wrapIntoSparseMatrix<RealType>(s.AddT, s.numOwnedDofs, s.numTotalDofs, s.nnzDDT,
                                        s.d_rowPtrDDT.data(), s.d_colIndDDT.data(), s.d_valuesDDT.data());
@@ -7554,24 +7554,26 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
     }
     else  // DDT: (D M^{-1} D^T) phi = -(rho/dt) D u**
     {
-        // DDT pressure ALWAYS uses the matrix-free path (the else branch
-        // below). The assembled DDT operator s.AddT holds POSITIVE off-
-        // diagonals at boundary rows (D M^-1 D^T is not an M-matrix),
-        // which BoomerAMG's classical strength-of-connection rejects --
-        // every Hypre Setup attempt on s.AddT returned HYPRE_ERROR_GENERIC
-        // (cg_iter_p=FAIL every step on cube16 cavity). The matrix-free
-        // CG path with Jacobi preconditioning (see solvePressureDDT) is
-        // the working production route. The Hypre wrappers still serve
-        // velocity solves and the K-path pressure solve, both of which
-        // are well-conditioned M-matrices where AMG works as designed.
+        // DDT pressure: matrix-free Jacobi-CG is the DEFAULT (the else branch
+        // below) -- unchanged, kept so we can return to it. The ASSEMBLED path
+        // (s.AddT, built at setup) is opt-in via --solver=hypre: it solves the
+        // SAME operator with Hypre FlexGMRES + BoomerAMG (or Jacobi). This was
+        // previously dead because the bare Gram-form D M^-1 D^T has positive
+        // boundary off-diagonals that BoomerAMG rejects -- now we assemble the
+        // PSPG tau*L into the CSR too, which regularizes the operator toward
+        // diagonal dominance so AMG (and even diagonal Jacobi under GMRES) can
+        // precondition it. GMRES/FlexGMRES (not PCG) is mandatory: the operator
+        // is SPSD with a constant null mode that PCG rejects (error 1).
         //
-        // The diagnostic env MARS_DDT_USE_ASSEMBLED_CG=1 still runs the
-        // assembled-CG path so we can verify the assembled matrix equals
-        // the matrix-free apply bit-for-bit (useful when changing the
-        // DDT assembler). It only fires when --solver=cg.
+        // Two activations:
+        //  - --solver=hypre  -> assembled FlexGMRES+AMG (the production target).
+        //  - MARS_DDT_USE_ASSEMBLED_CG=1 with --solver=cg -> assembled CG, the
+        //    bit-identity check vs the matrix-free apply (validates the assembler).
         const char* useAsmEv = std::getenv("MARS_DDT_USE_ASSEMBLED_CG");
-        bool useAssembledCG = (useAsmEv && std::string(useAsmEv) != "0")
-                              && (s.solverKind == SolverKind::CG);
+        bool assembledDiagCG = (useAsmEv && std::string(useAsmEv) != "0")
+                               && (s.solverKind == SolverKind::CG);
+        bool useAssembledCG = (s.solverKind == SolverKind::Hypre && s.nnzDDT > 0)
+                              || assembledDiagCG;
         if (useAssembledCG)
         {
             // DDT + (Hypre or assembled-CG): use the assembled DDT matrix

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -5115,7 +5115,15 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
         // owned DOF with diag < MARS_SLIVER_PIN_FRAC * globalMax (default 1e-6).
         // This makes the pressure system solvable so the real physics (and PSPG)
         // become readable. Off (frac<=0) restores the old behaviour.
-        if (s.d_isPressureBdryDof.size() == static_cast<size_t>(s.numOwnedDofs))
+        //
+        // ONLY for the matrix-free Jacobi-CG path. The Hypre/assembled path uses
+        // BoomerAMG, which handles the conditioning WITHOUT pinning -- and worse,
+        // this pin reads the matrix-free d_diagDDT (whose tiny entries get floored
+        // to 1 -> globalMax=1 -> 1e-6 threshold pins ~all sliver-ish rows, ~220k
+        // DOFs), which would zero most of the RHS via enforcePressureBcRhsKernel
+        // and give phi=0 (no flow). So skip the pin entirely when solving with Hypre.
+        if (s.solverKind != SolverKind::Hypre
+            && s.d_isPressureBdryDof.size() == static_cast<size_t>(s.numOwnedDofs))
         {
             RealType pinFrac = RealType(1e-6);
             const char* evS = std::getenv("MARS_SLIVER_PIN_FRAC");

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -1661,6 +1661,60 @@ __global__ void assembleDDTPerNodeKernel(const KeyType* c0, const KeyType* c1,
 // middle is why this is node-driven, not per-element: cross-element face pairs
 // that share node i must both contribute to A[*, *] through 1/V[i].
 template<typename KeyType, typename RealType>
+// Assemble the PSPG stabilization tau*L into the SAME DDT CSR. L is the linear-
+// tet stiffness L[i][j] = Vol*(dNdx_i . dNdx_j); we add tau*L[i][j] to A[dof_i,dof_j].
+// Element-driven (one thread per element, 4x4 local stencil) -- mirrors the BD
+// assemble. Its support is a SUBSET of the DDT two-hop sparsity, so every (i,j)
+// entry already exists in the pattern (atomicAddSparseEntry no-ops if missing,
+// which would only happen for a node beyond the sparsity neighbour cap). This is
+// the SAME tau*L the matrix-free applyPSPGLaplacianTetKernel adds, so the
+// assembled operator A+tau*L matches the matrix-free A+tau*L. tau is a LENGTH^2
+// (~h^2/24). Beyond consistency, tau*L is a true SPD Laplacian that regularizes
+// the bare Gram-form DDT toward diagonal dominance -> makes Jacobi/AMG tractable.
+template<typename KeyType, typename RealType>
+__global__ void assemblePSPGStiffnessTetKernel(
+    const KeyType* c0, const KeyType* c1, const KeyType* c2, const KeyType* c3,
+    const RealType* nodeX, const RealType* nodeY, const RealType* nodeZ,
+    const int* nodeToDof, const uint8_t* ownership,
+    const int* rowPtr, const int* colInd, int numOwnedDofs,
+    RealType tau, RealType* values, size_t numElem)
+{
+    size_t e = blockIdx.x * blockDim.x + threadIdx.x;
+    if (e >= numElem) return;
+    constexpr int NPE = ElemTraits<TetTag>::NodesPerElem;   // 4
+    const KeyType* cc[4] = {c0, c1, c2, c3};
+    KeyType n[NPE];
+    for (int i = 0; i < NPE; ++i) n[i] = cc[i][e];
+    RealType coords[4][3];
+    for (int i = 0; i < NPE; ++i) {
+        coords[i][0] = nodeX[n[i]];
+        coords[i][1] = nodeY[n[i]];
+        coords[i][2] = nodeZ[n[i]];
+    }
+    RealType det, dNdx[4][3];
+    Tet4CVFEM::jacobian_and_dNdx<RealType>(coords, det, dNdx);
+    // element volume = det/6 (Tet4CVFEM convention); guard degenerate tets.
+    RealType vol = det / RealType(6);
+    if (!(vol > RealType(0))) return;
+    RealType coef = tau * vol;
+    // scatter the 4x4 stiffness; only OWNED rows (dof_i valid) get written.
+    for (int i = 0; i < NPE; ++i) {
+        int dofI = nodeToDof[n[i]];
+        if (ownership[n[i]] != 1) continue;
+        if (dofI < 0 || dofI >= numOwnedDofs) continue;
+        int rs = rowPtr[dofI], re = rowPtr[dofI + 1];
+        for (int j = 0; j < NPE; ++j) {
+            int dofJ = nodeToDof[n[j]];
+            if (dofJ < 0) continue;
+            RealType kij = coef * (dNdx[i][0]*dNdx[j][0]
+                                 + dNdx[i][1]*dNdx[j][1]
+                                 + dNdx[i][2]*dNdx[j][2]);
+            fem::atomicAddSparseEntry(values, colInd, rs, re, dofJ, kij);
+        }
+    }
+}
+
+template<typename KeyType, typename RealType>
 __global__ void assembleDDTPerNodeKernelTet(const KeyType* c0, const KeyType* c1,
                                             const KeyType* c2, const KeyType* c3,
                                             const RealType* areaVecX,
@@ -3640,6 +3694,31 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
         }
     }
     pt.lap("assembly D M^-1 D^T (tet, node-driven)");
+
+    // Assemble PSPG tau*L into the SAME CSR (when usePSPG). Keeps the
+    // stabilization on the assembled/Hypre path (the matrix-free PSPG inside
+    // applyDDTPerNode is bypassed when we solve the assembled operator), AND
+    // regularizes the spectrum toward diagonal dominance so Jacobi/BoomerAMG
+    // can precondition the otherwise 9-OOM-spread Gram-form operator.
+    if (s.usePSPG && s.elementCount > 0)
+    {
+        RealType tauL = (s.pspgTau > RealType(0)) ? s.pspgTau : s.pspgTauAuto;
+        if (tauL > RealType(0))
+        {
+            int eB = int((s.elementCount + s.blockSize - 1) / s.blockSize);
+            assemblePSPGStiffnessTetKernel<KeyType, RealType><<<eB, s.blockSize>>>(
+                std::get<0>(d_conn).data(), std::get<1>(d_conn).data(),
+                std::get<2>(d_conn).data(), std::get<3>(d_conn).data(),
+                s.domain.getNodeX().data(), s.domain.getNodeY().data(), s.domain.getNodeZ().data(),
+                s.d_node_to_dof.data(), d_nodeOwnership.data(),
+                s.d_rowPtrDDT.data(), s.d_colIndDDT.data(), s.numOwnedDofs,
+                tauL, s.d_valuesDDT.data(), s.elementCount);
+            cudaDeviceSynchronize();
+            if (s.rank == 0)
+                std::cout << "  [DDT] assembled PSPG tau*L into CSR (tau=" << std::scientific
+                          << tauL << ")" << std::defaultfloat << "\n";
+        }
+    }
 
     // Same optional diagonal shift A := A + eps*I (MARS_DDT_DIAG_SHIFT) as hex.
     {

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -5617,12 +5617,18 @@ int solveOneComponent(NSStepper<KeyType, RealType, ElementTag>& s,
                       cstone::DeviceVector<RealType>& xVec,
                       cstone::DeviceVector<RealType>& qOut,
                       typename NSStepper<KeyType, RealType, ElementTag>::Matrix& A,
-                      KrylovHint krylov = KrylovHint::PCG)
+                      KrylovHint krylov = KrylovHint::PCG,
+                      bool forceCG = false)
 {
     bool converged = false;
     int iters = 0;
 
-    if (s.solverKind == SolverKind::CG)
+    // forceCG keeps a solve on the in-house matrix-free CG even when
+    // solverKind==Hypre. Used for the VELOCITY matrix (M/dt + nu*K), which is
+    // mass-dominated / near-diagonal -- BoomerAMG is the wrong tool there (it
+    // exits in ~1 iter returning x~0 -> u**=0 -> dead run). Hypre is reserved
+    // for the ill-conditioned DDT PRESSURE operator, which is what needs AMG.
+    if (s.solverKind == SolverKind::CG || forceCG)
     {
         ConjugateGradientSolver<RealType, int, cstone::GpuTag> solver(s.maxIter, s.tolerance);
         solver.setVerbose(false);
@@ -7171,9 +7177,12 @@ void runImplicitDiffusionStep(NSStepper<KeyType, RealType, ElementTag>& s, RealT
             cudaDeviceSynchronize();
         }
 
+        // Velocity matrix is mass-dominated -> force the in-house CG even under
+        // --solver=hypre (Hypre/AMG is reserved for the DDT pressure operator).
         return solveOneComponent<KeyType, RealType, ElementTag>(
             s, b, xVec, qStarStar,
-            bdf2Active ? s.Avel_bdf2 : s.Avel);
+            bdf2Active ? s.Avel_bdf2 : s.Avel,
+            KrylovHint::PCG, /*forceCG=*/true);
     };
 
     s.lastUIters = runImplicit(s.d_uStar, s.d_uStarStar, s.d_uTarget, s.d_velLiftU);

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -5795,12 +5795,25 @@ int solveOneComponent(NSStepper<KeyType, RealType, ElementTag>& s,
                 static_cast<int>(s.globalRowStart), static_cast<int>(s.globalRowEnd),
                 0, static_cast<int>(s.numInteriorGlobal),
                 s.d_localToGlobalDof);
+            // ACCEPT a best-effort pressure solve. A projection step does NOT need
+            // a machine-precision phi every step -- a partial solve still removes
+            // most of the divergence (the leftover is corrected next step). The
+            // strict (final_res<tol) gate threw away a nonzero, useful xVec when
+            // the solve stalled short of 1e-8 (Jacobi got to ~7e-3 -> rejected ->
+            // phi=0 -> dead). Accept when the relative residual is below a usable
+            // threshold (MARS_HYPRE_ACCEPT_RES, default 1e-2) AND xVec is finite.
+            RealType acceptRes = RealType(1e-2);
+            if (const char* ev = std::getenv("MARS_HYPRE_ACCEPT_RES"))
+            { double v = std::atof(ev); if (v > 0) acceptRes = RealType(v); }
+            bool usable = (hypreSolver.getLastFinalResidual() < acceptRes);
+            converged = converged || usable;
             iters = converged ? hypreSolver.getLastIterations() : -2;
             if (s.rank == 0 && hypreSolver.getLastFinalResidual() > s.tolerance * 10)
             {
                 std::cout << "  [hypre-gmres] iters=" << hypreSolver.getLastIterations()
                           << " final_res=" << hypreSolver.getLastFinalResidual()
-                          << " (tol=" << s.tolerance << ", looser than expected)\n";
+                          << " accepted=" << (converged ? 1 : 0)
+                          << " (tol=" << s.tolerance << ")\n";
             }
         }
 #else

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -1646,6 +1646,137 @@ __global__ void assembleDDTPerNodeKernel(const KeyType* c0, const KeyType* c1,
     }
 }
 
+// Tet4 node-driven assembly of A = D M^-1 D^T. Identical math and scatter
+// pattern as assembleDDTPerNodeKernel (hex) -- the analytic stencil
+//   delta_A[i,c] = 0.25 * sigma_g(i) * sigma_f(c) * (A_g . A_f) / V[i]
+// is element-agnostic. Only the geometry differs: tet has 4 corners, 6 SCS
+// edges (d_tetLRSCV), and the per-corner incidence
+//   nodeFaces[4][3] = {{0,2,3},{0,1,4},{1,2,5},{3,4,5}}
+// derived from d_tetLRSCV faces 0(0,1) 1(1,2) 2(0,2) 3(0,3) 4(1,3) 5(2,3):
+//   node0 in faces {0L,2L,3L}, node1 in {0R,1L,4L}, node2 in {1R,2R,5L},
+//   node3 in {3R,4R,5R}.
+// This MUST stay in lock-step with buildDDTEdgeListKernelTet so every column
+// the assembler writes exists in the sparsity pattern. Area vectors are
+// per-element-per-SCS at offset e*6+gFace. The per-node M^-1 (V[i]) in the
+// middle is why this is node-driven, not per-element: cross-element face pairs
+// that share node i must both contribute to A[*, *] through 1/V[i].
+template<typename KeyType, typename RealType>
+__global__ void assembleDDTPerNodeKernelTet(const KeyType* c0, const KeyType* c1,
+                                            const KeyType* c2, const KeyType* c3,
+                                            const RealType* areaVecX,
+                                            const RealType* areaVecY,
+                                            const RealType* areaVecZ,
+                                            const KeyType* nodeToElemOffsets,
+                                            const KeyType* nodeToElemList,
+                                            const int* nodeToDof,
+                                            const uint8_t* ownership,
+                                            const RealType* lumpedMassNode,
+                                            const int* rowPtr,
+                                            const int* colInd,
+                                            int numOwnedDofs,
+                                            RealType* values,
+                                            size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (ownership[i] != 1) return;
+    int dofI = nodeToDof[i];
+    if (dofI < 0 || dofI >= numOwnedDofs) return;
+
+    RealType vi = lumpedMassNode[i];
+    if (!(vi > RealType(0))) return;
+    RealType invVi = RealType(1) / vi;
+
+    constexpr int nodeFaces[4][3] = { {0,2,3}, {0,1,4}, {1,2,5}, {3,4,5} };
+
+    // MAX_FACES bounds the raw incident-FACE count (one record per element*face
+    // touching i). buildDDTSparsityTet bounds distinct NEIGHBOUR DOFs at 48;
+    // the two cap different quantities, but both exceed realistic tet valence
+    // (1-ring ~20-30, faces ~60-90). If a pathological node exceeded the 48
+    // neighbour cap, the sparsity would lack a column this kernel writes and
+    // atomicAddSparseEntry would silently drop it -> the [DDT-health] check and
+    // MARS_DDT_PROBE_DIFF would flag the resulting mismatch.
+    constexpr int MAX_FACES = ElemTraits<TetTag>::MaxFacesPerNode;
+    int      incCount = 0;
+    KeyType  incOtherNode[MAX_FACES];
+    int      incOtherDof[MAX_FACES];
+    RealType incAx[MAX_FACES], incAy[MAX_FACES], incAz[MAX_FACES];
+    int8_t   incSigma[MAX_FACES];
+
+    KeyType eStart = nodeToElemOffsets[i];
+    KeyType eEnd   = nodeToElemOffsets[i + 1];
+    for (KeyType ep = eStart; ep < eEnd; ++ep)
+    {
+        KeyType e = nodeToElemList[ep];
+        KeyType en[4] = {c0[e], c1[e], c2[e], c3[e]};
+        int iLocal = -1;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) if (en[k] == (KeyType)i) iLocal = k;
+        if (iLocal < 0) continue;
+
+        #pragma unroll
+        for (int gi = 0; gi < 3; ++gi)
+        {
+            if (incCount >= MAX_FACES) break;
+            int gFace = nodeFaces[iLocal][gi];
+            int gL_local = d_tetLRSCV[gFace * 2];
+            int gR_local = d_tetLRSCV[gFace * 2 + 1];
+            int sigma = (iLocal == gL_local) ? +1 : -1;
+            int otherLocal = (iLocal == gL_local) ? gR_local : gL_local;
+            KeyType otherNode = en[otherLocal];
+            size_t off = e * 6 + gFace;
+
+            incOtherNode[incCount] = otherNode;
+            incOtherDof[incCount]  = nodeToDof[otherNode];
+            incAx[incCount]        = areaVecX[off];
+            incAy[incCount]        = areaVecY[off];
+            incAz[incCount]        = areaVecZ[off];
+            incSigma[incCount]     = int8_t(sigma);
+            incCount++;
+        }
+    }
+
+    int rs_i = rowPtr[dofI];
+    int re_i = rowPtr[dofI + 1];
+
+    for (int g = 0; g < incCount; ++g)
+    {
+        RealType agx = incAx[g], agy = incAy[g], agz = incAz[g];
+        int sg_i = incSigma[g];
+        KeyType otherG_node = incOtherNode[g];
+        int otherG_dof = -1;
+        int rs_og = 0, re_og = 0;
+        if (ownership[otherG_node] == 1)
+        {
+            otherG_dof = nodeToDof[otherG_node];
+            if (otherG_dof >= 0 && otherG_dof < numOwnedDofs)
+            {
+                rs_og = rowPtr[otherG_dof];
+                re_og = rowPtr[otherG_dof + 1];
+            }
+            else otherG_dof = -1;
+        }
+
+        for (int f = 0; f < incCount; ++f)
+        {
+            RealType dot   = agx * incAx[f] + agy * incAy[f] + agz * incAz[f];
+            RealType scale = RealType(0.25) * dot * invVi;
+            int sf_i = incSigma[f];
+            int otherF_dof = incOtherDof[f];
+            RealType base = RealType(sg_i) * RealType(sf_i) * scale;
+            fem::atomicAddSparseEntry(values, colInd, rs_i, re_i, dofI,  base);
+            if (otherF_dof >= 0)
+                fem::atomicAddSparseEntry(values, colInd, rs_i, re_i, otherF_dof, -base);
+            if (otherG_dof >= 0)
+            {
+                fem::atomicAddSparseEntry(values, colInd, rs_og, re_og, dofI, -base);
+                if (otherF_dof >= 0)
+                    fem::atomicAddSparseEntry(values, colInd, rs_og, re_og, otherF_dof, base);
+            }
+        }
+    }
+}
+
 // Divide accumulator by V; write to per-node output (kept node-indexed for the
 // predictor/corrector apply, which iterates over nodes).
 template<typename RealType>
@@ -3274,11 +3405,13 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
     // and emits exactly the pairs the assembler writes; verified bit-exact
     // against applyDDTPerNode via MARS_DDT_PROBE_DIFF=1.
     //
-    // Hex-only: buildDDTSparsity / assembleDDTPerNodeKernel spell std::get<7>
-    // and the fixed hex 8-corner / nodeFaces[8][3] incidence. The tet DDT
-    // operator is a separate follow-up; if constexpr keeps the whole block
-    // (sparsity, node-driven assembly, health check, diagonal shift) out of
-    // the tet compile entirely.
+    // Hex branch: buildDDTSparsity / assembleDDTPerNodeKernel spell std::get<7>
+    // and the fixed hex 8-corner / nodeFaces[8][3] incidence. The TET branch
+    // (else if constexpr below) is the parallel path: buildDDTSparsityTet /
+    // assembleDDTPerNodeKernelTet with the 4-corner / nodeFaces[4][3] / 6-SCS
+    // incidence. if constexpr keeps each block's std::get<>/table out of the
+    // other element's compile. Both produce the same assembled A = D M^-1 D^T;
+    // the matrix-free applyDDTPerNode path is independent and untouched.
     if constexpr (std::is_same_v<ElementTag, HexTag>)
     {
     const auto& d_n2eOff_sparsity  = s.domain.getNodeToElementOffsets();
@@ -3411,6 +3544,126 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
         }
     }
     } // end if constexpr hex (DDT operator block)
+
+    // Tet DDT operator: same assembled A = D M^-1 D^T path as hex above, but
+    // tet has 4 corners / 6 SCS edges so it goes through buildDDTSparsityTet
+    // (4 conn columns, nodeFaces[4][3]) and assembleDDTPerNodeKernelTet. The
+    // matrix-free applyDDTPerNode (the path the user keeps) is UNCHANGED; this
+    // is the additive assembled path for Hypre. Bit-exactness against the
+    // matrix-free operator is checked via MARS_DDT_PROBE_DIFF (tet branch below).
+    // NOTE: when PSPG is on (s.usePSPG), applyDDTPerNode also adds tau*L; that
+    // term is NOT in this assembled A, so the probe must run with PSPG off to
+    // see a clean match (documented at the probe).
+    else if constexpr (std::is_same_v<ElementTag, TetTag>)
+    {
+    const auto& d_n2eOff_sparsity  = s.domain.getNodeToElementOffsets();
+    const auto& d_n2eList_sparsity = s.domain.getNodeToElementList();
+    s.d_rowPtrDDT.resize(s.numTotalDofs + 1);
+    s.d_diagPtrDDT.resize(s.numTotalDofs);
+    s.nnzDDT = CvfemSparsityBuilder<KeyType>::buildDDTSparsityTet(
+        std::get<0>(d_conn).data(), std::get<1>(d_conn).data(),
+        std::get<2>(d_conn).data(), std::get<3>(d_conn).data(),
+        s.elementCount, s.nodeCount,
+        d_n2eOff_sparsity.data(), d_n2eList_sparsity.data(),
+        s.d_node_to_dof.data(), s.numTotalDofs,
+        s.d_rowPtrDDT.data(), nullptr, nullptr, 0);
+    s.d_colIndDDT.resize(s.nnzDDT);
+    CvfemSparsityBuilder<KeyType>::buildDDTSparsityTet(
+        std::get<0>(d_conn).data(), std::get<1>(d_conn).data(),
+        std::get<2>(d_conn).data(), std::get<3>(d_conn).data(),
+        s.elementCount, s.nodeCount,
+        d_n2eOff_sparsity.data(), d_n2eList_sparsity.data(),
+        s.d_node_to_dof.data(), s.numTotalDofs,
+        s.d_rowPtrDDT.data(), s.d_colIndDDT.data(), s.d_diagPtrDDT.data(), 0);
+    s.d_valuesDDT.resize(s.nnzDDT);
+    thrust::fill(thrust::device_pointer_cast(s.d_valuesDDT.data()),
+                 thrust::device_pointer_cast(s.d_valuesDDT.data() + s.nnzDDT),
+                 RealType(0));
+    {
+        const auto& d_n2eOff  = s.domain.getNodeToElementOffsets();
+        const auto& d_n2eList = s.domain.getNodeToElementList();
+        if (s.nodeCount > 0)
+        {
+            int nBlocks = int((s.nodeCount + s.blockSize - 1) / s.blockSize);
+            assembleDDTPerNodeKernelTet<KeyType, RealType><<<nBlocks, s.blockSize>>>(
+                std::get<0>(d_conn).data(), std::get<1>(d_conn).data(),
+                std::get<2>(d_conn).data(), std::get<3>(d_conn).data(),
+                s.d_areaVec_x.data(), s.d_areaVec_y.data(), s.d_areaVec_z.data(),
+                d_n2eOff.data(), d_n2eList.data(),
+                s.d_node_to_dof.data(), d_nodeOwnership.data(),
+                s.d_massNode.data(),
+                s.d_rowPtrDDT.data(), s.d_colIndDDT.data(), s.numOwnedDofs,
+                s.d_valuesDDT.data(), s.nodeCount);
+            cudaDeviceSynchronize();
+        }
+        // Same post-assembly health check as the hex branch (rank 0 only).
+        if (s.rank == 0)
+        {
+            std::vector<int> hRowPtr(s.numOwnedDofs + 1);
+            cudaMemcpy(hRowPtr.data(), s.d_rowPtrDDT.data(),
+                       (s.numOwnedDofs + 1) * sizeof(int), cudaMemcpyDeviceToHost);
+            std::vector<int> hColInd(hRowPtr[s.numOwnedDofs]);
+            std::vector<RealType> hVals(hRowPtr[s.numOwnedDofs]);
+            cudaMemcpy(hColInd.data(), s.d_colIndDDT.data(),
+                       hRowPtr[s.numOwnedDofs] * sizeof(int), cudaMemcpyDeviceToHost);
+            cudaMemcpy(hVals.data(), s.d_valuesDDT.data(),
+                       hRowPtr[s.numOwnedDofs] * sizeof(RealType), cudaMemcpyDeviceToHost);
+            int emptyRows = 0, missingDiag = 0, zeroDiag = 0, negDiag = 0;
+            int firstEmpty = -1, firstMissingDiag = -1;
+            RealType minDiag = 1e30, maxDiag = -1e30;
+            for (int r = 0; r < s.numOwnedDofs; ++r)
+            {
+                int rs = hRowPtr[r], re = hRowPtr[r + 1];
+                if (re == rs) { emptyRows++; if (firstEmpty<0) firstEmpty=r; continue; }
+                int diagIdx = -1;
+                for (int k = rs; k < re; ++k) if (hColInd[k] == r) { diagIdx = k; break; }
+                if (diagIdx < 0) {
+                    missingDiag++;
+                    if (firstMissingDiag<0) firstMissingDiag=r;
+                    continue;
+                }
+                RealType d = hVals[diagIdx];
+                if (d == RealType(0)) zeroDiag++;
+                else if (d < RealType(0)) negDiag++;
+                if (d < minDiag) minDiag = d;
+                if (d > maxDiag) maxDiag = d;
+            }
+            std::cout << "  [DDT-health] emptyRows=" << emptyRows
+                      << " missingDiag=" << missingDiag
+                      << " zeroDiag=" << zeroDiag
+                      << " negDiag=" << negDiag
+                      << " diag range=[" << minDiag << ", " << maxDiag << "]\n";
+            if (emptyRows > 0)
+                std::cout << "    first empty row: " << firstEmpty << "\n";
+            if (missingDiag > 0)
+                std::cout << "    first missing-diag row: " << firstMissingDiag << "\n";
+        }
+    }
+    pt.lap("assembly D M^-1 D^T (tet, node-driven)");
+
+    // Same optional diagonal shift A := A + eps*I (MARS_DDT_DIAG_SHIFT) as hex.
+    {
+        const char* shiftEnv = std::getenv("MARS_DDT_DIAG_SHIFT");
+        RealType eps = (shiftEnv) ? RealType(std::atof(shiftEnv)) : RealType(0);
+        if (eps > RealType(0))
+        {
+            int n = s.numOwnedDofs;
+            const int* dpDdt = s.d_diagPtrDDT.data();
+            RealType* vDdt   = s.d_valuesDDT.data();
+            thrust::for_each(thrust::device,
+                thrust::counting_iterator<int>(0),
+                thrust::counting_iterator<int>(n),
+                [dpDdt, vDdt, eps] __device__ (int r) {
+                    vDdt[dpDdt[r]] += eps;
+                });
+            cudaDeviceSynchronize();
+            if (s.rank == 0)
+                std::cout << "  [DDT] diagonal shift A := A + "
+                          << std::scientific << eps << " * I (Hypre SPD regularization)\n"
+                          << std::defaultfloat;
+        }
+    }
+    } // end else if constexpr tet (DDT operator block)
 
     // Add M/dt to the velocity matrix diagonal -> (M/dt + nu K).
     {
@@ -4534,9 +4787,12 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
     }
 
     // These enforce Dirichlet BCs on the ASSEMBLED DDT matrix (s.d_*DDT). Those
-    // buffers are only built inside the if constexpr(hex) DDT block above, so
-    // nnzDDT==0 for tet / any run without an assembled DDT operator -- skip,
-    // or the kernels dereference a null DDT rowPtr (illegal access). The K-path
+    // buffers are built inside the if constexpr(hex)/else if constexpr(tet) DDT
+    // block above; nnzDDT==0 for any run without an assembled DDT operator (e.g.
+    // the matrix-free-only path) -- skip then, or the kernels dereference a null
+    // DDT rowPtr (illegal access). The identity rows written here match the
+    // identity-row enforcement applyDDTPerNode does at solve time, which is why
+    // MARS_DDT_PROBE_DIFF still matches at pinned/masked rows. The K-path
     // velocity/pressure matrices get their own BC enforcement separately.
     if (s.nnzDDT > 0
         && (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Channel
@@ -4845,13 +5101,31 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
     // exactly which rows and how much. Used to debug the node-driven
     // assembler vs matrix-free identity.
     //
-    // Hex-only: applyDDTPerNode is a no-op for tet and the assembled DDT CSR
-    // (s.d_rowPtrDDT etc.) is only built in the hex branch above. if constexpr
-    // keeps the whole probe out of the tet compile.
-    if constexpr (std::is_same_v<ElementTag, HexTag>)
+    // Runs for BOTH hex and tet now: applyDDTPerNode is templated and the
+    // assembled DDT CSR (s.d_rowPtrDDT etc.) is built in both the hex and tet
+    // branches above. The probe gathers e_k through the matrix-free operator
+    // and the assembled SpMV and prints the worst per-row diff -- a clean
+    // (~1e-12) result proves A_assembled == A_matrixfree for that element type.
+    // TET CAVEAT: when s.usePSPG is on, the matrix-free applyDDTPerNode adds
+    // tau*L (applyPSPGLaplacianTetKernel) which is NOT in the assembled A, so
+    // the probe would show a spurious diff. Skip+warn in that case; run the
+    // probe with PSPG disabled to validate the pure D M^-1 D^T assembly.
+    if constexpr (std::is_same_v<ElementTag, HexTag> || std::is_same_v<ElementTag, TetTag>)
     if (s.bcKind != NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
         && std::getenv("MARS_DDT_PROBE_DIFF"))
     {
+        // PSPG guard: for tet, the matrix-free applyDDTPerNode adds tau*L when
+        // s.usePSPG, but the assembled A is pure D M^-1 D^T -> the probe would
+        // diff. Skip (with a note) so the probe only ever reports a TRUE
+        // assembly defect, not the expected PSPG term mismatch.
+        if (std::is_same_v<ElementTag, TetTag> && s.usePSPG)
+        {
+            if (s.rank == 0)
+                std::cout << "  [MARS_DDT_PROBE_DIFF] SKIPPED for tet: s.usePSPG adds "
+                             "tau*L to the matrix-free operator that the assembled A omits; "
+                             "rerun with PSPG off to validate pure D M^-1 D^T.\n";
+        }
+        else {
         // Choose probe DOFs scattered across the owned range. Skip dof 0
         // because in cavity mode it's the pressure pin and BC enforcement
         // (row-zero + col-zero) is INTENTIONALLY applied to the assembled
@@ -4970,6 +5244,7 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
                 }
             }
         }
+        } // end else (PSPG-off probe body)
     }
 
 #ifdef MARS_ENABLE_HYPRE

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -5798,6 +5798,20 @@ int solveOneComponent(NSStepper<KeyType, RealType, ElementTag>& s,
     }
     cudaDeviceSynchronize();
 
+    // One-shot diagnostic: did the solve converge, and is xVec nonzero?
+    // Pins down whether phi=0 is (a) converged=false -> no scatter, or
+    // (b) scatter happens but xVec~0. Env-gated, rank 0.
+    if (std::getenv("MARS_SOLVE_TRACE") && s.rank == 0 && s.numOwnedDofs > 0)
+    {
+        auto xp = thrust::device_pointer_cast(xVec.data());
+        RealType xMax = thrust::transform_reduce(thrust::device, xp, xp + s.numOwnedDofs,
+            [] __device__ (RealType v) -> RealType { return fabs(v); },
+            RealType(0), thrust::maximum<RealType>());
+        std::cout << "  [solve-trace] converged=" << (converged ? 1 : 0)
+                  << " iters=" << iters << " |xVec|max=" << std::scientific << xMax
+                  << std::defaultfloat << "\n";
+    }
+
     // Only scatter a CONVERGED solution into qOut. A failed Hypre solve
     // (error 1 on the near-singular DDT operator) can leave xVec holding
     // partial garbage; scattering it would poison qOut (= phi) and the

--- a/backend/distributed/unstructured/fem/mars_sparsity_builder.hpp
+++ b/backend/distributed/unstructured/fem/mars_sparsity_builder.hpp
@@ -138,6 +138,27 @@ public:
         int* d_colInd,
         int* d_diagPtr = nullptr,
         cudaStream_t stream = 0);
+
+    // Tet4 variant of buildDDTSparsity. Same node-driven two-hop pattern, but
+    // tet has 4 corners and 6 SCS edges (d_tetLRSCV), so the per-corner
+    // incidence table and the per-node neighbour budget differ. Tet meshes have
+    // much higher vertex valence than hex, so the neighbour cap is larger.
+    // Takes only 4 connectivity columns (tet has no conn4..conn7).
+    static int buildDDTSparsityTet(
+        const KeyType* d_conn0,
+        const KeyType* d_conn1,
+        const KeyType* d_conn2,
+        const KeyType* d_conn3,
+        size_t numElements,
+        size_t numNodes,
+        const KeyType* d_nodeToElemOffsets,
+        const KeyType* d_nodeToElemList,
+        const int* d_nodeToDof,
+        int numDofs,
+        int* d_rowPtr,
+        int* d_colInd,
+        int* d_diagPtr = nullptr,
+        cudaStream_t stream = 0);
 };
 
 // GPU kernel implementation (free function)
@@ -920,6 +941,218 @@ int CvfemSparsityBuilder<KeyType>::buildDDTSparsity(
     d_edgeCol.resize(nnz);
 
     // Build rowPtr via per-row counts + exclusive scan.
+    thrust::device_vector<int> d_rowCounts(numDofs, 0);
+    thrust::for_each(
+        thrust::device, d_edgeRow.begin(), d_edgeRow.end(),
+        [counts = thrust::raw_pointer_cast(d_rowCounts.data())] __device__(int row) {
+            atomicAdd(&counts[row], 1);
+        });
+
+    thrust::device_vector<int> d_rowPtrTemp(numDofs + 1);
+    thrust::exclusive_scan(thrust::device, d_rowCounts.begin(), d_rowCounts.end(), d_rowPtrTemp.begin());
+    int lastCount = 0, lastPtr = 0;
+    cudaMemcpy(&lastCount, thrust::raw_pointer_cast(d_rowCounts.data() + numDofs - 1),
+               sizeof(int), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&lastPtr, thrust::raw_pointer_cast(d_rowPtrTemp.data() + numDofs - 1),
+               sizeof(int), cudaMemcpyDeviceToHost);
+    int finalVal = lastPtr + lastCount;
+    cudaMemcpy(thrust::raw_pointer_cast(d_rowPtrTemp.data() + numDofs), &finalVal,
+               sizeof(int), cudaMemcpyHostToDevice);
+
+    cudaMemcpy(d_rowPtr, thrust::raw_pointer_cast(d_rowPtrTemp.data()),
+               (numDofs + 1) * sizeof(int), cudaMemcpyDeviceToDevice);
+
+    if (d_colInd != nullptr)
+    {
+        cudaMemcpy(d_colInd, thrust::raw_pointer_cast(d_edgeCol.data()),
+                   nnz * sizeof(int), cudaMemcpyDeviceToDevice);
+    }
+
+    if (d_diagPtr != nullptr && d_colInd != nullptr)
+    {
+        thrust::for_each(
+            thrust::device, thrust::make_counting_iterator(0), thrust::make_counting_iterator(numDofs),
+            [rowPtr = d_rowPtr, colInd = d_colInd, diagPtr = d_diagPtr] __device__(int row)
+            {
+                int start = rowPtr[row];
+                int end   = rowPtr[row + 1];
+                int lo = start, hi = end;
+                while (lo < hi)
+                {
+                    int mid = lo + (hi - lo) / 2;
+                    if (colInd[mid] < row) lo = mid + 1;
+                    else hi = mid;
+                }
+                diagPtr[row] = lo;
+            });
+    }
+
+    return nnz;
+}
+
+// Tet4 DDT sparsity edge-list kernel. Same node-driven two-hop emission as
+// buildDDTEdgeListKernel, but tet has 4 corners and 6 SCS edges, so the
+// per-corner incidence is nodeFacesTet[4][3] (derived from d_tetLRSCV):
+//   face: 0(0,1) 1(1,2) 2(0,2) 3(0,3) 4(1,3) 5(2,3)
+//   node0 -> faces {0,2,3}, node1 -> {0,1,4}, node2 -> {1,2,5}, node3 -> {3,4,5}
+// This MUST stay in lock-step with the assembleDDTPerNodeKernelTet enumeration
+// in the pump solver, or the assembler will write columns the pattern lacks.
+template<typename KeyType>
+__global__ void buildDDTEdgeListKernelTet(
+    const KeyType* __restrict__ conn0,
+    const KeyType* __restrict__ conn1,
+    const KeyType* __restrict__ conn2,
+    const KeyType* __restrict__ conn3,
+    const KeyType* __restrict__ nodeToElemOffsets,
+    const KeyType* __restrict__ nodeToElemList,
+    const int* __restrict__ nodeToDof,
+    size_t numNodes,
+    int maxEdgesPerNode,
+    int* edgeListRow,
+    int* edgeListCol)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+
+    int dofI = nodeToDof[i];
+    size_t base = i * size_t(maxEdgesPerNode);
+
+    for (int s = 0; s < maxEdgesPerNode; ++s)
+    {
+        edgeListRow[base + s] = -1;
+        edgeListCol[base + s] = -1;
+    }
+
+    if (dofI < 0) return; // orphan/ghost-only node with no owned DOF
+
+    // Local copy of the Tet4 SCS L/R pairs (same as d_tetLRSCV in
+    // mars_element_traits.hpp); kept local so this header does not depend on
+    // that constant, matching buildSparsityEdgeListKernelTet below.
+    const int lr_pairs[12] = {0,1, 1,2, 0,2, 0,3, 1,3, 2,3};
+    constexpr int nodeFaces[4][3] = { {0,2,3}, {0,1,4}, {1,2,5}, {3,4,5} };
+
+    // Distinct neighbour DOFs (the node's 1-ring), NOT the raw incident-face
+    // count. A high-valence tet interior node has a 1-ring of ~20-30 nodes; 48
+    // is a safe cap. Kept small because the caller allocates (cap+1)^2 edge
+    // slots PER NODE -- a large cap blows VRAM on big meshes. MUST equal
+    // kMaxOthers in buildDDTSparsityTet so the (cap+1)^2 slot budget matches.
+    constexpr int MAX_OTHERS = 48;
+    int otherDofs[MAX_OTHERS];
+    int otherCount = 0;
+
+    KeyType eStart = nodeToElemOffsets[i];
+    KeyType eEnd   = nodeToElemOffsets[i + 1];
+    for (KeyType ep = eStart; ep < eEnd; ++ep)
+    {
+        KeyType e = nodeToElemList[ep];
+        KeyType en[4] = {conn0[e], conn1[e], conn2[e], conn3[e]};
+        int iLocal = -1;
+        for (int k = 0; k < 4; ++k) if (en[k] == (KeyType)i) iLocal = k;
+        if (iLocal < 0) continue;
+
+        for (int gi = 0; gi < 3; ++gi)
+        {
+            if (otherCount >= MAX_OTHERS) break;
+            int gFace = nodeFaces[iLocal][gi];
+            int gL_local = lr_pairs[gFace * 2];
+            int gR_local = lr_pairs[gFace * 2 + 1];
+            int otherLocal = (iLocal == gL_local) ? gR_local : gL_local;
+            KeyType otherNode = en[otherLocal];
+            int otherDof = nodeToDof[otherNode];
+            if (otherDof < 0) continue;
+            bool seen = false;
+            for (int s = 0; s < otherCount; ++s)
+                if (otherDofs[s] == otherDof) { seen = true; break; }
+            if (seen) continue;
+            otherDofs[otherCount++] = otherDof;
+        }
+    }
+
+    int slot = 0;
+    auto emit = [&](int r, int c) {
+        if (slot < maxEdgesPerNode)
+        {
+            edgeListRow[base + slot] = r;
+            edgeListCol[base + slot] = c;
+            ++slot;
+        }
+    };
+
+    emit(dofI, dofI);
+    for (int s = 0; s < otherCount; ++s)
+    {
+        emit(dofI, otherDofs[s]);
+        emit(otherDofs[s], dofI);
+    }
+    for (int s = 0; s < otherCount; ++s)
+        for (int t = 0; t < otherCount; ++t)
+            emit(otherDofs[s], otherDofs[t]);
+}
+
+template<typename KeyType>
+int CvfemSparsityBuilder<KeyType>::buildDDTSparsityTet(
+    const KeyType* d_conn0,
+    const KeyType* d_conn1,
+    const KeyType* d_conn2,
+    const KeyType* d_conn3,
+    size_t numElements,
+    size_t numNodes,
+    const KeyType* d_nodeToElemOffsets,
+    const KeyType* d_nodeToElemList,
+    const int* d_nodeToDof,
+    int numDofs,
+    int* d_rowPtr,
+    int* d_colInd,
+    int* d_diagPtr,
+    cudaStream_t stream)
+{
+    (void)numElements; // not needed -- node->element CSR encodes it
+    // Distinct-neighbour cap for the 1-ring (~20-30 for a high-valence tet
+    // interior node). (cap+1)^2 edge slots per node; 48 keeps VRAM bounded
+    // (49^2=2401 slots/node) while leaving generous headroom. MUST equal
+    // MAX_OTHERS in buildDDTEdgeListKernelTet (the kernel writes (cap+1)^2 pairs).
+    constexpr int kMaxOthers       = 48;
+    constexpr int kMaxEdgesPerNode = (kMaxOthers + 1) * (kMaxOthers + 1);
+    size_t numEdges = numNodes * size_t(kMaxEdgesPerNode);
+
+    thrust::device_vector<int> d_edgeRow(numEdges);
+    thrust::device_vector<int> d_edgeCol(numEdges);
+
+    int blockSize = 256;
+    int numBlocks = (numNodes + blockSize - 1) / blockSize;
+    buildDDTEdgeListKernelTet<<<numBlocks, blockSize, 0, stream>>>(
+        d_conn0, d_conn1, d_conn2, d_conn3,
+        d_nodeToElemOffsets, d_nodeToElemList,
+        d_nodeToDof, numNodes, kMaxEdgesPerNode,
+        thrust::raw_pointer_cast(d_edgeRow.data()),
+        thrust::raw_pointer_cast(d_edgeCol.data()));
+
+    auto new_end = thrust::remove_if(
+        thrust::device,
+        thrust::make_zip_iterator(thrust::make_tuple(d_edgeRow.begin(), d_edgeCol.begin())),
+        thrust::make_zip_iterator(thrust::make_tuple(d_edgeRow.end(), d_edgeCol.end())),
+        [] __device__(const thrust::tuple<int, int>& t) { return thrust::get<0>(t) < 0; });
+
+    size_t validEntries = thrust::distance(
+        thrust::make_zip_iterator(thrust::make_tuple(d_edgeRow.begin(), d_edgeCol.begin())), new_end);
+    d_edgeRow.resize(validEntries);
+    d_edgeCol.resize(validEntries);
+
+    thrust::sort(
+        thrust::device,
+        thrust::make_zip_iterator(thrust::make_tuple(d_edgeRow.begin(), d_edgeCol.begin())),
+        thrust::make_zip_iterator(thrust::make_tuple(d_edgeRow.end(), d_edgeCol.end())));
+
+    auto unique_end = thrust::unique(
+        thrust::device,
+        thrust::make_zip_iterator(thrust::make_tuple(d_edgeRow.begin(), d_edgeCol.begin())),
+        thrust::make_zip_iterator(thrust::make_tuple(d_edgeRow.end(), d_edgeCol.end())));
+
+    int nnz = thrust::distance(
+        thrust::make_zip_iterator(thrust::make_tuple(d_edgeRow.begin(), d_edgeCol.begin())), unique_end);
+    d_edgeRow.resize(nnz);
+    d_edgeCol.resize(nnz);
+
     thrust::device_vector<int> d_rowCounts(numDofs, 0);
     thrust::for_each(
         thrust::device, d_edgeRow.begin(), d_edgeRow.end(),

--- a/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
+++ b/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
@@ -33,6 +33,16 @@ public:
           solver_(nullptr), precond_(nullptr), A_hypre_(nullptr),
           b_hypre_(nullptr), x_hypre_(nullptr), verbose_(true), precondType_(precondType),
           kDim_(kDim) {
+        // FlexGMRES vs plain GMRES. FlexGMRES allows a VARYING (non-fixed)
+        // preconditioner -- the right choice when the preconditioner is itself
+        // an iterative solve (BoomerAMG V-cycles are not a fixed linear op once
+        // you use >1 sweep / aggressive coarsening), which can break plain
+        // GMRES's assumption of a constant M. Default ON for BoomerAMG (where it
+        // matters), OFF for diagonal Jacobi (fixed -> plain GMRES is fine).
+        // Env MARS_HYPRE_FLEXGMRES=1/0 forces it on/off.
+        useFlexGmres_ = (precondType == BOOMERAMG);
+        const char* fev = std::getenv("MARS_HYPRE_FLEXGMRES");
+        if (fev) useFlexGmres_ = (std::string(fev) != "0");
     }
 
     ~HypreGMRESSolver() {
@@ -263,6 +273,19 @@ public:
             HYPRE_BoomerAMGSetMaxCoarseSize(precond_, 128); // upper bound on coarsest direct solve
             HYPRE_BoomerAMGSetTol(precond_, 0.0);           // GMRES controls outer tol
             HYPRE_BoomerAMGSetMaxIter(precond_, 1);         // 1 V-cycle per GMRES iter
+            // Note: an earlier attempt called HYPRE_BoomerAMGSetInterpVectors
+            // with the constant-of-ones to declare the near-null mode of the
+            // pressure-Poisson. That call is REJECTED with HYPRE_ERROR_GENERIC
+            // by hypre/parcsr_ls/par_amg_setup.c:506 unless paired with
+            // SetNodal(1) + SetInterpVecVariant(2) + SetInterpVecQMax(...) +
+            // SetSmoothInterpVectors(0) (cf. MFEM hypre.cpp:5152-5160).
+            // Since the assembled DDT operator also fails BoomerAMG for a
+            // separate reason -- its boundary rows hold POSITIVE off-diagonals
+            // (non-M-matrix), which BoomerAMG's classical strength-of-
+            // connection drops -- we instead route DDT pressure through the
+            // matrix-free CG path (with Jacobi preconditioning) entirely, and
+            // keep this wrapper for the K-path / velocity solves where the
+            // matrix IS an M-matrix and AMG works as designed.
             // MARS_HYPRE_VERBOSE=1 also enables BoomerAMG setup-phase prints
             // (level structure, complexity, row sums per level).
             {
@@ -276,17 +299,21 @@ public:
             precond_ = (HYPRE_Solver) parcsr_A_;
         }
 
-        if (verbose_ && rank == 0) std::cout << "Creating GMRES solver..." << std::endl;
-        HYPRE_ParCSRGMRESCreate(comm_, &solver_);
+        const char* krylovName = useFlexGmres_ ? "FlexGMRES" : "GMRES";
+        if (verbose_ && rank == 0) std::cout << "Creating " << krylovName << " solver..." << std::endl;
+        if (useFlexGmres_) HYPRE_ParCSRFlexGMRESCreate(comm_, &solver_);
+        else               HYPRE_ParCSRGMRESCreate(comm_, &solver_);
         if (!solver_) {
-            std::cerr << "Failed to create Hypre GMRES solver" << std::endl;
+            std::cerr << "Failed to create Hypre " << krylovName << " solver" << std::endl;
             return false;
         }
+        // FlexGMRES and GMRES share the HYPRE_GMRES* setter/getter symbols
+        // (FlexGMRES is a GMRES variant in Hypre); only Create/Setup/Solve/
+        // Destroy and SetPrecond differ. So the Set* calls below are common.
         HYPRE_GMRESSetMaxIter(solver_, maxIter_);
         HYPRE_GMRESSetTol(solver_, tolerance_);
         HYPRE_GMRESSetKDim(solver_, kDim_);  // restart length
-        // GMRES print level: 0 silent, 2 per-iter residuals. Env var
-        // MARS_HYPRE_VERBOSE=1 turns it on without rebuild.
+        // print level: 0 silent, 2 per-iter residuals. Env MARS_HYPRE_VERBOSE=1.
         {
             const char* ev = std::getenv("MARS_HYPRE_VERBOSE");
             int gmresPrint = (verbose_ || (ev && std::string(ev) != "0")) ? 2 : 0;
@@ -295,21 +322,35 @@ public:
 
         if (precondType_ == BOOMERAMG && precond_) {
             if (verbose_ && rank == 0) std::cout << "Setting BoomerAMG preconditioner..." << std::endl;
-            HYPRE_GMRESSetPrecond(solver_,
-                               (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_BoomerAMGSolve,
-                               (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_BoomerAMGSetup,
-                               precond_);
+            if (useFlexGmres_)
+                HYPRE_FlexGMRESSetPrecond(solver_,
+                                   (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_BoomerAMGSolve,
+                                   (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_BoomerAMGSetup,
+                                   precond_);
+            else
+                HYPRE_GMRESSetPrecond(solver_,
+                                   (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_BoomerAMGSolve,
+                                   (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_BoomerAMGSetup,
+                                   precond_);
         } else if (precondType_ == JACOBI) {
             if (verbose_ && rank == 0) std::cout << "Setting Jacobi (diagonal) preconditioner..." << std::endl;
-            HYPRE_GMRESSetPrecond(solver_,
-                               (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_ParCSRDiagScale,
-                               (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_ParCSRDiagScaleSetup,
-                               (HYPRE_Solver) parcsr_A_);
+            if (useFlexGmres_)
+                HYPRE_FlexGMRESSetPrecond(solver_,
+                                   (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_ParCSRDiagScale,
+                                   (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_ParCSRDiagScaleSetup,
+                                   (HYPRE_Solver) parcsr_A_);
+            else
+                HYPRE_GMRESSetPrecond(solver_,
+                                   (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_ParCSRDiagScale,
+                                   (HYPRE_Int (*)(HYPRE_Solver, HYPRE_Matrix, HYPRE_Vector, HYPRE_Vector))HYPRE_ParCSRDiagScaleSetup,
+                                   (HYPRE_Solver) parcsr_A_);
         }
 
-        if (verbose_ && rank == 0) std::cout << "Setting up GMRES solver..." << std::endl;
+        if (verbose_ && rank == 0) std::cout << "Setting up " << krylovName << " solver..." << std::endl;
         MPI_Barrier(comm_);
-        HYPRE_Int setup_err = HYPRE_ParCSRGMRESSetup(solver_, parcsr_A_, par_b_, par_x_);
+        HYPRE_Int setup_err = useFlexGmres_
+            ? HYPRE_ParCSRFlexGMRESSetup(solver_, parcsr_A_, par_b_, par_x_)
+            : HYPRE_ParCSRGMRESSetup(solver_, parcsr_A_, par_b_, par_x_);
         if (setup_err != 0 && rank == 0) {
             std::cerr << "[HypreGMRES] Setup returned error " << setup_err
                       << " (HYPRE_GetError=" << HYPRE_GetError() << ")\n";
@@ -321,7 +362,9 @@ public:
         if (verbose_ && rank == 0) std::cout << "GMRES setup complete, starting solve..." << std::endl;
 
         MPI_Barrier(comm_);
-        HYPRE_Int solve_err = HYPRE_ParCSRGMRESSolve(solver_, parcsr_A_, par_b_, par_x_);
+        HYPRE_Int solve_err = useFlexGmres_
+            ? HYPRE_ParCSRFlexGMRESSolve(solver_, parcsr_A_, par_b_, par_x_)
+            : HYPRE_ParCSRGMRESSolve(solver_, parcsr_A_, par_b_, par_x_);
         if (solve_err != 0 && rank == 0) {
             std::cerr << "[HypreGMRES] Solve returned error " << solve_err
                       << " (HYPRE_GetError=" << HYPRE_GetError() << ")\n";
@@ -558,7 +601,8 @@ public:
 
     void destroy() {
         if (solver_) {
-            HYPRE_ParCSRGMRESDestroy(solver_);
+            if (useFlexGmres_) HYPRE_ParCSRFlexGMRESDestroy(solver_);
+            else               HYPRE_ParCSRGMRESDestroy(solver_);
             solver_ = nullptr;
         }
         if (precond_ && precondType_ == BOOMERAMG) {
@@ -609,6 +653,7 @@ private:
 
     // GMRES(k) restart length.
     int kDim_;
+    bool useFlexGmres_ = false;  // FlexGMRES (varying precond) vs plain GMRES
 };
 
 } // namespace fem

--- a/docs/poiseuille_tutorial.md
+++ b/docs/poiseuille_tutorial.md
@@ -224,6 +224,9 @@ Useful flags:
 | `--no-seed-interior`      | start from rest instead of seeded plug flow (slower development) |
 | `--profile-x=X`           | move the validation plane (default 90% down the channel) |
 | `--cross-axis=y\|z`       | which axis the parabola varies over (default y) |
+| `--check`                 | regression mode: exit 1 unless RMS and flux ratios pass (Part 6) |
+| `--rms-tol=VAL`           | RMS pass threshold for `--check` (default 6e-3, the reference tol) |
+| `--flux-tol=VAL`          | flux-ratio tolerance for `--check` (default 0.10 = ±10%) |
 
 ---
 
@@ -277,15 +280,94 @@ the BC back at you — a lesson from the pump debugging). Ratios near 1.0 at
 
 | Quantity | Expected |
 |----------|----------|
-| `|u|` plateau | 0.846 (analytic 0.849) |
-| RMS vs parabola | 5.8e-3 raw, 3.9e-3 normalized (tol 6e-3) |
+| `|u|` plateau | 0.847 (analytic 0.849) |
+| RMS vs parabola | 5.4e-3 raw, 3.6e-3 normalized (tol 6e-3) |
 | flux ratios 25/50/75% | 0.99 – 1.01 |
-| `div_max` at t=12 | ~1.6, still falling |
-| wall time, 1200 steps, 1 GH200 | ~20 min |
+| velocity-fit G | 0.121 (exact 0.12, ~101%) |
+| `div_max` at convergence | ~1.5–1.8 (frozen boundary-bookkeeping residual, not interior error) |
+| wall time, 1500 steps, 1 GH200 | ~25 min |
 
 ---
 
-## Part 6 — Troubleshooting
+## Part 6 — Regression test, profile plot, and animation
+
+**Regression test.** With `--check` the driver grades itself at the end and
+sets the exit code:
+
+```
+VALIDATION PASS: RMS=5.781e-03 < 6e-3, flux ratios 0.992/0.992/1.006 within 1 +/- 0.1
+```
+
+The case is registered with ctest as `marsPoiseuilleValidation` (labels
+`validation;gpu;long`, 40-minute timeout) whenever the mesh sits at the repo
+root. Run it with `ctest -L validation`. This is the canary for any change to
+the projection, the boundary conditions, or the opening-flux source: if one
+of them regresses, the parabola degrades and the test fails loudly.
+
+**Profile plot.** At the end of every run the driver writes
+`<prefix>_profile.csv` — solved u(y) sampled at ONE fixed x station (the node
+plane nearest the probe x; the RMS uses a small slab, but a figure must show a
+single station). Turn it into the same figure the reference report shows:
+
+```bash
+python3 scripts/plot_poiseuille_profile.py poiseuille_profile.csv
+```
+
+(plain matplotlib, no VTK). The exact curve is drawn from the closed-form
+Wikipedia formula — `u(y) = G/(2μ)·y(h−y)` with `G = 8μU_max/h²` stated in the
+legend — not fitted to the data, and the script warns if the driver's analytic
+column ever disagrees with it.
+
+**The exact solution, four ways.** The Wikipedia "Plane Poiseuille flow"
+section defines the solution by four related quantities; the run checks all of
+them independently:
+
+| Wikipedia quantity | Checked by |
+|---|---|
+| `u(y) = G/(2μ)·y(h−y)` | profile RMS at fixed x + the figure above |
+| `Q = Gh³/(12μ)` | interior-flux probe (Q ≈ Q_in at 25/50/75%) |
+| `G = −dp/dx` | **velocity-fit G**: quadratic fit of the core profile, `G = −μ·u″` (validated: 100.8% of exact at convergence) |
+| `U_max = Gh²/(8μ)` | identical to the `U_max = 1.5·U_mean` target (same parabola, anchored by the inlet velocity instead of G) |
+
+The G line in the run log reads:
+
+```
+G from velocity (core parabola fit, 48 nodes): 1.2096e-01   exact 1.2000e-01   (100.8% of exact)
+```
+
+A match here means the velocity profile, the flow rate, *and* the momentum
+balance (which sets G) independently agree with the exact solution — stronger
+than the profile RMS alone. Note the fit tracks the actual state: on a
+half-developed run it honestly reports ~96%, reaching ~100% only at
+convergence.
+
+**Why G is measured from the velocity, not the solved pressure (a known
+artifact).** Incremental Chorin updates `p += phi` every step and nothing ever
+removes what accumulates, so the violent startup transient leaves a giant
+frozen smooth ramp in `p` (~1e5 × the physical pressure; the driver prints the
+raw `dp/dx` under an ARTIFACT label for tracking). Worse, the mismatch between
+the predictor's SCS gradient and the corrector's `D^T` gradient leaks this
+giant field into the weakly-anchored `v`/`w` components — `umag` in the VTU
+output reaches O(100) garbage while `u` underneath is the clean validated
+parabola. Consequences: **visualize the `u` field, never `umag` or `p`** (the
+render script defaults to `u` for this reason), and trust only velocity-derived
+diagnostics. The clean structural fix is a boundary-complete divergence /
+stabilized formulation — active work on the pump side.
+
+**Animation.** `--vtu-output=PREFIX` writes a `PREFIX_umag.pvd` timeline;
+render the channel developing — uniform plug at the inlet bending into the
+red-core/blue-wall parabola — with:
+
+```bash
+pvbatch scripts/render_poiseuille.py --pvd PREFIX     # -> PREFIX_movie.mp4
+```
+
+Use `--vtu-every=10` on the run for a smooth 121-frame movie (default 50
+gives 25 frames).
+
+---
+
+## Part 7 — Troubleshooting
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
@@ -294,10 +376,12 @@ the BC back at you — a lesson from the pump debugging). Ratios near 1.0 at
 | `cg_iter_p=FAIL` at iteration 1 (`pAp<=0`) | Jacobi diagonal clip too small for extreme cell-size ratios | `MARS_DDT_JACOBI_CLIP_FRAC=1e-2` (env var, no rebuild) |
 | blows up within a few steps after flow develops | unbalanced opening source (should not happen with `oScale`), or — on harder meshes — the equal-order checkerboard instability | this clean hex mesh does not checkerboard through t=12; for meshes that do, pressure stabilization (PSPG/VMS) is required — active work on the pump side |
 | run dies near step 1250 with no validation block | srun wall-time limit | `--time=00:30:00` |
+| `umag`/`p` look like garbage in ParaView while the run PASSes | known incremental-pressure artifact leaking into v/w (Part 6) | render the `u` field (script default); trust velocity diagnostics only |
+| rerun reproduces identical numbers to many digits after a code change | stale binary — build dir not rebuilt | rebuild `mars_poiseuille_flow`; bit-identical output after an intended change is the tell |
 
 ---
 
-## Part 7 — Where to go next
+## Part 8 — Where to go next
 
 - `docs/pump_cfd_tutorial.md` — the full from-scratch CFD background: CVFEM,
   the discrete operators, the projection algebra, stabilization.

--- a/examples/distributed/unstructured/CMakeLists.txt
+++ b/examples/distributed/unstructured/CMakeLists.txt
@@ -167,6 +167,22 @@ target_include_directories(mars_poiseuille_flow PRIVATE
 )
 install(TARGETS mars_poiseuille_flow RUNTIME DESTINATION bin/examples)
 
+# Long-running GPU regression: converge the channel to the analytic parabola
+# and fail if the profile RMS or the interior through-flow drifts. Registered
+# only when the validation mesh sits at the repo root (gunzip -k the .gz once).
+# ~25 min on one GH200; run via `ctest -L validation`.
+if(EXISTS ${CMAKE_SOURCE_DIR}/poiseuille_hex_14k_elem.e)
+    add_test(NAME marsPoiseuilleValidation
+             COMMAND mars_poiseuille_flow
+                     --mesh=${CMAKE_SOURCE_DIR}/poiseuille_hex_14k_elem.e
+                     --uinf=1.0 --nu=0.01 --dt=0.01 --tol=1e-6 --max-iter=4000
+                     --num-steps=1500 --check)
+    set_tests_properties(marsPoiseuilleValidation PROPERTIES
+        TIMEOUT 2400
+        LABELS "validation;gpu;long"
+        ENVIRONMENT "MARS_NODEHALO_V2=1")
+endif()
+
 # Taylor-Green vortex driver. Periodic-cube NS solver + AMR. Currently a
 # skeleton that loads a mesh, builds the periodic node-pair map, applies the
 # TGV initial condition, and writes the IC as VTU. The full projection time

--- a/examples/distributed/unstructured/mars_poiseuille_flow.cu
+++ b/examples/distributed/unstructured/mars_poiseuille_flow.cu
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <vector>
 #include <algorithm>
+#include <fstream>
 
 // Voronoi-lumped per-node areas of a y-z cross-section plane of this quasi-2D
 // mesh (one cell thick in z, two z node-planes): per node, (Voronoi y-interval)
@@ -125,6 +126,12 @@ int main(int argc, char** argv)
     // Default ON in inlet mode -- without it the inlet is invisible to the
     // pressure solve. --no-opening-flux-source gives the A/B baseline.
     bool openingFluxSource = true;
+    // Regression-check mode: exit 1 unless the final profile RMS is below
+    // rmsTol (the FLUYA reference tolerance) AND every interior-flux ratio is
+    // within fluxTol of 1. Drives the ctest entry.
+    bool   checkMode = false;
+    double rmsTol    = 6e-3;
+    double fluxTol   = 0.10;
 
     for (int i = 1; i < argc; ++i)
     {
@@ -145,6 +152,9 @@ int main(int argc, char** argv)
         else if (arg.find("--body-force-x=") == 0) bodyForceX = std::stod(arg.substr(15));
         else if (arg == "--no-seed-interior")      seedInterior = false;
         else if (arg == "--no-opening-flux-source") openingFluxSource = false;
+        else if (arg == "--check")                 checkMode = true;
+        else if (arg.find("--rms-tol=") == 0)      rmsTol  = std::stod(arg.substr(10));
+        else if (arg.find("--flux-tol=") == 0)     fluxTol = std::stod(arg.substr(11));
         else if (arg.find("--block-size=") == 0)   blockSize  = std::stoi(arg.substr(13));
         else if (arg.find("--bucket-size=") == 0)  bucketSize = std::stoi(arg.substr(14));
         else if (arg.find("--max-iter=") == 0)     maxIter    = std::stoi(arg.substr(11));
@@ -185,6 +195,10 @@ int main(int argc, char** argv)
                       << "  --no-seed-interior  Start from rest (default seeds interior with mean flow)\n"
                       << "  --no-opening-flux-source  Disable the balanced opening-flux source (A/B baseline;\n"
                       << "                      without it the inlet is invisible to the pressure solve)\n"
+                      << "  --check             Regression mode: exit 1 unless RMS < rms-tol and flux\n"
+                      << "                      ratios within flux-tol of 1\n"
+                      << "  --rms-tol=VAL       RMS pass threshold (default 6e-3, the reference tol)\n"
+                      << "  --flux-tol=VAL      Relative flux-ratio tolerance (default 0.10)\n"
                       << "  --profile-x=X       Outlet probe plane x (default: 90% down the channel)\n"
                       << "  --profile-xtol=TOL  Half-width of the probe plane (default: one element)\n"
                       << "  --solver=cg|hypre   Linear solver (default cg)\n"
@@ -308,7 +322,11 @@ int main(int argc, char** argv)
         MPI_Allreduce(&yMaxL, &yMax, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
         MPI_Allreduce(&zMinL, &zMin, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
         MPI_Allreduce(&zMaxL, &zMax, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
-        RealType eps = 1e-4 * std::max(RealType(1), yMax - yMin);
+        // 1e-5, NOT 1e-4: the first interior node sits 1e-4 off the wall, and
+        // with eps=1e-4 float rounding pinned it on the TOP wall but not the
+        // bottom (observed: u(0.9999)=0 exactly, u(0.0001) free) -- a silent
+        // extra no-slip layer on one side.
+        RealType eps = 1e-5 * std::max(RealType(1), yMax - yMin);
         double H = static_cast<double>(yMax - yMin);   // channel height
 
         std::vector<uint8_t>  hostIsBdry(s.numOwnedDofs, 0);
@@ -549,6 +567,9 @@ int main(int argc, char** argv)
             writeVtuFrame(step, t);
     }
 
+    double finalRms     = -1.0;      // raw RMS vs analytic (reference tol 6e-3)
+    double fluxRatio[3] = {0, 0, 0}; // Q(25/50/75%) / Q(inlet)
+
     // -------------------------------------------------------------------------
     // Outlet-plane validation against the analytic parabolic profile.
     // Pull u and node coords to host, gather the probe-plane nodes, fit the
@@ -560,7 +581,8 @@ int main(int argc, char** argv)
         const auto& d_z = amr.domain().getNodeZ();
         size_t n = s.nodeCount;
 
-        std::vector<RealType> h_u(n), h_x(n), h_y(n), h_z(n);
+        std::vector<RealType> h_u(n), h_x(n), h_y(n), h_z(n), h_p(n);
+        cudaMemcpy(h_p.data(), s.d_p.data(), n * sizeof(RealType), cudaMemcpyDeviceToHost);
         cudaMemcpy(h_u.data(), s.d_u.data(), n * sizeof(RealType), cudaMemcpyDeviceToHost);
         cudaMemcpy(h_x.data(), d_x.data(),   n * sizeof(RealType), cudaMemcpyDeviceToHost);
         cudaMemcpy(h_y.data(), d_y.data(),   n * sizeof(RealType), cudaMemcpyDeviceToHost);
@@ -606,6 +628,73 @@ int main(int argc, char** argv)
         MPI_Allreduce(&cntL,   &cnt,   1, MPI_LONG,   MPI_SUM, MPI_COMM_WORLD);
 
         double rms = cnt > 0 ? std::sqrt(sumSq / cnt) : -1.0;
+        finalRms = rms;
+
+        // Profile CSV for plotting (scripts/plot_poiseuille_profile.py):
+        // cross-coordinate, solved u, analytic u at ONE fixed x (the node plane
+        // nearest xProbe) -- the report's figure samples a single station, so
+        // the CSV must too (the RMS above uses a slab, which is fine for the
+        // norm but would smear the dot plot). Rank-0-local nodes only.
+        if (rank == 0)
+        {
+            double xSnap = 1e300;
+            for (size_t i = 0; i < n; ++i)
+                if (std::abs(h_x[i] - xProbe) < std::abs(xSnap - xProbe)) xSnap = h_x[i];
+            double snapTol = 1e-9 * std::max(1.0, double(xMax - xMin));
+            std::vector<std::pair<double,double>> pts;
+            for (size_t i = 0; i < n; ++i)
+                if (std::abs(h_x[i] - xSnap) < snapTol)
+                    pts.emplace_back(double(cross[i]), double(h_u[i]));
+            std::sort(pts.begin(), pts.end());
+            std::string csvName = (vtuPrefix.empty() ? std::string("poiseuille") : vtuPrefix)
+                                  + "_profile.csv";
+            std::ofstream csv(csvName);
+            csv << "y,u_solved,u_analytic\n";
+            for (auto& p : pts)
+                csv << p.first << "," << p.second << "," << prof.analytic(p.first) << "\n";
+            std::cout << "Profile CSV written: " << csvName
+                      << "  (single plane x=" << xSnap << ", " << pts.size() << " nodes)\n";
+
+            // G from the solved VELOCITY: quadratic fit over the core
+            // (u > 0.5 U_max -- avoids the near-wall overshoot layer), then
+            // G = -mu * u'' = -2 a mu. This is the trustworthy pressure-
+            // gradient measurement; the solved p field cannot give it (see
+            // the artifact note at the p-based check below).
+            double s0 = 0, s1 = 0, s2 = 0, s3 = 0, s4 = 0, b0 = 0, b1 = 0, b2 = 0;
+            for (auto& pr : pts)
+            {
+                if (pr.second <= 0.5 * targetUMax) continue;
+                double yv = pr.first, uv = pr.second;
+                double y2 = yv * yv;
+                s0 += 1;  s1 += yv;  s2 += y2;  s3 += y2 * yv;  s4 += y2 * y2;
+                b0 += uv; b1 += yv * uv; b2 += y2 * uv;
+            }
+            if (s0 >= 5)
+            {
+                // Solve the 3x3 normal equations [s4 s3 s2; s3 s2 s1; s2 s1 s0]
+                // (a b c)^T = (b2 b1 b0)^T by Cramer's rule.
+                auto det3 = [](double a11, double a12, double a13,
+                               double a21, double a22, double a23,
+                               double a31, double a32, double a33) {
+                    return a11 * (a22 * a33 - a23 * a32)
+                         - a12 * (a21 * a33 - a23 * a31)
+                         + a13 * (a21 * a32 - a22 * a31);
+                };
+                double D  = det3(s4, s3, s2,  s3, s2, s1,  s2, s1, s0);
+                double Da = det3(b2, s3, s2,  b1, s2, s1,  b0, s1, s0);
+                double aFit = (D != 0) ? Da / D : 0;
+                double mu = rho * nu;
+                double Gfit = -2.0 * aFit * mu;
+                double Gexact = 8.0 * mu * targetUMax;   // h=1-normalized below
+                double Hloc = sHi - sLo;
+                if (Hloc > 0) Gexact = 8.0 * mu * targetUMax / (Hloc * Hloc);
+                std::cout << "G from velocity (core parabola fit, " << long(s0) << " nodes): "
+                          << std::scientific << std::setprecision(4) << Gfit
+                          << "   exact " << Gexact << "   ("
+                          << std::fixed << std::setprecision(1)
+                          << (Gexact != 0 ? 100.0 * Gfit / Gexact : 0.0) << "% of exact)\n";
+            }
+        }
 
         if (rank == 0)
         {
@@ -649,27 +738,103 @@ int main(int argc, char** argv)
                 auto areas = planeVoronoiAreas(ys, dz);
                 double q = 0;
                 for (size_t k = 0; k < us.size(); ++k) q += us[k] * areas[k];
-                return q;
+                // All ranks call planeFlux the same number of times, so this
+                // collective is safe; areas at partition cuts are approximate.
+                double qG = q;
+                MPI_Allreduce(&q, &qG, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+                return qG;
             };
 
             double qIn = planeFlux(double(xMin));
+            const double fracs[3] = {0.25, 0.50, 0.75};
+            double qAt[3];
+            for (int k = 0; k < 3; ++k)
+            {
+                qAt[k] = planeFlux(double(xMin) + fracs[k] * double(xMax - xMin));
+                fluxRatio[k] = (std::abs(qIn) > 0) ? qAt[k] / qIn : 0.0;
+            }
             if (rank == 0)
             {
                 std::cout << "Interior-flux probe (solved u, Voronoi-lumped):\n";
                 std::cout << "  Q(inlet) = " << std::scientific << std::setprecision(4) << qIn << "\n";
-                for (double f : {0.25, 0.50, 0.75})
-                {
-                    double q = planeFlux(double(xMin) + f * double(xMax - xMin));
-                    std::cout << "  Q(" << std::fixed << std::setprecision(0) << f * 100
-                              << "%) = " << std::scientific << std::setprecision(4) << q
+                for (int k = 0; k < 3; ++k)
+                    std::cout << "  Q(" << std::fixed << std::setprecision(0) << fracs[k] * 100
+                              << "%) = " << std::scientific << std::setprecision(4) << qAt[k]
                               << "  ratio=" << std::fixed << std::setprecision(3)
-                              << (std::abs(qIn) > 0 ? q / qIn : 0.0) << "\n";
-                }
+                              << fluxRatio[k] << "\n";
                 std::cout << "========================================\n";
             }
         }
+
+        // Wikipedia plane-Poiseuille closure check: the exact solution is
+        // u(y) = G/(2 mu) y(h-y) with G = -dp/dx = 8 mu U_max/h^2. Measure the
+        // SOLVED pressure gradient between two developed stations (60%, 90%)
+        // and compare -- validates the pressure field, not just the velocity.
+        //
+        // Sample ONLY the moving core (u > 0.5 U_max): incremental Chorin does
+        // p += phi at EVERY node each step, and at velocity-Dirichlet nodes
+        // (walls/inlet) phi carries the projection's one-sided boundary residue
+        // that the corrector can never clean -- p there accumulates linearly
+        // into garbage and poisons a full-station mean (observed: measured G
+        // off by 8 orders of magnitude when wall nodes were included). The core
+        // nodes feel the physical gradient (the steady parabola proves it).
+        // Plane means are Allreduced; ghosts may be double-counted on
+        // multi-rank, so the mean is exact on 1 rank, approximate on N.
+        {
+            auto planeMeanP = [&](double xTarget) -> double
+            {
+                double xSnap = 1e300;
+                for (size_t i = 0; i < n; ++i)
+                    if (std::abs(h_x[i] - xTarget) < std::abs(xSnap - xTarget)) xSnap = h_x[i];
+                double snapTol = 1e-9 * std::max(1.0, double(xMax - xMin));
+                double uCore = 0.5 * targetUMax;
+                double sum = 0; long cntP = 0;
+                for (size_t i = 0; i < n; ++i)
+                    if (std::abs(h_x[i] - xSnap) < snapTol && double(h_u[i]) > uCore)
+                    { sum += h_p[i]; ++cntP; }
+                double sumG = sum; long cntG = cntP;
+                MPI_Allreduce(&sum,  &sumG, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+                MPI_Allreduce(&cntP, &cntG, 1, MPI_LONG,   MPI_SUM, MPI_COMM_WORLD);
+                return cntG > 0 ? sumG / double(cntG) : 0.0;
+            };
+            double xA = double(xMin) + 0.60 * double(xMax - xMin);
+            double xB = double(xMin) + 0.90 * double(xMax - xMin);
+            double pA = planeMeanP(xA);
+            double pB = planeMeanP(xB);
+            double H      = sHi - sLo;
+            double Gmeas  = (pA - pB) / (xB - xA);
+            double Gexact = (H > 0) ? 8.0 * rho * nu * targetUMax / (H * H) : 0.0;
+            if (rank == 0)
+                std::cout << "Pressure-gradient from SOLVED p (KNOWN ARTIFACT -- incremental Chorin\n"
+                          << "accumulates the startup-transient phi into p and nothing removes it, so\n"
+                          << "p carries a giant frozen ramp ~1e5 x physical; use the velocity-fit G\n"
+                          << "above as the physical measurement):\n"
+                          << "  raw dp/dx = " << std::scientific << std::setprecision(4) << Gmeas
+                          << "   physical G = " << Gexact << "\n"
+                          << "========================================\n";
+        }
+    }
+
+    // Regression verdict. finalRms and fluxRatio are identical on all ranks
+    // (both come from Allreduced sums), so every rank computes the same code.
+    int exitCode = 0;
+    if (checkMode)
+    {
+        bool rmsOk  = (finalRms >= 0.0) && (finalRms < rmsTol);
+        bool fluxOk = true;
+        for (int k = 0; k < 3; ++k)
+            fluxOk = fluxOk && (std::abs(fluxRatio[k] - 1.0) <= fluxTol);
+        bool pass = rmsOk && fluxOk;
+        if (rank == 0)
+            std::cout << "VALIDATION " << (pass ? "PASS" : "FAIL")
+                      << ": RMS=" << std::scientific << std::setprecision(3) << finalRms
+                      << (rmsOk ? " < " : " >= ") << rmsTol
+                      << ", flux ratios " << std::fixed << std::setprecision(3)
+                      << fluxRatio[0] << "/" << fluxRatio[1] << "/" << fluxRatio[2]
+                      << (fluxOk ? " within " : " OUTSIDE ") << "1 +/- " << fluxTol << "\n";
+        exitCode = pass ? 0 : 1;
     }
 
     MPI_Finalize();
-    return 0;
+    return exitCode;
 }

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -81,6 +81,7 @@ int main(int argc, char** argv)
     bool        useVMSStab = false;    // Nalu-Wind VMS pressure stab (NOT Rhie-Chow); --vms-stab. EXPERIMENTAL, validate.
     bool        usePSPG    = false;    // implicit PSPG pressure stab (tau*L in the DDT operator); --pspg. The correct equal-order checkerboard fix.
     double      pspgTau    = -1;       // <=0 => auto h^2/24; --pspg-tau=V overrides
+    bool        useHypre   = false;    // --solver=hypre: assembled DDT + Hypre FlexGMRES+BoomerAMG (else matrix-free Jacobi-CG)
     std::string inletSS;   // inlet side-set name (required for --bc=pump; pass --inlet-ss=)
     std::string outletSS;  // outlet side-set name (required for --bc=pump; pass --outlet-ss=)
     // Inlet velocity follows each node's OWN local surface normal (area-weighted
@@ -145,6 +146,8 @@ int main(int argc, char** argv)
         else if (a == "--vms-stab")                  useVMSStab = true;  // Nalu VMS pressure stab (tet-only, experimental)
         else if (a == "--pspg")                      usePSPG    = true;  // implicit PSPG (tau*L in DDT operator) -- the correct checkerboard fix
         else if (a.rfind("--pspg-tau=", 0) == 0)     pspgTau    = std::stod(a.substr(11));
+        else if (a == "--solver=hypre")              useHypre   = true;  // assembled DDT + Hypre FlexGMRES+BoomerAMG (else matrix-free Jacobi-CG)
+        else if (a == "--solver=cg")                 useHypre   = false;
         else if (a.rfind("--inlet-ss=", 0) == 0)     inletSS   = a.substr(11);
         else if (a.rfind("--outlet-ss=", 0) == 0)    outletSS  = a.substr(12);
         else if (a == "--inlet-pernode-normal")      inletPernodeNormal = true;
@@ -257,6 +260,7 @@ int main(int argc, char** argv)
                   << "VMS-stab    = " << (useVMSStab ? "ON (Nalu, tet-only, EXPERIMENTAL)" : "OFF") << "\n"
                   << "PSPG        = " << (usePSPG ? "ON (implicit tau*L in DDT operator)" : "OFF")
                   << (usePSPG && pspgTau > 0 ? "  (tau=" + std::to_string(pspgTau) + ")" : (usePSPG ? "  (tau=auto h^2/24)" : "")) << "\n"
+                  << "pressure    = " << (useHypre ? "assembled DDT + Hypre FlexGMRES+BoomerAMG (--solver=hypre)" : "matrix-free DDT + Jacobi-CG") << "\n"
                   << "MPI ranks   = " << numRanks << "\n"
                   << "========================================\n\n";
     }
@@ -299,7 +303,9 @@ int main(int argc, char** argv)
                       << "use --nu for a real fluid.\n";
     }
 
-    NSStepper<KeyType, RealType, TetTag> s{amr.domain(), SolverKind::CG, blockSize,
+    NSStepper<KeyType, RealType, TetTag> s{amr.domain(),
+                                           useHypre ? SolverKind::Hypre : SolverKind::CG,
+                                           blockSize,
                                            maxIter, RealType(tolerance), rank, numRanks};
     s.Uinf          = RealType(inletU);
     s.uinfBase      = RealType(inletU);   // unramped full-strength inlet speed (ramp target)

--- a/scripts/plot_poiseuille_profile.py
+++ b/scripts/plot_poiseuille_profile.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Plot solved Poiseuille points on the exact plane-Poiseuille parabola.
+
+The exact curve is the Wikipedia "Plane Poiseuille flow" solution
+(https://en.wikipedia.org/wiki/Hagen-Poiseuille_equation):
+
+    u(y) = G/(2 mu) * y * (h - y),   G = -dp/dx = 8 mu U_max / h^2
+
+drawn from the closed-form formula (NOT fitted to the data). The dots are the
+solved velocity at one fixed x station, read from the CSV written by
+mars_poiseuille_flow (<prefix>_profile.csv: y, u_solved, u_analytic).
+
+Usage:
+    python3 scripts/plot_poiseuille_profile.py poiseuille_profile.csv [out.png]
+        [--umax 1.5] [--mu 0.01]
+
+Defaults match the validation case: rho=1, mu=0.01, U_mean=1 -> U_max=1.5,
+h taken from the wall extents in the CSV. The script cross-checks its formula
+against the driver's analytic column and warns if they disagree.
+"""
+
+import argparse
+import csv
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("csv_path")
+    ap.add_argument("out_path", nargs="?", default=None)
+    ap.add_argument("--umax", type=float, default=1.5,
+                    help="exact centerline speed U_max = 1.5*U_mean (default 1.5)")
+    ap.add_argument("--mu", type=float, default=0.01,
+                    help="dynamic viscosity, only for the G annotation (default 0.01)")
+    args = ap.parse_args()
+    out_path = args.out_path or args.csv_path.replace(".csv", ".png")
+
+    y, u_solved, u_driver = [], [], []
+    with open(args.csv_path) as f:
+        for row in csv.DictReader(f):
+            y.append(float(row["y"]))
+            u_solved.append(float(row["u_solved"]))
+            u_driver.append(float(row["u_analytic"]))
+    y = np.array(y)
+    u_solved = np.array(u_solved)
+    u_driver = np.array(u_driver)
+
+    # Walls from the data extents (the plane includes the wall nodes, u=0).
+    y0, y1 = y.min(), y.max()
+    h = y1 - y0
+    G = 8.0 * args.mu * args.umax / h**2
+
+    # Exact Wikipedia form, in wall coordinates yw = y - y0 in [0, h]:
+    # u = G/(2 mu) * yw * (h - yw). With G as above this equals
+    # U_max * 4 yw (h - yw) / h^2.
+    def exact(yv):
+        yw = yv - y0
+        return G / (2.0 * args.mu) * yw * (h - yw)
+
+    # Consistency: the driver's analytic column must be the same curve.
+    # Tolerance 1e-4: the driver's wall extents come from a slab around the
+    # probe plane and differ from this plane's by a few 1e-6 -- harmless.
+    drift = float(np.max(np.abs(exact(y) - u_driver)))
+    if drift > 1e-4 * args.umax:
+        print(f"WARNING: driver analytic column differs from the closed form "
+              f"by up to {drift:.3e} -- check U_max / wall extents")
+
+    rms = float(np.sqrt(np.mean((u_solved - exact(y)) ** 2)))
+
+    yy = np.linspace(y0, y1, 400)
+    fig, ax = plt.subplots(figsize=(5, 4.2))
+    ax.plot(exact(yy), yy, "-", color="tab:blue", lw=2,
+            label=f"exact: u=G/(2μ)·y(h−y), G={G:.3g}")
+    ax.plot(u_solved, y, "o", color="tab:red", ms=3.5, mfc="none",
+            label="MARS (solved)")
+    ax.set_xlabel("u (streamwise velocity)")
+    ax.set_ylabel("y (wall-normal)")
+    ax.set_title(f"Plane Poiseuille profile, RMS = {rms:.2e}")
+    ax.legend(loc="center left", fontsize=9)
+    ax.grid(alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    print(f"wrote {out_path}")
+    print(f"  h={h:.4g}  U_max={args.umax}  mu={args.mu}  G=8*mu*U_max/h^2={G:.4g}")
+    print(f"  RMS vs exact: {rms:.3e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/render_poiseuille.py
+++ b/scripts/render_poiseuille.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env pvbatch
+# Render the Poiseuille channel animation from mars_poiseuille_flow VTU output.
+#
+# Input (derived from --pvd PREFIX): PREFIX_<field>.pvd. Default field is u
+# (the validated streamwise velocity). NOTE: umag = sqrt(u^2+v^2+w^2) is
+# contaminated by the incremental-pressure artifact leaking into v/w -- it
+# renders as saturated garbage even when the u physics is perfect. The channel is one
+# element thick in z, so a single top-down (x-y) view shows everything: the
+# uniform plug inflow on the left bending into the parabolic profile
+# downstream (fast red core, slow blue walls).
+#
+# Output:
+#   <PREFIX>_movie/frame_NNNN.png   -- per-timestep frames
+#   <PREFIX>_movie.mp4              -- assembled animation (if ffmpeg in PATH)
+#
+# Usage on Mac:
+#   /Applications/ParaView-5.13.2.app/Contents/bin/pvbatch \
+#       scripts/render_poiseuille.py --pvd poiseuille
+# Usage on Alps (offscreen pvbatch):
+#   pvbatch scripts/render_poiseuille.py --pvd poiseuille
+#
+# For a smooth video run the driver with --vtu-every=10 (121 frames over the
+# 1200-step run) rather than the default 50.
+
+import argparse, os, sys, shutil, subprocess
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--pvd",    required=True, help="driver --vtu-output prefix (reads PREFIX_umag.pvd)")
+ap.add_argument("--width",  type=int, default=1920)
+ap.add_argument("--height", type=int, default=540)
+ap.add_argument("--fps",    type=int, default=12)
+ap.add_argument("--field", default="u",
+                help="which PVD timeline to render: u (default; the validated streamwise "
+                     "component) or umag (CAUTION: contains v/w garbage from the "
+                     "incremental-pressure artifact -- looks wrong even when u is correct)")
+ap.add_argument("--u-range", default="0,1.5",
+                help="color range LOW,HI (default 0,1.5 = up to U_max)")
+ap.add_argument("--no-mp4", action="store_true", help="skip ffmpeg assembly")
+args = ap.parse_args()
+
+pvd_path = args.pvd + "_" + args.field + ".pvd"
+if not os.path.exists(pvd_path):
+    print(f"PVD not found: {pvd_path}", file=sys.stderr)
+    sys.exit(1)
+
+out_dir = args.pvd + "_movie"
+os.makedirs(out_dir, exist_ok=True)
+ulo, uhi = [float(x) for x in args.u_range.split(",")]
+
+from paraview.simple import *
+paraview.simple._DisableFirstRenderCameraReset()
+
+reader = PVDReader(FileName=pvd_path)
+reader.UpdatePipeline()
+times = reader.TimestepValues or [0.0]
+
+view = CreateView("RenderView")
+view.ViewSize = [args.width, args.height]
+view.Background = [1, 1, 1]
+view.OrientationAxesVisibility = 0
+view.UseFXAA = 1
+
+disp = Show(reader, view)
+disp.Representation = "Surface"
+ColorBy(disp, ("POINTS", args.field))
+lut = GetColorTransferFunction(args.field)
+lut.ApplyPreset("Turbo", True)
+lut.RescaleTransferFunction(ulo, uhi)
+bar = GetScalarBar(lut, view)
+bar.Title = args.field
+bar.ComponentTitle = ""
+bar.TitleColor = [0, 0, 0]
+bar.LabelColor = [0, 0, 0]
+bar.WindowLocation = "Any Location"
+bar.Position = [0.92, 0.25]
+bar.ScalarBarLength = 0.5
+
+annot = AnnotateTimeFilter(Input=reader)
+annot.Format = "t = {time:.2f}"
+adisp = Show(annot, view)
+adisp.Color = [0, 0, 0]
+adisp.WindowLocation = "Any Location"
+adisp.Position = [0.02, 0.88]
+
+# Top-down camera fitted to the 11:1 channel with parallel projection.
+b = reader.GetDataInformation().GetBounds()
+cx, cy = 0.5 * (b[0] + b[1]), 0.5 * (b[2] + b[3])
+view.InteractionMode = "2D"
+view.CameraPosition = [cx, cy, 10]
+view.CameraFocalPoint = [cx, cy, 0]
+view.CameraViewUp = [0, 1, 0]
+view.CameraParallelProjection = 1
+aspect = float(args.width) / float(args.height)
+half_x = 0.5 * (b[1] - b[0]) * 1.04
+half_y = 0.5 * (b[3] - b[2]) * 1.30
+view.CameraParallelScale = max(half_y, half_x / aspect)
+
+for i, t in enumerate(times):
+    view.ViewTime = t
+    Render(view)
+    SaveScreenshot(os.path.join(out_dir, f"frame_{i:04d}.png"), view,
+                   ImageResolution=[args.width, args.height])
+    print(f"frame {i + 1}/{len(times)}  t={t:.2f}")
+
+if not args.no_mp4:
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg:
+        mp4 = args.pvd + "_movie.mp4"
+        subprocess.run([ffmpeg, "-y", "-framerate", str(args.fps),
+                        "-i", os.path.join(out_dir, "frame_%04d.png"),
+                        "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "18",
+                        mp4], check=True)
+        print(f"wrote {mp4}")
+    else:
+        print("ffmpeg not in PATH; frames left in " + out_dir)

--- a/scripts/render_poiseuille.py
+++ b/scripts/render_poiseuille.py
@@ -1,41 +1,38 @@
 #!/usr/bin/env pvbatch
-# Render the Poiseuille channel animation from mars_poiseuille_flow VTU output.
+# Render the Poiseuille channel validation animation from mars_poiseuille_flow
+# VTU output. Pump-renderer style (render_pump_4panel.py): per-view PNGs
+# composited with PIL into a labeled multi-panel frame + header, then ffmpeg.
 #
-# Input (derived from --pvd PREFIX): PREFIX_<field>.pvd. Default field is u
-# (the validated streamwise velocity). NOTE: umag = sqrt(u^2+v^2+w^2) is
-# contaminated by the incremental-pressure artifact leaking into v/w -- it
-# renders as saturated garbage even when the u physics is perfect. The channel is one
-# element thick in z, so a single top-down (x-y) view shows everything: the
-# uniform plug inflow on the left bending into the parabolic profile
-# downstream (fast red core, slow blue walls).
+# Default layout (--layout panels):
+#   TOP    : u colormap of the whole channel (top-down x-y view)
+#   BOT-L  : velocity profile u(y) at the probe station vs the EXACT parabola
+#            u = G/(2mu) y(h-y) -- the validation figure, animated
+#   BOT-R  : centerline u(x) -- entrance development toward U_max
+# --layout simple gives the old single-panel field view.
 #
-# Output:
-#   <PREFIX>_movie/frame_NNNN.png   -- per-timestep frames
-#   <PREFIX>_movie.mp4              -- assembled animation (if ffmpeg in PATH)
+# Input: PREFIX_<field>.pvd (default field u -- the validated component;
+# umag/p carry the incremental-pressure artifact and render as garbage).
 #
-# Usage on Mac:
-#   /Applications/ParaView-5.13.2.app/Contents/bin/pvbatch \
-#       scripts/render_poiseuille.py --pvd poiseuille
-# Usage on Alps (offscreen pvbatch):
-#   pvbatch scripts/render_poiseuille.py --pvd poiseuille
-#
-# For a smooth video run the driver with --vtu-every=10 (121 frames over the
-# 1200-step run) rather than the default 50.
+# Usage:
+#   pvbatch scripts/render_poiseuille.py --pvd poiseuille_final
+#   /Applications/ParaView-6.1.1.app/Contents/bin/pvbatch \
+#       scripts/render_poiseuille.py --pvd /tmp/poise_render/poiseuille_final
 
 import argparse, os, sys, shutil, subprocess
 
 ap = argparse.ArgumentParser()
-ap.add_argument("--pvd",    required=True, help="driver --vtu-output prefix (reads PREFIX_umag.pvd)")
+ap.add_argument("--pvd",    required=True, help="driver --vtu-output prefix")
+ap.add_argument("--field",  default="u",
+                help="PVD timeline to render (default u; umag/p are artifact-contaminated)")
+ap.add_argument("--layout", default="panels", choices=["panels", "simple"])
 ap.add_argument("--width",  type=int, default=1920)
-ap.add_argument("--height", type=int, default=540)
+ap.add_argument("--height", type=int, default=1080)
 ap.add_argument("--fps",    type=int, default=12)
-ap.add_argument("--field", default="u",
-                help="which PVD timeline to render: u (default; the validated streamwise "
-                     "component) or umag (CAUTION: contains v/w garbage from the "
-                     "incremental-pressure artifact -- looks wrong even when u is correct)")
-ap.add_argument("--u-range", default="0,1.5",
-                help="color range LOW,HI (default 0,1.5 = up to U_max)")
-ap.add_argument("--no-mp4", action="store_true", help="skip ffmpeg assembly")
+ap.add_argument("--frames", type=int, default=0, help="0 = all timesteps")
+ap.add_argument("--u-range", default="0,1.5", help="color/axis range LOW,HI")
+ap.add_argument("--umax",   type=float, default=1.5, help="exact centerline U_max")
+ap.add_argument("--profile-x", type=float, default=9.0, help="profile station x")
+ap.add_argument("--no-mp4", action="store_true")
 args = ap.parse_args()
 
 pvd_path = args.pvd + "_" + args.field + ".pvd"
@@ -53,60 +50,191 @@ paraview.simple._DisableFirstRenderCameraReset()
 reader = PVDReader(FileName=pvd_path)
 reader.UpdatePipeline()
 times = reader.TimestepValues or [0.0]
+if args.frames > 0:
+    times = times[:args.frames]
 
-view = CreateView("RenderView")
-view.ViewSize = [args.width, args.height]
-view.Background = [1, 1, 1]
-view.OrientationAxesVisibility = 0
-view.UseFXAA = 1
+b = reader.GetDataInformation().GetBounds()
+cx, cy, cz = 0.5*(b[0]+b[1]), 0.5*(b[2]+b[3]), 0.5*(b[4]+b[5])
+h = b[3] - b[2]
+y0 = b[2]
 
-disp = Show(reader, view)
+# --- TOP: field view ----------------------------------------------------------
+def make_render_view(w, hgt):
+    rv = CreateView("RenderView")
+    rv.ViewSize = [w, hgt]
+    rv.Background = [1, 1, 1]
+    try: rv.UseColorPaletteForBackground = 0
+    except Exception: pass
+    try: rv.BackgroundColorMode = "Single Color"
+    except Exception: pass
+    rv.OrientationAxesVisibility = 0
+    try: rv.UseFXAA = 1
+    except Exception: pass
+    return rv
+
+panel_pad = 10
+top_h    = int(args.height * 0.40)
+bot_h    = args.height - top_h - 56      # 56 px header strip
+half_w   = args.width // 2
+
+simple_mode = (args.layout == "simple")
+top_w  = args.width if simple_mode else args.width - 2*panel_pad
+view_T = make_render_view(top_w, (args.height if simple_mode else top_h) - 2*panel_pad)
+
+disp = Show(reader, view_T)
 disp.Representation = "Surface"
 ColorBy(disp, ("POINTS", args.field))
 lut = GetColorTransferFunction(args.field)
 lut.ApplyPreset("Turbo", True)
 lut.RescaleTransferFunction(ulo, uhi)
-bar = GetScalarBar(lut, view)
+bar = GetScalarBar(lut, view_T)
 bar.Title = args.field
 bar.ComponentTitle = ""
 bar.TitleColor = [0, 0, 0]
 bar.LabelColor = [0, 0, 0]
 bar.WindowLocation = "Any Location"
-bar.Position = [0.92, 0.25]
-bar.ScalarBarLength = 0.5
+bar.Position = [0.93, 0.20]
+bar.ScalarBarLength = 0.6
 
-annot = AnnotateTimeFilter(Input=reader)
-annot.Format = "t = {time:.2f}"
-adisp = Show(annot, view)
-adisp.Color = [0, 0, 0]
-adisp.WindowLocation = "Any Location"
-adisp.Position = [0.02, 0.88]
+view_T.InteractionMode = "2D"
+view_T.CameraPosition = [cx, cy, 10]
+view_T.CameraFocalPoint = [cx, cy, 0]
+view_T.CameraViewUp = [0, 1, 0]
+view_T.CameraParallelProjection = 1
+aspect = float(view_T.ViewSize[0]) / float(view_T.ViewSize[1])
+view_T.CameraParallelScale = max(0.5*(b[3]-b[2])*1.12, 0.5*(b[1]-b[0])*1.02 / aspect)
 
-# Top-down camera fitted to the 11:1 channel with parallel projection.
-b = reader.GetDataInformation().GetBounds()
-cx, cy = 0.5 * (b[0] + b[1]), 0.5 * (b[2] + b[3])
-view.InteractionMode = "2D"
-view.CameraPosition = [cx, cy, 10]
-view.CameraFocalPoint = [cx, cy, 0]
-view.CameraViewUp = [0, 1, 0]
-view.CameraParallelProjection = 1
-aspect = float(args.width) / float(args.height)
-half_x = 0.5 * (b[1] - b[0]) * 1.04
-half_y = 0.5 * (b[3] - b[2]) * 1.30
-view.CameraParallelScale = max(half_y, half_x / aspect)
+# --- Charts (panels layout only) ----------------------------------------------
+if not simple_mode:
+    # Profile at the probe station: vertical line through the channel.
+    profLine = PlotOverLine(Input=reader)
+    for attr, val in (("Point1", [args.profile_x, b[2], cz]),
+                      ("Point2", [args.profile_x, b[3], cz])):
+        try: setattr(profLine, attr, val)
+        except Exception: setattr(profLine.Source, attr, val)
+    try: profLine.Resolution = 200
+    except Exception: pass
+
+    # Exact parabola on the same line: u = Umax * 4 (y-y0)(h-(y-y0)) / h^2.
+    exactCalc = Calculator(Input=profLine)
+    exactCalc.ResultArrayName = "u_exact"
+    exactCalc.Function = (f"{args.umax}*4*(coordsY-{y0})*({h}-(coordsY-{y0}))/({h}*{h})")
+
+    view_BL = CreateView("XYChartView")
+    view_BL.ViewSize = [half_w - 2*panel_pad, bot_h - 2*panel_pad]
+    view_BL.ChartTitle = "profile at x=%g vs exact parabola" % args.profile_x
+    view_BL.BottomAxisTitle = "u"
+    view_BL.LeftAxisTitle = "y"
+    dBL_exact = Show(exactCalc, view_BL)
+    dBL_exact.UseIndexForXAxis = 0
+    dBL_exact.XArrayName = "u_exact"
+    dBL_exact.SeriesVisibility = ["Points_Y", "1"]
+    dBL_exact.SeriesColor = ["Points_Y", "0.12", "0.38", "0.85"]
+    dBL_exact.SeriesLineThickness = ["Points_Y", "4"]
+    dBL_exact.SeriesLabel = ["Points_Y", "exact"]
+    dBL_sol = Show(profLine, view_BL)
+    dBL_sol.UseIndexForXAxis = 0
+    dBL_sol.XArrayName = args.field
+    dBL_sol.SeriesVisibility = ["Points_Y", "1"]
+    dBL_sol.SeriesColor = ["Points_Y", "0.85", "0.10", "0.10"]
+    dBL_sol.SeriesLineThickness = ["Points_Y", "2"]
+    dBL_sol.SeriesLineStyle = ["Points_Y", "0"]
+    dBL_sol.SeriesMarkerStyle = ["Points_Y", "4"]
+    dBL_sol.SeriesMarkerSize = ["Points_Y", "7"]
+    dBL_sol.SeriesLabel = ["Points_Y", "MARS (solved)"]
+    view_BL.BottomAxisUseCustomRange = 1
+    view_BL.BottomAxisRangeMinimum = ulo - 0.05
+    view_BL.BottomAxisRangeMaximum = uhi * 1.08
+    view_BL.LeftAxisUseCustomRange = 1
+    view_BL.LeftAxisRangeMinimum = b[2] - 0.03*h
+    view_BL.LeftAxisRangeMaximum = b[3] + 0.03*h
+
+    # Centerline development u(x) at mid-height.
+    centerLine = PlotOverLine(Input=reader)
+    ymid = 0.5 * (b[2] + b[3])
+    for attr, val in (("Point1", [b[0], ymid, cz]),
+                      ("Point2", [b[1], ymid, cz])):
+        try: setattr(centerLine, attr, val)
+        except Exception: setattr(centerLine.Source, attr, val)
+    try: centerLine.Resolution = 300
+    except Exception: pass
+
+    view_BR = CreateView("XYChartView")
+    view_BR.ViewSize = [half_w - 2*panel_pad, bot_h - 2*panel_pad]
+    view_BR.ChartTitle = "centerline u(x): development toward U_max=%g" % args.umax
+    view_BR.BottomAxisTitle = "x"
+    view_BR.LeftAxisTitle = "u centerline"
+    dBR = Show(centerLine, view_BR)
+    dBR.UseIndexForXAxis = 0
+    dBR.XArrayName = "Points_X"
+    dBR.SeriesVisibility = [args.field, "1"]
+    dBR.SeriesColor = [args.field, "0.85", "0.10", "0.10"]
+    dBR.SeriesLineThickness = [args.field, "3"]
+    dBR.SeriesLabel = [args.field, "u(x, y=H/2)"]
+    view_BR.LeftAxisUseCustomRange = 1
+    view_BR.LeftAxisRangeMinimum = 0
+    view_BR.LeftAxisRangeMaximum = uhi * 1.08
+    view_BR.BottomAxisUseCustomRange = 1
+    view_BR.BottomAxisRangeMinimum = b[0]
+    view_BR.BottomAxisRangeMaximum = b[1]
+
+# --- Compositing ----------------------------------------------------------------
+try:
+    from PIL import Image, ImageDraw, ImageFont
+    have_pil = True
+except ImportError:
+    have_pil = False
+    if not simple_mode:
+        print("WARNING: PIL unavailable -- falling back to simple layout")
+        simple_mode = True
+
+def _font(size):
+    for path in ("/System/Library/Fonts/Helvetica.ttc",
+                 "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+                 "/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf"):
+        try: return ImageFont.truetype(path, size)
+        except Exception: continue
+    return ImageFont.load_default()
+
+font_big = _font(34) if have_pil else None
 
 for i, t in enumerate(times):
-    view.ViewTime = t
-    Render(view)
-    SaveScreenshot(os.path.join(out_dir, f"frame_{i:04d}.png"), view,
-                   ImageResolution=[args.width, args.height])
-    print(f"frame {i + 1}/{len(times)}  t={t:.2f}")
+    if simple_mode:
+        view_T.ViewTime = t
+        Render(view_T)
+        SaveScreenshot(os.path.join(out_dir, f"frame_{i:04d}.png"), view_T,
+                       ImageResolution=list(view_T.ViewSize))
+    else:
+        views = [("T", view_T), ("BL", view_BL), ("BR", view_BR)]
+        paths = {}
+        for name, v in views:
+            v.ViewTime = t
+            try: v.Update()
+            except Exception: pass
+            p = os.path.join(out_dir, f"_{name}_{i:04d}.png")
+            SaveScreenshot(p, v, ImageResolution=list(v.ViewSize))
+            paths[name] = p
+        canvas = Image.new("RGB", (args.width, args.height), (255, 255, 255))
+        imgs = {k: Image.open(p) for k, p in paths.items()}
+        canvas.paste(imgs["T"],  (panel_pad, 56 + panel_pad))
+        canvas.paste(imgs["BL"], (panel_pad, 56 + top_h + panel_pad))
+        canvas.paste(imgs["BR"], (half_w + panel_pad, 56 + top_h + panel_pad))
+        draw = ImageDraw.Draw(canvas)
+        draw.rectangle([(0, 0), (args.width, 56)], fill=(25, 25, 25))
+        draw.text((16, 9), f"MARS Poiseuille validation    t = {t:6.2f}",
+                  fill=(255, 255, 255), font=font_big)
+        canvas.save(os.path.join(out_dir, f"frame_{i:04d}.png"))
+        for p in paths.values():
+            try: os.remove(p)
+            except OSError: pass
+    print(f"frame {i+1}/{len(times)}  t={t:.2f}")
 
 if not args.no_mp4:
     ffmpeg = shutil.which("ffmpeg")
     if ffmpeg:
         mp4 = args.pvd + "_movie.mp4"
-        subprocess.run([ffmpeg, "-y", "-framerate", str(args.fps),
+        subprocess.run([ffmpeg, "-y", "-loglevel", "error",
+                        "-framerate", str(args.fps),
                         "-i", os.path.join(out_dir, "frame_%04d.png"),
                         "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "18",
                         mp4], check=True)


### PR DESCRIPTION
- **fix(pump): revive the pressure outlet (the REAL through-flow fix). outletU was set unconditionally -> always velocity-Dirichlet outlet -> both-ends-Dirichlet admits a flat-pressure tank-recirculation div=0 solution -> NO flow through the passage (confirmed: 1e-10 pressure solve gave identical flat-p, so it's structural not convergence -- AMG would NOT help). Gate outletU on !outletDoNothing so do-nothing (default) leaves outletU<=0 -> solver masks the WHOLE outlet face p=0 + frees outlet velocity (singlePin=false, solver:4080) -> inlet flux against fixed-p outlet FORCES the outlet->suction gradient -> through-flow. The dead --outlet flag now actually works**
- **fix(pump): default outlet back to MASS-CONSERVING (the correct design). Root cause found: the divergence operator only loops interior faces (sum(div)==0 always), so the pressure solve is NEVER told mass enters at the inlet -> a velocity-inlet + free pressure-outlet is UNPROJECTABLE -> no through-flow (flow dies at inlet, pressure parks in body). The code's own comment (solver:2295) flags this. My prior do-nothing default was backwards: the mass-conserving outlet (vel outflow removes Q + single pin) BALANCES the flux so the projection builds the inlet->outlet gradient that drives flow through the passage. The dead-flag gate stays so do-nothing is still selectable (needs a boundary-flux source term to be correct -- separate work)**
- **pump through-flow: (1) default to do-nothing outlet = whole-face p=0 + FREE outlet velocity (the channel-proven pairing that builds the inlet->outlet pressure head; both-ends-velocity-Dirichlet + single pin gave a flat-pressure dead-passage solution). (2) --inlet-flux-source (GUARDED, off): add the prescribed inlet flux as a boundary divergence source -- the exterior opening flux is in no interior SCS so it's never integrated (verified not a double-count); A/B it. (3) [through-flow] Q_in/Q_out/ratio diagnostic each step so we MEASURE through-flow (ratio->1) instead of eyeballing uMax. mass-conserving still selectable. cavity/channel/TGV unaffected**
- **pump: REMOVE the broken --inlet-flux-source (double-counted the inlet flux already registered via interior SCS scatter; full-opening-area x rho/dt -> instant blowup, ratio=garbage) and revert default to MASS-CONSERVING outlet. Verified high-confidence: the inlet flux is already in the divergence for a velocity-Dirichlet inlet, so the only correct inlet boundary source is ZERO. do-nothing (whole-face p=0 + free outlet) does NOT self-drive a small interior outlet -> ratio=0 (no through-flow); the prior do-nothing-default + comments were disproven by the A/B. mass-conserving (U_out=Uin*Ain/Aout + single pin) forces Q_out=Q_in by construction. Kept the [through-flow] Q diagnostic (correct + useful)**
- **pump through-flow REWORK (verified root cause): the reference flows through the pump with ANY scheme (bj/upwind) so the dead passage is OUR bug, not Re/scheme. TWO real defects fixed: FIX1 --opening-flux-source (GUARDED off): inlet/outlet OPENING faces are exterior, in no interior SCS, so the prescribed opening flux never reaches the pressure RHS -> pressure flat -> no through-flow. Add it as a COMPATIBLE surface integral (u.n)*A_share, SAME scale as interior scatter, NOT x rho/dt (RHS does it), net~0 -- verified NOT a double-count (telescoping interior pairs never touch the opening face). FIX2 --dirichlet-lift (default ON): velocity-diffusion col-zero had no Dirichlet lift -> inlet momentum never diffused inward -> jet died at inlet. Add b-=K[row,bdry]*uTarget. FIX3: replace TAUTOLOGICAL Q_out (relocked to prescribed outletU) with an INTERIOR cut-plane flux probe at 25/50/75% -- measures SOLVED through-flow, can't be faked. old line relabeled [bc-sanity]**
- **pump FIX B: pressure-drop drive via --pump-dp=VALUE (gated, off by default -> existing pump byte-identical). Root cause: the divergence operator integrates only INTERIOR SCS faces, so a VELOCITY prescribed on the interior inlet opening is invisible to the pressure solver (exterior opening face never integrated) + the corrector freezes velocity-Dirichlet nodes -> no through-flow (proven: interior-flux mid-cut=0). FIX B masks BOTH openings as pressure-Dirichlet (p=dP inlet, p=0 outlet), frees both velocities, seeds the dP head in d_p -> flow EMERGES from the interior gradient (SCS-captured, VISIBLE). Startup-safe: two Dirichlet faces make the matrix NONSINGULAR -> no compatibility condition -> no FIX-1 source-blowup. inlet velocity becomes an OUTPUT (tune dP to hit ~0.5 m/s). Keeps interior-flux probe to verify mid-cut goes nonzero**
- **pump FIX B phi-lift (the piece that makes dP actually drive flow). Bug: FIX B seeded a one-node dP spike + pinned the phi increment to 0 at both faces -> interior never relaxed into the inlet->outlet gradient -> dP didn't drive flow (identical tiny flow at dP=1000 vs 30000). FIX: pin the SOLVED pressure to the target via rhs=target-p^n at masked DOFs (clamp to constant, NOT additive -> steady+bounded), so the Poisson solve imposes dP->0 Dirichlet data + relaxes the spanning gradient; the already-live predictor grad(p^n) then drives through-flow. LOAD-BEARING: pump runs DDT matrix-free, so the lift goes in solvePressureDDT's boundary-pin lambda (not the K-path). All gated pumpDp>0; pumpDp<=0 byte-identical (cavity/channel/TGV untouched)**
- **pump THROUGH-FLOW fix: prescribed-balanced opening-flux source (default ON). The verified root cause: a velocity-inlet's opening flux is invisible to the pressure solver (divergence integrates interior SCS only) -> flat passage -> dead passage (proven: interior-flux cut@50%=0). FIX: inject the opening flux into divAccNode so the projection SEES the inflow and builds the inlet->outlet gradient that drives the passage. KEY over the broken FIX 1: use PRESCRIBED GLOBAL-direction velocities (Uinf*inletDir, outletU*outletDir) not the solved u** -> inlet sums to -Q_in, outlet to +Q_in (outletU=Uin*Ain/Aout) -> total=0 EXACTLY every step incl step0 -> single-pin Neumann stays compatible -> CANNOT blow up like FIX 1 (which used u**=0 at the step0 outlet -> one-sided -> phi=1e36). Config: mass-conserving velocity inlet+outlet (sustains the jet) + this source (makes it visible). No removeMean (pin handles it). FIX B (pumpDp) abandoned, gated off**
- **pump: default opening-flux-source back OFF -- the prescribed-balanced source STILL blows up at step0 (phi=1e7->inf, CG residual grows = incompatible, same FLT_MAX as FIX 1). The 'sum=0 by construction' startup-safety proof was WRONG: the discrete per-node area shares evidently do not sum to exactly Q, so sum!=0, x rho/dt=1e6 -> explodes even at step0. Revert to the STABLE mass-conserving default (no through-flow, but runs). The opening-flux-source remains a flag for debugging but is NOT a working fix. Through-flow is UNRESOLVED -- see scratch/pump_throughflow_HANDOFF.md**
- **pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B**
- **Revert "pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B"**
- **debug: MARS_OFS_DBG -- print divAccNode |max| before/after the opening-flux source + the global net source sum, to SEE if the source is a giant localized spike (divAcc max jumps) and whether net is actually ~0. Instrumentation only, gated on env. Investigating the repeated step0 phi=1e7 blowup**
- **debug: print Qin_raw/Qout_raw separately -- the [ofs-dbg] net=-Q_in (one-sided) proves the OUTLET source contributes ZERO. Need to see Qin_raw vs Qout_raw to find why the outlet half does not fire (area-vec sign? outletDir?)**
- **pump: adjustPhi rescale FOUND THE BUG via debug -- the discrete inlet/outlet fluxes differ ~1.5% (Qin_raw=-5.975e-3, Qout_raw=+5.884e-3), NOT roundoff: the per-node area-vectors sum to a different value than the analytic areaIn/areaOut used for outletU. That 9e-5 residual x rho/dt=1e6 -> incompatible RHS -> phi=1e7 blowup. FIX: oScale=-Qin_raw/Qout_raw, rescale the outlet source so it EXACTLY cancels the inlet (net->0). The reductions now always run (not just debug). [ofs-dbg2] prints the net to confirm it goes to ~0**
- **pump: removeMean for the opening-flux source -- THE ACTUAL FIX. Debug PROVED the blowup is NOT flux imbalance: with the adjustPhi rescale the net source is bit-exactly 0 (8.67e-19) and it STILL blew up to phi=1e7 identically. Real cause (the code's own comments flag it: lines 897/2209/3333/5145): the single p=0 pin weakly controls the DDT constant null space; a boundary source excites that mode and Jacobi-PCG loses pAp>0 (residual GROWS 0.98->1.46 then garbage phi=1e7). FIX: removeMean the RHS + phi (project the null-space component out) when opening-flux is on -- the same cure the periodic path uses. Gated on useOpeningFluxSource**
- **debug: removeMean did NOT fix the blowup (phi=1e7 identical) -> null-space theory also wrong. KEY realization: the CG CONVERGES (3e-8), so phi=1e7 is the TRUE solution -- the operator+RHS are fine, the answer is legitimately huge. Add [ofs-dbg3] b|max and [ofs-dbg4] phi|max split by OPENING vs INTERIOR nodes, to decide: is phi huge only at the opening nodes (tiny DDT boundary-layer diagonal, b/diag=1e6*1e-4/1e-5=1e7 LOCAL) or everywhere (global)? That picks the final fix**
- **pump: --source-ramp-steps=N gentle startup for the opening-flux source. ROOT CAUSE (measured): the source WORKS (real through-flow, step1 cut@50% nonzero) but starting from rest at full strength dumps the whole inlet->outlet pressure head onto a near-singular interior node (sliver cell, DDT diag=1e-5, 600x below bulk) -> phi spikes to 6e6 there -> grad(phi) spike -> corrector velocity spike -> advection 950x/step -> blowup. NOT fixable by clip (preconditioner-only, phi is the true solution), CFL (structural per-step amplification), or balance/removeMean (all already correct). FIX: ramp Uinf 0->full over N steps so the head + phi + grad stay small while flow develops gently. Scales the inlet velocity target (from a base snapshot) AND the opening-flux source (reads Uinf live) -> balance preserved at every ramp level**
- **pump: allow dt to shrink up to 2x/step (was 5%/step). With the ramp, the flow develops stably for ~16 steps (phi=1e4, u_max bounded+growing, cut@50% nonzero) then a CFL violation at u~100 ran away because the 5%/step shrink cap could not drop dt fast enough to catch it. Fast shrink catches the violation in one step; growth stays gentle (5%/step) so BDF2's constant-dt assumption holds at steady state**
- **pump: targeted operator-diagonal floor on the matrix-free DDT (the sliver-node fix). MEASURED: the ramp fixes startup (steps 1-16 stable, flow developing, cut@50% nonzero) but one sliver interior node (tiny SCS face areas -> DDT diag=1e-5, 600x below bulk) makes phi spike there -> corrector velocity spike -> diffusion CG breaks (pAp<0, u**>>u*) -> blowup, even at dt=5e-8 (so NOT CFL). Jacobi clip is preconditioner-only (no-op on phi). FIX: raise ONLY the degenerate rows to epsFloor=0.05*max_diag in the TRUE matrix-free operator via per-node shift out[i]+=shift_i*phi[i]; 0 on the healthy bulk -> byte-identical there -> cavity/channel/cube16 untouched. Caps phi at b/3.3e-4 (~31x smaller) -> below blowup threshold. Pure positive diagonal add -> keeps SPD. Preconditioner diag floored to match. Velocity diffusion needs NO floor (M/dt keeps it conditioned; its divergence was downstream of the phi spike). Env MARS_DDT_OP_FLOOR_FRAC**
- **debug: MARS_CHECKER -- per-element mean-free pressure RMS diagnostic (the checkerboard mode an inf-sup stabilizer penalizes). Lets us SEE the checkerboard grow + SEE a stabilizer kill it in a few steps, instead of inferring from a full-run blowup. Confirms/quantifies the LBB decoupling diagnosis. Env-gated, tet-only, rank0, free in production. NOTE: adjudication confirmed BD-on-DDT is WRONG (breaks div=0 identity, accumulating divergence); the identity-safe path is VMS/RC on the divergence SOURCE (needs a phi-vs-d_p fix). Checkerboard fix != through-flow fix (separate defects)**
- **fix: checker diagnostic compile error -- a pair-returning __device__ lambda in transform_reduce needs its return type proclaimed in host context. Split into two scalar (double) reductions (mean-free energy + total) -- avoids the trait error, same result**
- **pump: replace the div-BREAKING operator-diagonal floor with an identity-safe MASS floor. The operator floor (out[i]+=shift*phi in applyDDTPerNode) only the OPERATOR saw, not the corrector -> solving (A+S)phi=b left div(u^{n+1})=(dt/rho)*S*phi un-projected -> accumulating residual -> smooth |p| 1e3->1e34 blowup (the SAME div=0-breaking class the code warns against for BD-on-DDT, lines 5602-5610). FIX: floor the lumped mass d_massNode instead -- A=D M^-1 D^T and the corrector ALSO applies M^-1 from the same d_massNode, so flooring mass changes operator AND corrector consistently -> div=0 PRESERVED. Removed d_shiftDDTNode + its apply + the operator-floor build. Env MARS_MASS_FLOOR_FRAC (default 1e-3*max_mass)**
- **pump: implicit PSPG pressure stabilization (--pspg) -- the CORRECT equal-order checkerboard fix. VERIFIED root cause of the checkerboard blowup: the existing VMS adds tau*(-lap p^n) to the RHS = an EXPLICIT forward-Euler Laplacian-of-p update -> unconditionally amplifies the high-freq mode at ANY tau (why 1e-6/1e-5/1e-3 all blew up). FIX: add tau*L*phi IMPLICITLY inside applyDDTPerNode so CG solves (A+tau*L)phi=b. L=sum_e V_e G^T G is symmetric PSD, shares A's constant null mode (removed by the pin) -> SPD, damps checkerboard at ALL tau>0. Acts on phi (the correction, ->0) so it self-extinguishes; post-corrector div relaxes to ~tau*lap(phi)=O(h^2), a CONSISTENT residual that vanishes under refinement -- the textbook PSPG, NOT the inconsistent div-breaking BD/floor. tau=h^2/24 (a LENGTH^2, not dt/rho). Confirm via MARS_CHECKER: frac must shrink. New kernel applyPSPGLaplacianTetKernel; gated --pspg, tau auto or --pspg-tau**
- **pump PSPG: FIX THE SIGN. The DDT operator outAcc = D M^-1 D^T phi ~ -lap(phi) (SPD-positive; A=-lap, matches b=-coef*div). My PSPG scattered +div(grad phi)=+lap(phi) = OPPOSITE sign -> SUBTRACTED definiteness (made conditioning worse, no damping). Flip: scatter -s to iL / +s to iR so it adds +tau*(-lap)phi = positive energy, same orientation as A. This is why the first PSPG run showed frac still growing + cg_p=-2 (wrong-sign term de-conditioned the operator). NOTE: that run ALSO lost the Jacobi clip (diag=6.5e-12) -- must pass MARS_DDT_JACOBI_CLIP_FRAC for the sliver**
- **pump PSPG: add tau*L diagonal to the Jacobi preconditioner (the REAL bug). Numerically verified (host dense-matrix replica): my PSPG sign was CORRECT (-s/+s -> L=+Vol*G^T*G, same sign as A=-lap, A+tau*L more SPD). The cg_p=-2 failure was the PRECONDITIONER mismatch: operator ran A+tau*L but d_diagDDT was built from A only -> worst on the sliver rows (tiny A-diag, large tau*L-diag) -> CG stalls. FIX: computeTetPSPGDiagonalKernel scatters tau*Vol*|dNdx_i|^2 into d_diagAccNode (before halo/gather) so the preconditioner matches the stabilized operator. Gated usePSPG, tet-only. Sign left unchanged (verified correct)**
- **pump: pin the degenerate sliver DOF(s) -- the identity-safe fix for the unsolvable pressure (cg_p=-2). A near-zero-volume tet gives a DDT diagonal ~9 OOM below bulk (1e-12 vs 6e-3); Jacobi-PCG cannot solve it. FIX: mask any owned DOF with diag < MARS_SLIVER_PIN_FRAC*max_diag (default 1e-6) into d_isPressureBdryDof -> the operator forces out=phi (identity row) AND the RHS forces b=0, exactly like the outflow/pin DOFs (verified both paths check maskPtr). One removed equation, div-safe. Makes the pressure solvable so the real physics + PSPG become readable. The mass floor was the wrong lever (sliver diag is AREA-driven, not mass); this pins the node directly**
- **poiseuille validation example: channel-fork NS solver with balanced opening-flux source; parabola matches analytic profile within reference tolerance (RMS 5.8e-3 < 6e-3, interior flux ratio ~1). Plus tutorial.**
- **pump: assembled tet DDT operator + FlexGMRES (toward Hypre AMG pressure solve). (1) ASSEMBLE the matrix-free D M^-1 D^T into CSR for tet (buildDDTSparsityTet + assembleDDTPerNodeKernelTet, node-driven so the per-node M^-1 cross-element face pairs are captured; tet nodeFaces[4][3]={{0,2,3},{0,1,4},{1,2,5},{3,4,5}} derived from d_tetLRSCV). Same operator as matrix-free (verify bit-identical via MARS_DDT_PROBE_DIFF, PSPG off) -> corrector stays div=0-exact. GPU-resident; only host touch is the rank0 setup [DDT-health] print. Matrix-free path UNTOUCHED (gated, additive -- can return to it). (2) FlexGMRES in the Hypre wrapper (default for BoomerAMG, the right Krylov for a varying AMG preconditioner; env MARS_HYPRE_FLEXGMRES). NOT YET COMPILED (no nvcc locally)**
- **pump: assemble PSPG tau*L into the DDT CSR (assemblePSPGStiffnessTetKernel). Element-driven 4x4 tet stiffness tau*Vol*(dNdx_i.dNdx_j) scattered via atomicAddSparseEntry into the existing DDT two-hop sparsity (subset, no new entries). Same tau*L the matrix-free path adds -> assembled A+tau*L == matrix-free A+tau*L. Iterates halo elements (elementCount includes halo) so owned boundary rows get cross-rank stiffness; writes owned rows only. Gated usePSPG. This (a) keeps PSPG on the assembled/Hypre path and (b) regularizes the Gram-form DDT toward diagonal dominance so Jacobi/BoomerAMG can precondition the 9-OOM operator. GPU-resident**
- **pump: activate the assembled DDT pressure solve on --solver=hypre. Re-gate the assembled-DDT block (was MARS_DDT_USE_ASSEMBLED_CG && CG only) to ALSO fire on solverKind==Hypre && nnzDDT>0 -> the SAME operator (D M^-1 D^T + assembled PSPG tau*L) is solved by Hypre FlexGMRES+BoomerAMG instead of matrix-free Jacobi-CG. Matrix-free path UNTOUCHED as the default (no --solver=hypre -> byte-identical). The wrapIntoSparseMatrix(s.AddT) now fires for tet automatically (nnzDDT>0). Global-DOF numbering + MPI partitioning already built at setup for the Hypre path. End-to-end: --solver=hypre -> assembled gate -> solveOneComponent(GMRES) -> FlexGMRES+AMG. Validate via MARS_DDT_PROBE_DIFF (PSPG off) first**
- **fix(pump): remove duplicate template clause before assembleDDTPerNodeKernelTet (my PSPG-kernel insert left an orphan template<> -> 'multiple template clauses' compile error)**
- **pump driver: parse --solver=hypre (was hardcoded SolverKind::CG -> the assembled Hypre path could never activate; explains why --solver=hypre runs were silently matrix-free CG). Sets SolverKind::Hypre -> the assembled DDT + FlexGMRES+BoomerAMG gate fires. --solver=cg restores default. Banner prints the active pressure path**
- **fix(pump hypre): skip the sliver-pin on the Hypre/assembled path. The pin reads the matrix-free d_diagDDT (tiny entries floored to 1 -> globalMax=1 -> 1e-6 threshold pinned ~220k DOFs), and enforcePressureBcRhsKernel then ZEROED b at all those rows -> RHS~0 -> phi=0 every step (no flow: u stuck at 0, div never projected). BoomerAMG handles the conditioning without pinning, so gate the pin on solverKind!=Hypre. This was why --solver=hypre ran stable but produced phi=0**
- **fix(pump hypre): force the VELOCITY solve onto in-house CG even under --solver=hypre. Root cause of the dead u=0 run: solverKind==Hypre routed the velocity matrix (M/dt + nu*K, mass-dominated / near-diagonal) through BoomerAMG-PCG, which is the wrong tool for a non-elliptic mass matrix -> exits ~1 iter returning x~0 -> u**=0 -> div(u**) RHS=0 -> phi=0 -> nothing develops. FIX: add forceCG param to solveOneComponent; velocity solves pass forceCG=true so they use the in-house CG (~14 iters, works) regardless of solverKind. Hypre/AMG stays reserved for the ill-conditioned DDT PRESSURE operator -- the only thing that needs it. (Also: pres_r0=0 under hypre is a stale-diagnostic artifact, lastPressR0 only written in the matrix-free path)**
- **poiseuille: --check regression mode + ctest entry, velocity-fit G closure (100.8% of exact), single-station profile CSV + plot script, u-field render script; fix wall-eps node pinning; document the incremental-p artifact (visualize u, not umag/p)**
- **debug(pump hypre): add MARS_SOLVE_TRACE -- prints converged/iters/|xVec|max right after the Hypre solve, to pin down whether phi=0 is (a) converged=false so xVec never scattered to qOut, or (b) xVec~0 itself. The verbose run showed BoomerAMG sets up + runs (b nonzero, L2=15) but only ~2 cycles at conv factor 0.43 -> likely final_res>tol -> converged=false -> no scatter -> phi=0**
- **poiseuille render: pump-style 3-panel validation layout (field + animated profile-vs-exact + centerline development), PIL composite + header**
- **fix(pump hypre): enforce the single pin into the ASSEMBLED DDT matrix (d_valuesDDT), not just the K-path d_valuesPre. ROOT CAUSE of phi=0: the pin row was only applied to d_valuesPre (K-path), so the assembled DDT operator s.AddT stayed SINGULAR (pure-Neumann pump pressure has a constant null mode). BoomerAMG/FlexGMRES on a singular operator returned the null-space solution = 0 -> 'converged in 2 iters', x=0, phi=0 (proven by MARS_SOLVE_TRACE: pressure solve converged=1 iters=2 |xVec|max=0 while velocity solves gave real nonzero x). FIX: enforcePinRowKeepDiagKernel on d_rowPtrDDT/d_colIndDDT/d_valuesDDT too (keepDiag = AMG-friendly). Single pin is the correct null-space removal for the pure-Neumann pump (matches the reference's 'single pressure reference')**
- **fix(pump hypre): accept a best-effort pressure solve (rel-res < MARS_HYPRE_ACCEPT_RES, default 1e-2) instead of requiring final_res<1e-8. Diagnosis via MARS_SOLVE_TRACE+Jacobi: FlexGMRES+Jacobi runs full 2000 iters and produces a NONZERO xVec (1930, growing) but stalls at res~7e-3 -> the strict converged gate rejected it -> not scattered -> phi=0 -> dead. A projection step does not need machine-precision phi; a partial solve removes most divergence. Now accept it. (AMG still falsely converges at x=0 on this near-singular op -- separate, retune next; Jacobi is the working floor)**
