### PR TITLE
cstone

### DIFF
--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -7831,17 +7831,15 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
                 cudaDeviceSynchronize();
             }
             cudaMemset(xVec.data(), 0, s.numTotalDofs * sizeof(RealType));
-            // Krylov choice depends on the operator's definiteness:
-            //  - PSPG ON: A = D M^-1 D^T + tau*L is SPD (tau*L is a real Laplacian)
-            //    and the symmetric pin removes the null mode -> use Hypre PCG.
-            //    CG+AMG is the textbook pressure-Poisson solver (deal.II/MFEM/Nalu)
-            //    and is far more stable than FlexGMRES on this operator.
-            //  - PSPG OFF: bare D M^-1 D^T is SPSD with a constant null mode that
-            //    Hypre PCG rejects (error 1) -> must use GMRES, which tolerates it.
-            // (MARS_HYPRE_KRYLOV=pcg|gmres still overrides for debugging.)
-            KrylovHint pressureKrylov = s.usePSPG ? KrylovHint::PCG : KrylovHint::GMRES;
+            // Use FlexGMRES for the pressure solve: it carries the null-mode +
+            // upper-bound-x guards (the PCG wrapper does NOT), which are what keep
+            // a near-singular / under-resolved huge phi from being scattered and
+            // blowing up the corrector. PCG+AMG is in principle the textbook SPD
+            // pressure solver, but routing --pspg to PCG LOST those guards and a
+            // converged-but-huge phi (1e123) blew the run up. Keep GMRES until the
+            // guards are ported to the PCG wrapper. (MARS_HYPRE_KRYLOV overrides.)
             s.lastPressureIters = solveOneComponent<KeyType, RealType, ElementTag>(
-                s, b, xVec, s.d_phi, s.AddT, pressureKrylov);
+                s, b, xVec, s.d_phi, s.AddT, KrylovHint::GMRES);
             // DIAGNOSTIC: sample WHOLE vectors via D2H, compute max-abs on
             // host. Lets us see whether the solution actually propagated.
             // Active only when env MARS_DDT_DIAG_AFTER_HYPRE is set.

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -7831,15 +7831,17 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
                 cudaDeviceSynchronize();
             }
             cudaMemset(xVec.data(), 0, s.numTotalDofs * sizeof(RealType));
-            // Use FlexGMRES for the pressure solve: it carries the null-mode +
-            // upper-bound-x guards (the PCG wrapper does NOT), which are what keep
-            // a near-singular / under-resolved huge phi from being scattered and
-            // blowing up the corrector. PCG+AMG is in principle the textbook SPD
-            // pressure solver, but routing --pspg to PCG LOST those guards and a
-            // converged-but-huge phi (1e123) blew the run up. Keep GMRES until the
-            // guards are ported to the PCG wrapper. (MARS_HYPRE_KRYLOV overrides.)
+            // PSPG ON -> A = D M^-1 D^T + tau*L is SPD (symmetric pin removes the
+            // null mode) -> Hypre PCG+AMG, which EMPIRICALLY converges on our GPU
+            // (16 iters, flow develops) where GMRES+AMG no-ops to x=0 (a separate
+            // GMRES-wrapper GPU bug to fix). CG+AMG is also the textbook pressure-
+            // Poisson solver. The PCG wrapper now carries the same null + upper-x
+            // guards as GMRES, so a huge/near-null phi is rejected, not scattered.
+            // PSPG OFF -> SPSD -> PCG rejects (error 1) -> GMRES.
+            // (MARS_HYPRE_KRYLOV=pcg|gmres overrides for debugging.)
+            KrylovHint pressureKrylov = s.usePSPG ? KrylovHint::PCG : KrylovHint::GMRES;
             s.lastPressureIters = solveOneComponent<KeyType, RealType, ElementTag>(
-                s, b, xVec, s.d_phi, s.AddT, KrylovHint::GMRES);
+                s, b, xVec, s.d_phi, s.AddT, pressureKrylov);
             // DIAGNOSTIC: sample WHOLE vectors via D2H, compute max-abs on
             // host. Lets us see whether the solution actually propagated.
             // Active only when env MARS_DDT_DIAG_AFTER_HYPRE is set.

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -5891,8 +5891,12 @@ int solveOneComponent(NSStepper<KeyType, RealType, ElementTag>& s,
             // strict (final_res<tol) gate threw away a nonzero, useful xVec when
             // the solve stalled short of 1e-8 (Jacobi got to ~7e-3 -> rejected ->
             // phi=0 -> dead). Accept when the relative residual is below a usable
-            // threshold (MARS_HYPRE_ACCEPT_RES, default 1e-2) AND xVec is finite.
-            RealType acceptRes = RealType(1e-2);
+            // threshold (MARS_HYPRE_ACCEPT_RES) AND xVec is finite. Default 1e-6:
+            // a properly-converged AMG solve reaches this easily; the old loose
+            // 1e-2 admitted under-resolved huge-amplitude phi (res~2e-4) that blew
+            // up the corrector. If a solve can't reach 1e-6 we WANT it rejected
+            // (phi stays at the warm-started prior) rather than scattering garbage.
+            RealType acceptRes = RealType(1e-6);
             if (const char* ev = std::getenv("MARS_HYPRE_ACCEPT_RES"))
             { double v = std::atof(ev); if (v > 0) acceptRes = RealType(v); }
             // Best-effort acceptance must NOT swallow the null-mode false

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -7831,11 +7831,17 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
                 cudaDeviceSynchronize();
             }
             cudaMemset(xVec.data(), 0, s.numTotalDofs * sizeof(RealType));
-            // DDT operator (D M^-1 D^T) is SPSD with constant null space; Hypre
-            // PCG rejects it (error 1). GMRES tolerates it. Hint passes through
-            // to solveOneComponent which selects HypreGMRESSolver wrapper.
+            // Krylov choice depends on the operator's definiteness:
+            //  - PSPG ON: A = D M^-1 D^T + tau*L is SPD (tau*L is a real Laplacian)
+            //    and the symmetric pin removes the null mode -> use Hypre PCG.
+            //    CG+AMG is the textbook pressure-Poisson solver (deal.II/MFEM/Nalu)
+            //    and is far more stable than FlexGMRES on this operator.
+            //  - PSPG OFF: bare D M^-1 D^T is SPSD with a constant null mode that
+            //    Hypre PCG rejects (error 1) -> must use GMRES, which tolerates it.
+            // (MARS_HYPRE_KRYLOV=pcg|gmres still overrides for debugging.)
+            KrylovHint pressureKrylov = s.usePSPG ? KrylovHint::PCG : KrylovHint::GMRES;
             s.lastPressureIters = solveOneComponent<KeyType, RealType, ElementTag>(
-                s, b, xVec, s.d_phi, s.AddT, KrylovHint::GMRES);
+                s, b, xVec, s.d_phi, s.AddT, pressureKrylov);
             // DIAGNOSTIC: sample WHOLE vectors via D2H, compute max-abs on
             // host. Lets us see whether the solution actually propagated.
             // Active only when env MARS_DDT_DIAG_AFTER_HYPRE is set.

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -351,6 +351,32 @@ __global__ void enforcePinRowKeepDiagKernel(int pinDof,
     if (!(values[dp] > RealType(0))) values[dp] = RealType(1);
 }
 
+// Read the diagonal value of one row into a single-element device buffer.
+// Used to capture the pump pin's NATIVE diagonal before BC enforcement
+// overwrites it, so it can be restored afterwards (keeps AMG-friendly scaling).
+template<typename RealType>
+__global__ void readRowDiagonalKernel(int row, const int* diagPtr,
+                                      const RealType* values, RealType* out)
+{
+    if (blockIdx.x * blockDim.x + threadIdx.x != 0) return;
+    if (row < 0) { *out = RealType(0); return; }
+    int dp = diagPtr[row];
+    *out = (dp >= 0) ? values[dp] : RealType(0);
+}
+
+// Write a given value into the diagonal of one row (off-diagonals untouched).
+// Restores the pump pin's native diagonal after the whole-face BC kernel forced
+// it to 1.0, removing the conditioning spike that breaks BoomerAMG coarsening.
+template<typename RealType>
+__global__ void setRowDiagonalKernel(int row, const int* diagPtr,
+                                     RealType* values, RealType val)
+{
+    if (blockIdx.x * blockDim.x + threadIdx.x != 0) return;
+    if (row < 0) return;
+    int dp = diagPtr[row];
+    if (dp >= 0) values[dp] = val;
+}
+
 // Zero RHS at the pin (called every step before the pressure solve).
 template<typename RealType>
 __global__ void enforcePinRhsKernel(int pinDof, RealType* rhs)
@@ -2371,6 +2397,10 @@ struct NSStepper
     // entire outflow face. Exactly one mechanism is active per run.
     int pressurePinDof = -1;   // owned-DOF id on the owning rank; -1 elsewhere (or in channel mode)
     int pressurePinRank = 0;   // global rank that owns the pin
+    // Native (pre-BC) assembled-DDT diagonal at the pump single-pin row. Captured
+    // before BC enforcement so the AMG-friendly diagonal can be restored after the
+    // whole-face kernel forces the pin diagonal to 1.0. 0 => not captured / not used.
+    RealType pinNativeDiagDDT = RealType(0);
     cstone::DeviceVector<uint8_t> d_isPressureBdryDof;   // size numOwnedDofs; only used in channel mode
     // FIX B (pump --pump-dp>0): per-OWNED-DOF target pressure at the masked
     // faces (pumpDp on inlet, 0 on outlet, 0 elsewhere). The lift enforce reads
@@ -4744,6 +4774,24 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
 
         s.pressurePinDof  = -1;
         s.pressurePinRank = -1;
+        // For the pump single-pin (mass-conserving velocity outlet, no pumpDp),
+        // record WHICH owned DOF is the pin and its rank. The mask path above
+        // already flagged it, but the assembled-DDT BC enforcement below routes
+        // it through enforceBcMatrixKernel, which forces the pin diagonal to 1.0.
+        // The DDT operator's native diagonals are ~0.04-0.14, so a diag=1 pin row
+        // is 10-25x its neighbors -- exactly the conditioning spike that makes
+        // BoomerAMG's PMIS coarsening collapse the V-cycle onto the constant null
+        // mode (FlexGMRES then "converges" at x=0 in 2 iters). Tracking the pin
+        // DOF here lets the DDT block below restore its native diagonal so AMG
+        // sees a uniformly-scaled SPD row, matching the cavity fix.
+        if (singlePin && !(s.pumpDp > RealType(0)))
+        {
+            int haveOutlet = (firstOutletDof >= 0) ? s.rank : s.numRanks;
+            int pinRank = s.numRanks;
+            MPI_Allreduce(&haveOutlet, &pinRank, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+            s.pressurePinRank = pinRank;
+            s.pressurePinDof  = (s.rank == pinRank) ? firstOutletDof : -1;
+        }
         if (s.rank == 0)
         {
             if (s.pumpDp > RealType(0))
@@ -4890,18 +4938,56 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
             || s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Pump))
     {
         int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
-        // Row enforcement: zero each Dirichlet row, set diagonal to 1.
+        // Pump single-pin: capture the pin's NATIVE assembled diagonal BEFORE the
+        // whole-face BC kernel overwrites it to 1.0. We restore it after the
+        // column kernel so AMG sees a uniformly-scaled SPD pin row (no spike).
+        if (s.pressurePinDof >= 0)
+        {
+            cstone::DeviceVector<RealType> d_pinDiag(1, RealType(0));
+            readRowDiagonalKernel<RealType><<<1, 1>>>(
+                s.pressurePinDof, s.d_diagPtrDDT.data(),
+                s.d_valuesDDT.data(), d_pinDiag.data());
+            cudaDeviceSynchronize();
+            cudaMemcpy(&s.pinNativeDiagDDT, d_pinDiag.data(),
+                       sizeof(RealType), cudaMemcpyDeviceToHost);
+        }
+        // Row enforcement on the WHOLE-FACE Dirichlet DOFs: zero each row, set
+        // diagonal to 1. The pump single-pin DOF (pressurePinDof>=0) must NOT go
+        // through this -- enforceBcMatrixKernel forces its diagonal to 1.0 while
+        // the DDT operator's native diagonals are ~0.04-0.14, and that single
+        // 10-25x diagonal spike is what makes BoomerAMG's PMIS coarsening collapse
+        // the V-cycle onto the constant null mode (FlexGMRES then "converges" at
+        // x=0 in 2 iters). For the pin we instead use enforcePinRowKeepDiagKernel
+        // below, which zeros the off-diagonals but KEEPS the native diagonal so
+        // AMG sees a uniformly-scaled SPD row -- the same cure the cavity pin uses.
+        // Whole-face Dirichlet (channel, pumpDp>0) is fine with diag=1: many
+        // boundary rows carry the boundary mass, so a per-row spike is negligible.
         enforceBcMatrixKernel<RealType><<<dofBlocks, s.blockSize>>>(
             s.d_isPressureBdryDof.data(), s.d_rowPtrDDT.data(), s.d_colIndDDT.data(),
             s.d_diagPtrDDT.data(), s.d_valuesDDT.data(), s.numOwnedDofs);
         // Symmetric column enforcement using per-NODE mask -- works on EVERY
-        // rank (including ghost-copies of Dirichlet nodes).
+        // rank (including ghost-copies of Dirichlet nodes). This zeros A[r,pin]
+        // in every neighbor row, which is exactly the symmetric pin AMG wants.
         enforceBcColMatrixKernelByNode<RealType><<<dofBlocks, s.blockSize>>>(
             s.d_isPressureBdryNode.data(),
             s.d_node_to_dof.data(), s.d_dofToNode.data(), s.numTotalDofs,
             s.d_rowPtrDDT.data(), s.d_colIndDDT.data(),
             s.d_valuesDDT.data(), s.numOwnedDofs);
         cudaDeviceSynchronize();
+        // PUMP SINGLE-PIN ONLY: the row kernel already zeroed the pin's
+        // off-diagonals and set its diagonal to 1.0; the column kernel zeroed
+        // A[r,pin] in every neighbor (symmetric pin). The only thing left wrong
+        // is the diag=1 spike, so write the native diagonal value back. The
+        // native value was clobbered by enforceBcMatrixKernel, which is why we
+        // captured s.pinNativeDiagDDT BEFORE the block. Guarded on >0 so a
+        // missing/non-positive native diagonal leaves the safe diag=1 in place.
+        if (s.pressurePinDof >= 0 && s.pinNativeDiagDDT > RealType(0))
+        {
+            setRowDiagonalKernel<RealType><<<1, 1>>>(
+                s.pressurePinDof, s.d_diagPtrDDT.data(),
+                s.d_valuesDDT.data(), s.pinNativeDiagDDT);
+            cudaDeviceSynchronize();
+        }
     }
     else if (s.nnzDDT > 0
              && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Cavity
@@ -4993,11 +5079,15 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
         // amplification at the pin DOF every iter -- biasing the global
         // search direction and producing the |gphi|~5x divergence injection
         // observed earlier in this session before the loop-bound fix landed.
-        // Channel/pump already get diag=1 from enforceBcMatrixKernel so they
-        // need no override. Predicted Jacobi-PCG pump iter count: ~400-700
-        // to 1e-8 (vs un-precond stall at 1e-3 after 20k).
-        if (s.pressurePinDof >= 0
-            && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Cavity)
+        // Whole-FACE Dirichlet (channel, pumpDp>0) gets diag=1 from
+        // enforceBcMatrixKernel so it needs no override. The pump SINGLE-PIN now
+        // keeps its native diagonal in s.d_valuesDDT (the AMG-spike fix above), so
+        // it ALSO needs the diag=1 override here -- the matrix-free applyDDTPerNode
+        // treats the pin as an identity row (effective diag=1), and an un-overridden
+        // ~0.04 would amplify r[pin] by ~25x in the Jacobi step. Both the cavity
+        // pin and the pump single-pin are flagged by pressurePinDof>=0.
+        // Predicted Jacobi-PCG pump iter count: ~400-700 to 1e-8.
+        if (s.pressurePinDof >= 0)
         {
             RealType one = RealType(1);
             cudaMemcpy(s.d_diagDDT.data() + s.pressurePinDof, &one,
@@ -5805,13 +5895,20 @@ int solveOneComponent(NSStepper<KeyType, RealType, ElementTag>& s,
             RealType acceptRes = RealType(1e-2);
             if (const char* ev = std::getenv("MARS_HYPRE_ACCEPT_RES"))
             { double v = std::atof(ev); if (v > 0) acceptRes = RealType(v); }
-            bool usable = (hypreSolver.getLastFinalResidual() < acceptRes);
+            // Best-effort acceptance must NOT swallow the null-mode false
+            // convergence: a tiny relative residual on an x~0 solution still
+            // passes the residual test, but that x is the null vector, not a
+            // projection. Require both a usable residual AND a non-null x.
+            bool nullSol = hypreSolver.lastReturnedNullSolution();
+            bool usable  = (hypreSolver.getLastFinalResidual() < acceptRes) && !nullSol;
             converged = converged || usable;
             iters = converged ? hypreSolver.getLastIterations() : -2;
-            if (s.rank == 0 && hypreSolver.getLastFinalResidual() > s.tolerance * 10)
+            if (s.rank == 0 && (hypreSolver.getLastFinalResidual() > s.tolerance * 10 || nullSol))
             {
                 std::cout << "  [hypre-gmres] iters=" << hypreSolver.getLastIterations()
                           << " final_res=" << hypreSolver.getLastFinalResidual()
+                          << " |x|max=" << hypreSolver.getLastSolutionMax()
+                          << " nullSol=" << (nullSol ? 1 : 0)
                           << " accepted=" << (converged ? 1 : 0)
                           << " (tol=" << s.tolerance << ")\n";
             }

--- a/backend/distributed/unstructured/fem/mars_ns_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_solver.hpp
@@ -7126,9 +7126,28 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
         s.domain.reverseExchangeNodeHaloAdd(d_gxAcc);
         s.domain.reverseExchangeNodeHaloAdd(d_gyAcc);
         s.domain.reverseExchangeNodeHaloAdd(d_gzAcc);
-        maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gxAcc);
-        maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gyAcc);
-        maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gzAcc);
+        // MARS_PRED_PERSLOT_GRADP=1 (Fable diagnosis, workflow wdxg6s3ce):
+        // SKIP the maybePeriodicSum fold on the predictor's grad(p) so it uses
+        // the SAME per-slot seam reduction the corrector/operator use under H2
+        // (NS:8462-8471, fold off). Without this, predictor grad(p) is the FOLDED
+        // full merged-CV gradient while corrector subtracts the per-slot HALF ->
+        // the mismatch (G_fold - G_perslot)*p is LINEAR in accumulated p, giving
+        // the dt-independent geometric feedback gain ~1.17 (explains why all
+        // projection-side fixes never moved it). Matching the operators makes
+        // B = A so the accumulated seam bias telescopes out in one step.
+        // Gated to multi-rank periodic CG; pump (BCKind::Pump) never enters.
+        const char* predPerSlotEnv = std::getenv("MARS_PRED_PERSLOT_GRADP");
+        const bool predPerSlot =
+            (predPerSlotEnv && std::string(predPerSlotEnv) == "1")
+            && s.numRanks > 1
+            && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+            && s.solverKind == SolverKind::CG;
+        if (!predPerSlot)
+        {
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gxAcc);
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gyAcc);
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gzAcc);
+        }
         normalizeGradientPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
             d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
             s.d_massNode.data(),

--- a/backend/distributed/unstructured/fem/mars_ns_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_solver.hpp
@@ -1892,14 +1892,21 @@ __global__ void updatePressureKernel(RealType* p,
                                      const RealType* phi,
                                      const int* nodeToDof,
                                      const uint8_t* ownership,
-                                     size_t numNodes)
+                                     size_t numNodes,
+                                     bool nonIncremental = false)
 {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numNodes) return;
     if (ownership[i] != 1) return;
     int dof = nodeToDof[i];
     if (dof < 0) return;
-    p[i] += phi[i];
+    // nonIncremental (MARS_TGV_NONINCREMENTAL=1, Fable fallback #3): p = phi
+    // instead of p += phi. Severs the pressure-accumulation edge entirely so
+    // the accumulated p never re-enters the predictor's grad(p) -> feedback
+    // loop gain is exactly 0. Cost: one formal order of pressure splitting
+    // accuracy (O(dt) vs O(dt^2)), acceptable for freely-decaying periodic TGV.
+    if (nonIncremental) p[i] = phi[i];
+    else                p[i] += phi[i];
 }
 
 // =============================================================================
@@ -9015,10 +9022,18 @@ void runCorrectorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
 
     // Pressure update + ghost sync (next step's predictor needs ghost p^{n+1}).
     // Standard incremental Chorin: p^{n+1} = p^n + phi.
+    // MARS_TGV_NONINCREMENTAL=1 (Fable fallback #3): p = phi (non-incremental)
+    // on the multi-rank periodic CG route, severing the accumulation feedback.
+    static const char* nonIncEnv = std::getenv("MARS_TGV_NONINCREMENTAL");
+    const bool nonIncremental =
+        (nonIncEnv && std::string(nonIncEnv) == "1")
+        && s.numRanks > 1
+        && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+        && s.solverKind == SolverKind::CG;
     updatePressureKernel<RealType><<<nodeBlocks, s.blockSize>>>(
         s.d_p.data(), s.d_phi.data(),
         s.d_node_to_dof.data(), d_nodeOwnership.data(),
-        s.nodeCount);
+        s.nodeCount, nonIncremental);
     cudaDeviceSynchronize();
 
     // Periodic: re-anchor pressure gauge after each cumulative incremental

--- a/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
+++ b/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
@@ -307,7 +307,7 @@ public:
             double amgStrong   = getEnvDouble("MARS_AMG_STRONG",    0.25);
             int   amgPMax      = getEnvInt   ("MARS_AMG_PMAX",      4);
             int   amgAgg       = getEnvInt   ("MARS_AMG_AGG",       0);
-            int   amgSweeps    = getEnvInt   ("MARS_AMG_SWEEPS",    1);
+            int   amgSweeps    = getEnvInt   ("MARS_AMG_SWEEPS",    2);  // l1-Jacobi(18) is weaker than SSOR; 2 sweeps restore smoothing
             if (verbose_ && rank == 0) {
                 std::cout << "  [BoomerAMG] coarsen=" << amgCoarsen
                           << " interp=" << amgInterp << " relax=" << amgRelax

--- a/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
+++ b/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
@@ -507,6 +507,21 @@ public:
                           << " -- this is the null-mode false convergence; "
                           << "reporting NOT converged.\n";
             }
+            // UPPER-BOUND reject: a |x| that is HUGE relative to |b| is an
+            // under-resolved near-null-space solution (the observed 1e7..1e9 phi
+            // from a stalled solve on a poorly-conditioned operator). Its small
+            // residual can slip a loose acceptance gate, but its gradient blows up
+            // the corrector. Reject it. Default ceiling 1e6 (an O(1)-conditioned
+            // pressure solve has |phi| ~ |b|/diag, not 1e6x|b|); MARS_HYPRE_MAXX_RATIO.
+            double maxXRatio = getEnvDouble("MARS_HYPRE_MAXX_RATIO", 1e6);
+            if (gBmax > 0.0 && gXmax > maxXRatio * gBmax) {
+                nullSolutionReturned_ = true;
+                if (rank == 0)
+                    std::cout << "[HypreGMRES] WARNING: |x|inf=" << gXmax
+                              << " >> |b|inf=" << gBmax << " (ratio>" << maxXRatio
+                              << ") -- under-resolved/null-contaminated solution; "
+                              << "reporting NOT converged.\n";
+            }
         }
 
         if (verbose_) {

--- a/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
+++ b/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
@@ -142,6 +142,23 @@ public:
 
     void setVerbose(bool verbose) { verbose_ = verbose; }
 
+    // Env-override helpers for the BoomerAMG knobs. Return the default when the
+    // var is unset or unparseable, so a typo never silently disables AMG tuning.
+    static int getEnvInt(const char* name, int defVal) {
+        const char* v = std::getenv(name);
+        if (!v || !*v) return defVal;
+        char* end = nullptr;
+        long parsed = std::strtol(v, &end, 10);
+        return (end && end != v) ? static_cast<int>(parsed) : defVal;
+    }
+    static double getEnvDouble(const char* name, double defVal) {
+        const char* v = std::getenv(name);
+        if (!v || !*v) return defVal;
+        char* end = nullptr;
+        double parsed = std::strtod(v, &end);
+        return (end && end != v) ? parsed : defVal;
+    }
+
     // Iteration count and final relative residual from the most recent solve.
     // Hypre fills these via HYPRE_GMRESGetNumIterations / GetFinalRelativeResidualNorm
     // at end of solve. Driver code reads these for per-step diagnostics so a
@@ -150,6 +167,8 @@ public:
     // print output.
     int    getLastIterations()    const { return lastNumIters_; }
     double getLastFinalResidual() const { return lastFinalRes_; }
+    double getLastSolutionMax()   const { return lastSolutionMax_; }
+    bool   lastReturnedNullSolution() const { return nullSolutionReturned_; }
 
     // The helpers below are conceptually private — they take internal Hypre
     // state and aren't meant to be called from outside — but nvcc rejects
@@ -246,28 +265,61 @@ public:
             const char* ev = std::getenv("MARS_HYPRE_VERBOSE");
             int hyprePrintLevel = (ev && std::string(ev) != "0") ? 3 : 0;
             HYPRE_BoomerAMGSetPrintLevel(precond_, hyprePrintLevel);
-            // GPU-required + tuned-for-Galerkin-Laplacian parameters. Defaults
-            // are tuned for diffusion on CPU and produce a "9x wrong answer at
-            // first solve" failure mode on a D M^-1 D^T projection operator
-            // (CG accepts what AMG can't precondition cleanly).
+            // GPU-required + tuned-for-3D-pressure-Poisson parameters. The
+            // assembled DDT operator (D M^-1 D^T + tau*PSPG, single-pin anchored)
+            // is a near-singular SPD Laplacian-like matrix. Prior defaults
+            // (RelaxType=18 l1-Jacobi, StrongThr=0.5, AggNumLevels=1) are WEAK
+            // for this operator: l1-Jacobi smoothing barely damps the
+            // low-frequency error, the 0.5 threshold drops too many couplings in
+            // 3D so coarsening loses the operator's connectivity, and aggressive
+            // coarsening on an irregular tet stencil produces a coarse operator
+            // whose near-constant null mode dominates the V-cycle output. Under
+            // FlexGMRES that makes the FIRST preconditioned direction collapse
+            // onto the (near-)null space: the relative residual ||r||/||b|| drops
+            // below tol in ~2 iters while the actual solution x stays ~0 (the
+            // false x=0 "convergence"). Hybrid symmetric Gauss-Seidel (RelaxType
+            // 6/8) is the standard strong smoother for pressure Poisson and
+            // damps the low modes the V-cycle must remove; StrongThr=0.25 is the
+            // 3D-Poisson value; AggNumLevels=0 keeps the full operator
+            // connectivity so the coarse grid still represents the constant mode
+            // correctly. All env-overridable so they can be swept without a
+            // rebuild.
             //   CoarsenType=8  = PMIS (mandatory on GPU; cheaper than CLJP)
             //   InterpType=6   = ext+i (long-range, works with PMIS)
-            //   RelaxType=18   = l1-Jacobi (SYMMETRIC -- required for PCG;
-            //                   default GS becomes non-symmetric on GPU)
+            //   RelaxType=8    = l1-scaled hybrid SSOR (strong + GPU-safe +
+            //                   symmetric). FlexGMRES does NOT need a symmetric
+            //                   preconditioner, so this strong smoother is the
+            //                   right default here, vs the weak l1-Jacobi (18)
+            //                   the PCG wrapper must use. Override via MARS_AMG_RELAX
             //   RelaxOrder=0   = lexicographic (mandatory on GPU)
             //   KeepTranspose=1= avoid SpMTV on GPU
-            //   StrongThr=0.5  = default 0.25 too loose for 3D Laplacians
+            //   StrongThr=0.25 = 3D-Poisson value (0.5 is for anisotropic)
             //   PMaxElmts=4    = truncate P (GPU memory + perf)
-            //   AggNumLevels=1 = aggressive coarsening on level 0 only
-            HYPRE_BoomerAMGSetCoarsenType(precond_, 8);
-            HYPRE_BoomerAMGSetInterpType(precond_, 6);
-            HYPRE_BoomerAMGSetRelaxType(precond_, 18);
-            HYPRE_BoomerAMGSetRelaxOrder(precond_, 0);
+            //   AggNumLevels=0 = no aggressive coarsening (keeps tet connectivity)
+            int   amgCoarsen   = getEnvInt   ("MARS_AMG_COARSEN",   8);
+            int   amgInterp    = getEnvInt   ("MARS_AMG_INTERP",    6);
+            int   amgRelax     = getEnvInt   ("MARS_AMG_RELAX",     8);
+            int   amgRelaxOrder= getEnvInt   ("MARS_AMG_RELAXORDER",0);
+            double amgStrong   = getEnvDouble("MARS_AMG_STRONG",    0.25);
+            int   amgPMax      = getEnvInt   ("MARS_AMG_PMAX",      4);
+            int   amgAgg       = getEnvInt   ("MARS_AMG_AGG",       0);
+            int   amgSweeps    = getEnvInt   ("MARS_AMG_SWEEPS",    1);
+            if (verbose_ && rank == 0) {
+                std::cout << "  [BoomerAMG] coarsen=" << amgCoarsen
+                          << " interp=" << amgInterp << " relax=" << amgRelax
+                          << " strong=" << amgStrong << " pmax=" << amgPMax
+                          << " agg=" << amgAgg << " sweeps=" << amgSweeps
+                          << std::endl;
+            }
+            HYPRE_BoomerAMGSetCoarsenType(precond_, amgCoarsen);
+            HYPRE_BoomerAMGSetInterpType(precond_, amgInterp);
+            HYPRE_BoomerAMGSetRelaxType(precond_, amgRelax);
+            HYPRE_BoomerAMGSetRelaxOrder(precond_, amgRelaxOrder);
             HYPRE_BoomerAMGSetKeepTranspose(precond_, 1);
-            HYPRE_BoomerAMGSetStrongThreshold(precond_, 0.5);
-            HYPRE_BoomerAMGSetPMaxElmts(precond_, 4);
-            HYPRE_BoomerAMGSetAggNumLevels(precond_, 1);
-            HYPRE_BoomerAMGSetNumSweeps(precond_, 1);
+            HYPRE_BoomerAMGSetStrongThreshold(precond_, amgStrong);
+            HYPRE_BoomerAMGSetPMaxElmts(precond_, amgPMax);
+            HYPRE_BoomerAMGSetAggNumLevels(precond_, amgAgg);
+            HYPRE_BoomerAMGSetNumSweeps(precond_, amgSweeps);
             HYPRE_BoomerAMGSetMaxLevels(precond_, 25);
             HYPRE_BoomerAMGSetMinCoarseSize(precond_, 32);  // avoid too-small coarse grid on small problems
             HYPRE_BoomerAMGSetMaxCoarseSize(precond_, 128); // upper bound on coarsest direct solve
@@ -313,6 +365,26 @@ public:
         HYPRE_GMRESSetMaxIter(solver_, maxIter_);
         HYPRE_GMRESSetTol(solver_, tolerance_);
         HYPRE_GMRESSetKDim(solver_, kDim_);  // restart length
+        // Floor on iterations. For the near-singular DDT pressure operator (one
+        // constant null mode, single pin), BoomerAMG's first V-cycle can map the
+        // initial residual almost entirely into the null space, dropping the
+        // RELATIVE residual ||r||/||b|| below tol in ~2 iters while the actual
+        // solution x is still ~0 (the false x=0 "convergence"). A small minimum
+        // iteration count forces GMRES to keep building the Krylov space past
+        // that first deceptive cycle so a real x emerges. Env-overridable.
+        {
+            int minIt = getEnvInt("MARS_HYPRE_MINITER", 3);
+            if (minIt > 0) HYPRE_GMRESSetMinIter(solver_, minIt);
+        }
+        // Absolute residual floor. A pure relative test can be satisfied by a
+        // tiny ||b|| whose mass sits in the null mode; pairing it with an
+        // absolute tol means convergence requires the TRUE residual to be small,
+        // not just relatively small versus a near-null RHS. Default 0 (disabled)
+        // keeps legacy behavior; set MARS_HYPRE_ABSTOL>0 to engage.
+        {
+            double absTol = getEnvDouble("MARS_HYPRE_ABSTOL", 0.0);
+            if (absTol > 0.0) HYPRE_GMRESSetAbsoluteTol(solver_, absTol);
+        }
         // print level: 0 silent, 2 per-iter residuals. Env MARS_HYPRE_VERBOSE=1.
         {
             const char* ev = std::getenv("MARS_HYPRE_VERBOSE");
@@ -396,12 +468,54 @@ public:
         lastNumIters_ = num_iterations;
         lastFinalRes_ = final_res_norm;
 
+        // False-convergence guard against the near-singular DDT operator. When
+        // BoomerAMG collapses the first cycle onto the constant null mode,
+        // FlexGMRES can report converged=true with a tiny relative residual while
+        // the returned x is essentially zero. Detect that here: compute ||x||inf
+        // and ||b||inf (global), and if Hypre claims convergence but x is ~0 while
+        // b is not, the "solution" is the null vector -- report NON-converged so
+        // the caller does not scatter a zero phi as if it were a real projection.
+        {
+            double localXmax = (m > 0)
+                ? thrust::transform_reduce(
+                      thrust::device_pointer_cast(x.data()),
+                      thrust::device_pointer_cast(x.data() + m),
+                      [] __device__ (RealType v) -> double { return fabs((double)v); },
+                      0.0, thrust::maximum<double>())
+                : 0.0;
+            double localBmax = (m > 0)
+                ? thrust::transform_reduce(
+                      thrust::device_pointer_cast(b.data()),
+                      thrust::device_pointer_cast(b.data() + m),
+                      [] __device__ (RealType v) -> double { return fabs((double)v); },
+                      0.0, thrust::maximum<double>())
+                : 0.0;
+            double gXmax = 0.0, gBmax = 0.0;
+            MPI_Allreduce(&localXmax, &gXmax, 1, MPI_DOUBLE, MPI_MAX, comm_);
+            MPI_Allreduce(&localBmax, &gBmax, 1, MPI_DOUBLE, MPI_MAX, comm_);
+            lastSolutionMax_ = gXmax;
+            // x is "null" if it is many orders below b. The default 1e-12 only
+            // fires on an essentially-exact x=0 (the observed failure mode), so
+            // it never rejects a physically meaningful phi. Raise the ratio via
+            // MARS_HYPRE_NULLX_RATIO if a borderline near-null x appears.
+            double nullRatio = getEnvDouble("MARS_HYPRE_NULLX_RATIO", 1e-12);
+            nullSolutionReturned_ = (gBmax > 0.0 && gXmax < nullRatio * gBmax);
+            if (nullSolutionReturned_ && rank == 0) {
+                std::cout << "[HypreGMRES] WARNING: solver reported converged (iters="
+                          << num_iterations << ", rel_res=" << final_res_norm
+                          << ") but |x|inf=" << gXmax << " << |b|inf=" << gBmax
+                          << " -- this is the null-mode false convergence; "
+                          << "reporting NOT converged.\n";
+            }
+        }
+
         if (verbose_) {
             std::cout << "Hypre GMRES converged in " << num_iterations
                       << " iterations, final residual: " << final_res_norm << std::endl;
         }
 
-        return (final_res_norm < tolerance_);
+        // Real convergence requires BOTH the residual test AND a non-null x.
+        return (final_res_norm < tolerance_) && !nullSolutionReturned_;
     }
 
     // Build A_hypre_ entirely on the device:
@@ -633,6 +747,8 @@ private:
     // Per-solve diagnostics (filled by solveImpl after Hypre returns).
     int    lastNumIters_ = 0;
     double lastFinalRes_ = 0.0;
+    double lastSolutionMax_ = 0.0;        // ||x||inf of the returned solution
+    bool   nullSolutionReturned_ = false; // converged-but-x~0 (null-mode) flag
 
     HYPRE_Solver solver_;
     HYPRE_Solver precond_;

--- a/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
+++ b/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
@@ -286,11 +286,15 @@ public:
             // rebuild.
             //   CoarsenType=8  = PMIS (mandatory on GPU; cheaper than CLJP)
             //   InterpType=6   = ext+i (long-range, works with PMIS)
-            //   RelaxType=8    = l1-scaled hybrid SSOR (strong + GPU-safe +
-            //                   symmetric). FlexGMRES does NOT need a symmetric
-            //                   preconditioner, so this strong smoother is the
-            //                   right default here, vs the weak l1-Jacobi (18)
-            //                   the PCG wrapper must use. Override via MARS_AMG_RELAX
+            //   RelaxType=18   = l1-Jacobi. MANDATORY on GPU: the GS-family
+            //                   smoothers (hybrid GS=3/6, l1-hybrid-SSOR=8)
+            //                   become non-symmetric / NO-OP on GPU (the cuda
+            //                   Hypre build does not implement them as a real
+            //                   sweep), so AMG returns x=0 with a garbage ~1e-315
+            //                   residual on the first cycle. The working PCG
+            //                   wrapper uses 18 for exactly this reason (not just
+            //                   PCG symmetry). Earlier 8 here was the cause of the
+            //                   pump's AMG x=0. Override via MARS_AMG_RELAX.
             //   RelaxOrder=0   = lexicographic (mandatory on GPU)
             //   KeepTranspose=1= avoid SpMTV on GPU
             //   StrongThr=0.25 = 3D-Poisson value (0.5 is for anisotropic)
@@ -298,7 +302,7 @@ public:
             //   AggNumLevels=0 = no aggressive coarsening (keeps tet connectivity)
             int   amgCoarsen   = getEnvInt   ("MARS_AMG_COARSEN",   8);
             int   amgInterp    = getEnvInt   ("MARS_AMG_INTERP",    6);
-            int   amgRelax     = getEnvInt   ("MARS_AMG_RELAX",     8);
+            int   amgRelax     = getEnvInt   ("MARS_AMG_RELAX",    18);
             int   amgRelaxOrder= getEnvInt   ("MARS_AMG_RELAXORDER",0);
             double amgStrong   = getEnvDouble("MARS_AMG_STRONG",    0.25);
             int   amgPMax      = getEnvInt   ("MARS_AMG_PMAX",      4);

--- a/backend/distributed/unstructured/solvers/mars_hypre_pcg_solver.hpp
+++ b/backend/distributed/unstructured/solvers/mars_hypre_pcg_solver.hpp
@@ -259,6 +259,17 @@ public:
     // print output.
     int    getLastIterations()    const { return lastNumIters_; }
     double getLastFinalResidual() const { return lastFinalRes_; }
+    double getLastSolutionMax()   const { return lastSolutionMax_; }
+    bool   lastReturnedNullSolution() const { return nullSolutionReturned_; }
+
+    // Env-override helper (local copy; the GMRES header has its own).
+    static double getEnvDouble(const char* name, double defVal) {
+        const char* v = std::getenv(name);
+        if (!v || !*v) return defVal;
+        char* end = nullptr;
+        double parsed = std::strtod(v, &end);
+        return (end && end != v) ? parsed : defVal;
+    }
 
     // The helpers below are conceptually private — they take internal Hypre
     // state and aren't meant to be called from outside — but nvcc rejects
@@ -483,7 +494,44 @@ public:
                       << " iterations, final residual: " << final_res_norm << std::endl;
         }
 
-        return (final_res_norm < tolerance_);
+        // Same guards as the GMRES wrapper: a converged-but-null x (AMG no-op)
+        // or a converged-but-HUGE x (under-resolved near-singular solution) must
+        // both be reported NOT converged so the caller never scatters a bad phi.
+        {
+            double localXmax = (m > 0)
+                ? thrust::transform_reduce(
+                      thrust::device_pointer_cast(x.data()),
+                      thrust::device_pointer_cast(x.data() + m),
+                      [] __device__ (RealType v) -> double { return fabs((double)v); },
+                      0.0, thrust::maximum<double>())
+                : 0.0;
+            double localBmax = (m > 0)
+                ? thrust::transform_reduce(
+                      thrust::device_pointer_cast(b.data()),
+                      thrust::device_pointer_cast(b.data() + m),
+                      [] __device__ (RealType v) -> double { return fabs((double)v); },
+                      0.0, thrust::maximum<double>())
+                : 0.0;
+            double gXmax = 0.0, gBmax = 0.0;
+            MPI_Allreduce(&localXmax, &gXmax, 1, MPI_DOUBLE, MPI_MAX, comm_);
+            MPI_Allreduce(&localBmax, &gBmax, 1, MPI_DOUBLE, MPI_MAX, comm_);
+            lastSolutionMax_ = gXmax;
+            double nullRatio = getEnvDouble("MARS_HYPRE_NULLX_RATIO", 1e-12);
+            nullSolutionReturned_ = (gBmax > 0.0 && gXmax < nullRatio * gBmax);
+            if (nullSolutionReturned_ && rank == 0)
+                std::cout << "[HyprePCG] WARNING: converged but |x|inf=" << gXmax
+                          << " << |b|inf=" << gBmax << " (null-mode); NOT converged.\n";
+            double maxXRatio = getEnvDouble("MARS_HYPRE_MAXX_RATIO", 1e6);
+            if (gBmax > 0.0 && gXmax > maxXRatio * gBmax) {
+                nullSolutionReturned_ = true;
+                if (rank == 0)
+                    std::cout << "[HyprePCG] WARNING: |x|inf=" << gXmax << " >> |b|inf="
+                              << gBmax << " (ratio>" << maxXRatio
+                              << "); under-resolved/null-contaminated; NOT converged.\n";
+            }
+        }
+
+        return (final_res_norm < tolerance_) && !nullSolutionReturned_;
     }
 
     // Build A_hypre_ entirely on the device:
@@ -714,6 +762,8 @@ private:
     // Per-solve diagnostics (filled by solveImpl after Hypre returns).
     int    lastNumIters_ = 0;
     double lastFinalRes_ = 0.0;
+    double lastSolutionMax_ = 0.0;
+    bool   nullSolutionReturned_ = false;
 
     HYPRE_Solver solver_;
     HYPRE_Solver precond_;

--- a/docs/poiseuille_tutorial.md
+++ b/docs/poiseuille_tutorial.md
@@ -98,22 +98,116 @@ Two of these are easy to get wrong:
 
 ---
 
-## Part 2 — How the solver works (the short version)
+## Part 2 — Equations, exact solution, discretization, solvers (for starters)
 
-Each time step of the Chorin projection method does:
+### 2.1 The equations
 
-1. **Predict**: move the velocity by advection + old pressure gradient
-   (explicit, BDF2/EXT2).
-2. **Diffuse**: implicit viscous solve, one CG solve per velocity component.
-3. **Project**: compute how much the predicted field violates `div u = 0`,
-   solve a pressure Poisson equation, and correct the velocity so mass is
-   conserved.
-4. **Correct**: update velocity and pressure; re-impose boundary values.
+Incompressible flow obeys the Navier–Stokes equations:
 
-The pressure projection is the heart of incompressible CFD: pressure is
-whatever it must be to keep the velocity divergence-free. The full derivation
-is in `docs/pump_cfd_tutorial.md`. Here the only step that needs detail is
-the projection — because it is where this example's big lesson lives.
+```
+∂u/∂t + (u·∇)u = −(1/ρ)∇p + ν∇²u      (momentum)
+∇·u = 0                                (mass: fluid neither piles up nor vanishes)
+```
+
+In words, a fluid parcel accelerates because neighboring fluid carries it
+along (*advection*, the `(u·∇)u` term), because pressure differences push it
+(`∇p`), and because viscous friction drags it (`ν∇²u`). The second equation
+is the hard one: there is no equation "for" pressure — pressure is whatever
+it must be so that the velocity stays divergence-free. Every incompressible
+solver is, at heart, a strategy for finding that pressure.
+
+### 2.2 Why the exact solution is a parabola (3-line derivation)
+
+Far from the inlet the flow is *steady* (`∂u/∂t = 0`) and *fully developed*
+(`u = (u(y), 0, 0)`, nothing changes with x). Then advection vanishes
+(`u·∂u/∂x = 0`) and the x-momentum equation collapses to a balance between
+the pressure push and the wall drag:
+
+```
+0 = −dp/dx + μ d²u/dy²
+```
+
+The left term cannot depend on y, the right cannot depend on x, so both equal
+a constant: `dp/dx = −G`. Integrate twice and apply no-slip (`u = 0` at both
+walls):
+
+```
+u(y) = G/(2μ) · y(h−y)        — the parabola
+```
+
+Everything else follows by integration: flow rate `Q = Gh³/(12μ)`, mean
+velocity `U_mean = Gh²/(12μ)`, centerline `U_max = Gh²/(8μ) = 1.5·U_mean`.
+This is why the case validates so sharply — every number is pinned by the
+input parameters alone.
+
+### 2.3 The discretization (CVFEM in one breath)
+
+The channel is tiled into hexahedral **elements** with **nodes** at the
+corners; velocity *and* pressure live at the nodes (equal-order,
+vertex-centered — one set of points for everything). Around every node sits
+a small **control volume**, and the physics is enforced in integral form:
+whatever flows into a control volume must flow out. The "FEM" in CVFEM is
+how the fluxes through the control-volume faces are evaluated: with finite-
+element shape functions interpolated inside each hex, on the sub-control
+surfaces (SCS) that the element contributes.
+
+From this one idea come the discrete operators the solver uses:
+
+| Operator | Discrete meaning |
+|---|---|
+| divergence `D` | net flux `Σ u·A` out of a node's control volume (the mass check) |
+| gradient `G` | how p varies across the control-volume faces (the pressure push) |
+| Laplacian `K` | viscous exchange between neighboring control volumes (the drag) |
+
+Two consequences matter for this example. First, the SCS faces are
+*interior* faces — boundary opening faces need the explicit source of
+Part 3, or inflow is invisible. Second, equal-order velocity/pressure is
+not naturally stable (the LBB issue): it works here on a clean mesh, but
+harder cases (the pump) need pressure stabilization.
+
+### 2.4 Marching in time: the projection method
+
+Each time step splits the physics into manageable pieces (Chorin
+projection, BDF2 time accuracy):
+
+1. **Predict**: move velocity by advection + the old pressure gradient
+   (explicit — cheap, but ignores incompressibility).
+2. **Diffuse**: apply viscosity implicitly — one linear solve per velocity
+   component (implicit so large time steps stay stable).
+3. **Project**: the predicted field violates `∇·u = 0`; solve a Poisson
+   equation for a pressure correction `phi` whose gradient removes exactly
+   that violation.
+4. **Correct**: subtract the gradient, update `p += phi`, re-impose boundary
+   values.
+
+The projection (step 3) is the heart and the cost: it is a global problem —
+a flux imbalance at the inlet must be felt instantly at the outlet — which
+is why its linear system is the hard one.
+
+### 2.5 The linear solvers
+
+Each implicit step is a sparse linear system `A x = b` with one row per
+node. At 30k nodes (or 10⁹ on Alps) you never factor A — you iterate:
+
+- **CG (conjugate gradient)** only needs matrix-vector products, which are
+  perfectly GPU-shaped. Each iteration improves the answer; you stop when
+  the residual `|Ax−b|/|b|` drops below `--tol`.
+- A **preconditioner** is a cheap approximate inverse applied each iteration
+  to speed convergence. Here: **Jacobi** (divide by the diagonal) — the
+  simplest possible one.
+- The three **velocity** solves are easy (mass-dominated matrices, a dozen
+  iterations). The **pressure Poisson** solve is hard: its conditioning
+  worsens with mesh size and cell-aspect-ratio, and on this thin-z channel
+  Jacobi-PCG needs ~3600 iterations per step. That is the entire runtime.
+  Stronger preconditioners (multigrid/AMG) exist, but reject this particular
+  matrix-free operator — a known open item, shared with the wing/pump work.
+- The pressure solve here is **matrix-free**: the operator `D M⁻¹ Dᵀ` is
+  applied as three scatters per CG iteration instead of being assembled —
+  cheaper in memory, and exactly consistent with the divergence/gradient
+  used elsewhere in the step.
+
+Deeper material (the full CVFEM derivation, stabilization, accuracy orders)
+lives in `docs/pump_cfd_tutorial.md`.
 
 ---
 
@@ -231,6 +325,14 @@ Useful flags:
 ---
 
 ## Part 5 — Reading the output
+
+With `--vtu-output=PREFIX` the run writes three ParaView timelines:
+
+| Files | Field | Use |
+|---|---|---|
+| `PREFIX_u.pvd` + steps | u — streamwise velocity component | **the one to visualize** (clean, validated) |
+| `PREFIX_umag.pvd` | umag — velocity *magnitude* √(u²+v²+w²) | avoid: contaminated by the v/w artifact (Part 6) |
+| `PREFIX_p.pvd` | p — pressure | avoid: carries the accumulated startup ramp (Part 6) |
 
 Per-step line:
 

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -116,8 +116,8 @@ int main(int argc, char** argv)
     // CORRECT through-flow fix -- it uses the PRESCRIBED (balanced) inlet/outlet
     // opening flux, which cancels EXACTLY at step0, so it cannot blow up like the
     // earlier solved-field version. Pairs with the mass-conserving outlet + pumpDp=0.
-    // --no-opening-flux-source disables it for A/B. Dirichlet lift ON (a correctness
-    // fix); --no-dirichlet-lift disables for comparison.
+    // Opening-flux source is OFF by default; enable with --opening-flux-source.
+    // Dirichlet lift ON (a correctness fix); --no-dirichlet-lift disables for comparison.
     bool        openingFluxSource = false;
     bool        dirichletLift     = true;
     // FIX B -- pressure-drop drive. >0 activates FIX B: prescribe p=pumpDp on the
@@ -341,7 +341,7 @@ int main(int argc, char** argv)
     // exactly (sum=0 at step0), so the single-pin Neumann pressure solve is
     // compatible and through-flow develops. The source REQUIRES the mass-conserving
     // outlet (so outletU>0 and the outlet term is nonzero); see the guard below.
-    s.useOpeningFluxSource = openingFluxSource;   // FIX 1 (on by default; correct fix)
+    s.useOpeningFluxSource = openingFluxSource;   // FIX 1 (OFF by default; --opening-flux-source enables)
     s.useDirichletLift     = dirichletLift;       // FIX 2 (on by default)
     s.pumpDp               = RealType(pumpDp);    // FIX B: pressure-drop drive (>0 active)
     s.rhieChowTau = rhieTau;   // <=0 -> kernel falls back to dt/rho
@@ -672,7 +672,7 @@ int main(int argc, char** argv)
         // opening-flux source can add ( Uprescribed . areaVec ) at each inlet node.
         // Same owner-complete field used for the inward normals above; outlet area-vecs
         // are uploaded separately below. Gated on openingFluxSource (ON by default), so
-        // this fires by default; --no-opening-flux-source skips it.
+        // fires only when --opening-flux-source is passed (OFF by default).
         if (openingFluxSource && areaIn > 1e-30)
         {
             const size_t nNodes = amr.domain().getNodeCount();


### PR DESCRIPTION
- **fix(pump): revive the pressure outlet (the REAL through-flow fix). outletU was set unconditionally -> always velocity-Dirichlet outlet -> both-ends-Dirichlet admits a flat-pressure tank-recirculation div=0 solution -> NO flow through the passage (confirmed: 1e-10 pressure solve gave identical flat-p, so it's structural not convergence -- AMG would NOT help). Gate outletU on !outletDoNothing so do-nothing (default) leaves outletU<=0 -> solver masks the WHOLE outlet face p=0 + frees outlet velocity (singlePin=false, solver:4080) -> inlet flux against fixed-p outlet FORCES the outlet->suction gradient -> through-flow. The dead --outlet flag now actually works**
- **fix(pump): default outlet back to MASS-CONSERVING (the correct design). Root cause found: the divergence operator only loops interior faces (sum(div)==0 always), so the pressure solve is NEVER told mass enters at the inlet -> a velocity-inlet + free pressure-outlet is UNPROJECTABLE -> no through-flow (flow dies at inlet, pressure parks in body). The code's own comment (solver:2295) flags this. My prior do-nothing default was backwards: the mass-conserving outlet (vel outflow removes Q + single pin) BALANCES the flux so the projection builds the inlet->outlet gradient that drives flow through the passage. The dead-flag gate stays so do-nothing is still selectable (needs a boundary-flux source term to be correct -- separate work)**
- **pump through-flow: (1) default to do-nothing outlet = whole-face p=0 + FREE outlet velocity (the channel-proven pairing that builds the inlet->outlet pressure head; both-ends-velocity-Dirichlet + single pin gave a flat-pressure dead-passage solution). (2) --inlet-flux-source (GUARDED, off): add the prescribed inlet flux as a boundary divergence source -- the exterior opening flux is in no interior SCS so it's never integrated (verified not a double-count); A/B it. (3) [through-flow] Q_in/Q_out/ratio diagnostic each step so we MEASURE through-flow (ratio->1) instead of eyeballing uMax. mass-conserving still selectable. cavity/channel/TGV unaffected**
- **pump: REMOVE the broken --inlet-flux-source (double-counted the inlet flux already registered via interior SCS scatter; full-opening-area x rho/dt -> instant blowup, ratio=garbage) and revert default to MASS-CONSERVING outlet. Verified high-confidence: the inlet flux is already in the divergence for a velocity-Dirichlet inlet, so the only correct inlet boundary source is ZERO. do-nothing (whole-face p=0 + free outlet) does NOT self-drive a small interior outlet -> ratio=0 (no through-flow); the prior do-nothing-default + comments were disproven by the A/B. mass-conserving (U_out=Uin*Ain/Aout + single pin) forces Q_out=Q_in by construction. Kept the [through-flow] Q diagnostic (correct + useful)**
- **pump through-flow REWORK (verified root cause): the reference flows through the pump with ANY scheme (bj/upwind) so the dead passage is OUR bug, not Re/scheme. TWO real defects fixed: FIX1 --opening-flux-source (GUARDED off): inlet/outlet OPENING faces are exterior, in no interior SCS, so the prescribed opening flux never reaches the pressure RHS -> pressure flat -> no through-flow. Add it as a COMPATIBLE surface integral (u.n)*A_share, SAME scale as interior scatter, NOT x rho/dt (RHS does it), net~0 -- verified NOT a double-count (telescoping interior pairs never touch the opening face). FIX2 --dirichlet-lift (default ON): velocity-diffusion col-zero had no Dirichlet lift -> inlet momentum never diffused inward -> jet died at inlet. Add b-=K[row,bdry]*uTarget. FIX3: replace TAUTOLOGICAL Q_out (relocked to prescribed outletU) with an INTERIOR cut-plane flux probe at 25/50/75% -- measures SOLVED through-flow, can't be faked. old line relabeled [bc-sanity]**
- **pump FIX B: pressure-drop drive via --pump-dp=VALUE (gated, off by default -> existing pump byte-identical). Root cause: the divergence operator integrates only INTERIOR SCS faces, so a VELOCITY prescribed on the interior inlet opening is invisible to the pressure solver (exterior opening face never integrated) + the corrector freezes velocity-Dirichlet nodes -> no through-flow (proven: interior-flux mid-cut=0). FIX B masks BOTH openings as pressure-Dirichlet (p=dP inlet, p=0 outlet), frees both velocities, seeds the dP head in d_p -> flow EMERGES from the interior gradient (SCS-captured, VISIBLE). Startup-safe: two Dirichlet faces make the matrix NONSINGULAR -> no compatibility condition -> no FIX-1 source-blowup. inlet velocity becomes an OUTPUT (tune dP to hit ~0.5 m/s). Keeps interior-flux probe to verify mid-cut goes nonzero**
- **pump FIX B phi-lift (the piece that makes dP actually drive flow). Bug: FIX B seeded a one-node dP spike + pinned the phi increment to 0 at both faces -> interior never relaxed into the inlet->outlet gradient -> dP didn't drive flow (identical tiny flow at dP=1000 vs 30000). FIX: pin the SOLVED pressure to the target via rhs=target-p^n at masked DOFs (clamp to constant, NOT additive -> steady+bounded), so the Poisson solve imposes dP->0 Dirichlet data + relaxes the spanning gradient; the already-live predictor grad(p^n) then drives through-flow. LOAD-BEARING: pump runs DDT matrix-free, so the lift goes in solvePressureDDT's boundary-pin lambda (not the K-path). All gated pumpDp>0; pumpDp<=0 byte-identical (cavity/channel/TGV untouched)**
- **pump THROUGH-FLOW fix: prescribed-balanced opening-flux source (default ON). The verified root cause: a velocity-inlet's opening flux is invisible to the pressure solver (divergence integrates interior SCS only) -> flat passage -> dead passage (proven: interior-flux cut@50%=0). FIX: inject the opening flux into divAccNode so the projection SEES the inflow and builds the inlet->outlet gradient that drives the passage. KEY over the broken FIX 1: use PRESCRIBED GLOBAL-direction velocities (Uinf*inletDir, outletU*outletDir) not the solved u** -> inlet sums to -Q_in, outlet to +Q_in (outletU=Uin*Ain/Aout) -> total=0 EXACTLY every step incl step0 -> single-pin Neumann stays compatible -> CANNOT blow up like FIX 1 (which used u**=0 at the step0 outlet -> one-sided -> phi=1e36). Config: mass-conserving velocity inlet+outlet (sustains the jet) + this source (makes it visible). No removeMean (pin handles it). FIX B (pumpDp) abandoned, gated off**
- **pump: default opening-flux-source back OFF -- the prescribed-balanced source STILL blows up at step0 (phi=1e7->inf, CG residual grows = incompatible, same FLT_MAX as FIX 1). The 'sum=0 by construction' startup-safety proof was WRONG: the discrete per-node area shares evidently do not sum to exactly Q, so sum!=0, x rho/dt=1e6 -> explodes even at step0. Revert to the STABLE mass-conserving default (no through-flow, but runs). The opening-flux-source remains a flag for debugging but is NOT a working fix. Through-flow is UNRESOLVED -- see scratch/pump_throughflow_HANDOFF.md**
- **pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B**
- **Revert "pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B"**
- **debug: MARS_OFS_DBG -- print divAccNode |max| before/after the opening-flux source + the global net source sum, to SEE if the source is a giant localized spike (divAcc max jumps) and whether net is actually ~0. Instrumentation only, gated on env. Investigating the repeated step0 phi=1e7 blowup**
- **debug: print Qin_raw/Qout_raw separately -- the [ofs-dbg] net=-Q_in (one-sided) proves the OUTLET source contributes ZERO. Need to see Qin_raw vs Qout_raw to find why the outlet half does not fire (area-vec sign? outletDir?)**
- **pump: adjustPhi rescale FOUND THE BUG via debug -- the discrete inlet/outlet fluxes differ ~1.5% (Qin_raw=-5.975e-3, Qout_raw=+5.884e-3), NOT roundoff: the per-node area-vectors sum to a different value than the analytic areaIn/areaOut used for outletU. That 9e-5 residual x rho/dt=1e6 -> incompatible RHS -> phi=1e7 blowup. FIX: oScale=-Qin_raw/Qout_raw, rescale the outlet source so it EXACTLY cancels the inlet (net->0). The reductions now always run (not just debug). [ofs-dbg2] prints the net to confirm it goes to ~0**
- **pump: removeMean for the opening-flux source -- THE ACTUAL FIX. Debug PROVED the blowup is NOT flux imbalance: with the adjustPhi rescale the net source is bit-exactly 0 (8.67e-19) and it STILL blew up to phi=1e7 identically. Real cause (the code's own comments flag it: lines 897/2209/3333/5145): the single p=0 pin weakly controls the DDT constant null space; a boundary source excites that mode and Jacobi-PCG loses pAp>0 (residual GROWS 0.98->1.46 then garbage phi=1e7). FIX: removeMean the RHS + phi (project the null-space component out) when opening-flux is on -- the same cure the periodic path uses. Gated on useOpeningFluxSource**
- **debug: removeMean did NOT fix the blowup (phi=1e7 identical) -> null-space theory also wrong. KEY realization: the CG CONVERGES (3e-8), so phi=1e7 is the TRUE solution -- the operator+RHS are fine, the answer is legitimately huge. Add [ofs-dbg3] b|max and [ofs-dbg4] phi|max split by OPENING vs INTERIOR nodes, to decide: is phi huge only at the opening nodes (tiny DDT boundary-layer diagonal, b/diag=1e6*1e-4/1e-5=1e7 LOCAL) or everywhere (global)? That picks the final fix**
- **pump: --source-ramp-steps=N gentle startup for the opening-flux source. ROOT CAUSE (measured): the source WORKS (real through-flow, step1 cut@50% nonzero) but starting from rest at full strength dumps the whole inlet->outlet pressure head onto a near-singular interior node (sliver cell, DDT diag=1e-5, 600x below bulk) -> phi spikes to 6e6 there -> grad(phi) spike -> corrector velocity spike -> advection 950x/step -> blowup. NOT fixable by clip (preconditioner-only, phi is the true solution), CFL (structural per-step amplification), or balance/removeMean (all already correct). FIX: ramp Uinf 0->full over N steps so the head + phi + grad stay small while flow develops gently. Scales the inlet velocity target (from a base snapshot) AND the opening-flux source (reads Uinf live) -> balance preserved at every ramp level**
- **pump: allow dt to shrink up to 2x/step (was 5%/step). With the ramp, the flow develops stably for ~16 steps (phi=1e4, u_max bounded+growing, cut@50% nonzero) then a CFL violation at u~100 ran away because the 5%/step shrink cap could not drop dt fast enough to catch it. Fast shrink catches the violation in one step; growth stays gentle (5%/step) so BDF2's constant-dt assumption holds at steady state**
- **pump: targeted operator-diagonal floor on the matrix-free DDT (the sliver-node fix). MEASURED: the ramp fixes startup (steps 1-16 stable, flow developing, cut@50% nonzero) but one sliver interior node (tiny SCS face areas -> DDT diag=1e-5, 600x below bulk) makes phi spike there -> corrector velocity spike -> diffusion CG breaks (pAp<0, u**>>u*) -> blowup, even at dt=5e-8 (so NOT CFL). Jacobi clip is preconditioner-only (no-op on phi). FIX: raise ONLY the degenerate rows to epsFloor=0.05*max_diag in the TRUE matrix-free operator via per-node shift out[i]+=shift_i*phi[i]; 0 on the healthy bulk -> byte-identical there -> cavity/channel/cube16 untouched. Caps phi at b/3.3e-4 (~31x smaller) -> below blowup threshold. Pure positive diagonal add -> keeps SPD. Preconditioner diag floored to match. Velocity diffusion needs NO floor (M/dt keeps it conditioned; its divergence was downstream of the phi spike). Env MARS_DDT_OP_FLOOR_FRAC**
- **debug: MARS_CHECKER -- per-element mean-free pressure RMS diagnostic (the checkerboard mode an inf-sup stabilizer penalizes). Lets us SEE the checkerboard grow + SEE a stabilizer kill it in a few steps, instead of inferring from a full-run blowup. Confirms/quantifies the LBB decoupling diagnosis. Env-gated, tet-only, rank0, free in production. NOTE: adjudication confirmed BD-on-DDT is WRONG (breaks div=0 identity, accumulating divergence); the identity-safe path is VMS/RC on the divergence SOURCE (needs a phi-vs-d_p fix). Checkerboard fix != through-flow fix (separate defects)**
- **fix: checker diagnostic compile error -- a pair-returning __device__ lambda in transform_reduce needs its return type proclaimed in host context. Split into two scalar (double) reductions (mean-free energy + total) -- avoids the trait error, same result**
- **pump: replace the div-BREAKING operator-diagonal floor with an identity-safe MASS floor. The operator floor (out[i]+=shift*phi in applyDDTPerNode) only the OPERATOR saw, not the corrector -> solving (A+S)phi=b left div(u^{n+1})=(dt/rho)*S*phi un-projected -> accumulating residual -> smooth |p| 1e3->1e34 blowup (the SAME div=0-breaking class the code warns against for BD-on-DDT, lines 5602-5610). FIX: floor the lumped mass d_massNode instead -- A=D M^-1 D^T and the corrector ALSO applies M^-1 from the same d_massNode, so flooring mass changes operator AND corrector consistently -> div=0 PRESERVED. Removed d_shiftDDTNode + its apply + the operator-floor build. Env MARS_MASS_FLOOR_FRAC (default 1e-3*max_mass)**
- **pump: implicit PSPG pressure stabilization (--pspg) -- the CORRECT equal-order checkerboard fix. VERIFIED root cause of the checkerboard blowup: the existing VMS adds tau*(-lap p^n) to the RHS = an EXPLICIT forward-Euler Laplacian-of-p update -> unconditionally amplifies the high-freq mode at ANY tau (why 1e-6/1e-5/1e-3 all blew up). FIX: add tau*L*phi IMPLICITLY inside applyDDTPerNode so CG solves (A+tau*L)phi=b. L=sum_e V_e G^T G is symmetric PSD, shares A's constant null mode (removed by the pin) -> SPD, damps checkerboard at ALL tau>0. Acts on phi (the correction, ->0) so it self-extinguishes; post-corrector div relaxes to ~tau*lap(phi)=O(h^2), a CONSISTENT residual that vanishes under refinement -- the textbook PSPG, NOT the inconsistent div-breaking BD/floor. tau=h^2/24 (a LENGTH^2, not dt/rho). Confirm via MARS_CHECKER: frac must shrink. New kernel applyPSPGLaplacianTetKernel; gated --pspg, tau auto or --pspg-tau**
- **pump PSPG: FIX THE SIGN. The DDT operator outAcc = D M^-1 D^T phi ~ -lap(phi) (SPD-positive; A=-lap, matches b=-coef*div). My PSPG scattered +div(grad phi)=+lap(phi) = OPPOSITE sign -> SUBTRACTED definiteness (made conditioning worse, no damping). Flip: scatter -s to iL / +s to iR so it adds +tau*(-lap)phi = positive energy, same orientation as A. This is why the first PSPG run showed frac still growing + cg_p=-2 (wrong-sign term de-conditioned the operator). NOTE: that run ALSO lost the Jacobi clip (diag=6.5e-12) -- must pass MARS_DDT_JACOBI_CLIP_FRAC for the sliver**
- **pump PSPG: add tau*L diagonal to the Jacobi preconditioner (the REAL bug). Numerically verified (host dense-matrix replica): my PSPG sign was CORRECT (-s/+s -> L=+Vol*G^T*G, same sign as A=-lap, A+tau*L more SPD). The cg_p=-2 failure was the PRECONDITIONER mismatch: operator ran A+tau*L but d_diagDDT was built from A only -> worst on the sliver rows (tiny A-diag, large tau*L-diag) -> CG stalls. FIX: computeTetPSPGDiagonalKernel scatters tau*Vol*|dNdx_i|^2 into d_diagAccNode (before halo/gather) so the preconditioner matches the stabilized operator. Gated usePSPG, tet-only. Sign left unchanged (verified correct)**
- **pump: pin the degenerate sliver DOF(s) -- the identity-safe fix for the unsolvable pressure (cg_p=-2). A near-zero-volume tet gives a DDT diagonal ~9 OOM below bulk (1e-12 vs 6e-3); Jacobi-PCG cannot solve it. FIX: mask any owned DOF with diag < MARS_SLIVER_PIN_FRAC*max_diag (default 1e-6) into d_isPressureBdryDof -> the operator forces out=phi (identity row) AND the RHS forces b=0, exactly like the outflow/pin DOFs (verified both paths check maskPtr). One removed equation, div-safe. Makes the pressure solvable so the real physics + PSPG become readable. The mass floor was the wrong lever (sliver diag is AREA-driven, not mass); this pins the node directly**
- **poiseuille validation example: channel-fork NS solver with balanced opening-flux source; parabola matches analytic profile within reference tolerance (RMS 5.8e-3 < 6e-3, interior flux ratio ~1). Plus tutorial.**
- **pump: assembled tet DDT operator + FlexGMRES (toward Hypre AMG pressure solve). (1) ASSEMBLE the matrix-free D M^-1 D^T into CSR for tet (buildDDTSparsityTet + assembleDDTPerNodeKernelTet, node-driven so the per-node M^-1 cross-element face pairs are captured; tet nodeFaces[4][3]={{0,2,3},{0,1,4},{1,2,5},{3,4,5}} derived from d_tetLRSCV). Same operator as matrix-free (verify bit-identical via MARS_DDT_PROBE_DIFF, PSPG off) -> corrector stays div=0-exact. GPU-resident; only host touch is the rank0 setup [DDT-health] print. Matrix-free path UNTOUCHED (gated, additive -- can return to it). (2) FlexGMRES in the Hypre wrapper (default for BoomerAMG, the right Krylov for a varying AMG preconditioner; env MARS_HYPRE_FLEXGMRES). NOT YET COMPILED (no nvcc locally)**
- **pump: assemble PSPG tau*L into the DDT CSR (assemblePSPGStiffnessTetKernel). Element-driven 4x4 tet stiffness tau*Vol*(dNdx_i.dNdx_j) scattered via atomicAddSparseEntry into the existing DDT two-hop sparsity (subset, no new entries). Same tau*L the matrix-free path adds -> assembled A+tau*L == matrix-free A+tau*L. Iterates halo elements (elementCount includes halo) so owned boundary rows get cross-rank stiffness; writes owned rows only. Gated usePSPG. This (a) keeps PSPG on the assembled/Hypre path and (b) regularizes the Gram-form DDT toward diagonal dominance so Jacobi/BoomerAMG can precondition the 9-OOM operator. GPU-resident**
- **pump: activate the assembled DDT pressure solve on --solver=hypre. Re-gate the assembled-DDT block (was MARS_DDT_USE_ASSEMBLED_CG && CG only) to ALSO fire on solverKind==Hypre && nnzDDT>0 -> the SAME operator (D M^-1 D^T + assembled PSPG tau*L) is solved by Hypre FlexGMRES+BoomerAMG instead of matrix-free Jacobi-CG. Matrix-free path UNTOUCHED as the default (no --solver=hypre -> byte-identical). The wrapIntoSparseMatrix(s.AddT) now fires for tet automatically (nnzDDT>0). Global-DOF numbering + MPI partitioning already built at setup for the Hypre path. End-to-end: --solver=hypre -> assembled gate -> solveOneComponent(GMRES) -> FlexGMRES+AMG. Validate via MARS_DDT_PROBE_DIFF (PSPG off) first**
- **fix(pump): remove duplicate template clause before assembleDDTPerNodeKernelTet (my PSPG-kernel insert left an orphan template<> -> 'multiple template clauses' compile error)**
- **pump driver: parse --solver=hypre (was hardcoded SolverKind::CG -> the assembled Hypre path could never activate; explains why --solver=hypre runs were silently matrix-free CG). Sets SolverKind::Hypre -> the assembled DDT + FlexGMRES+BoomerAMG gate fires. --solver=cg restores default. Banner prints the active pressure path**
- **fix(pump hypre): skip the sliver-pin on the Hypre/assembled path. The pin reads the matrix-free d_diagDDT (tiny entries floored to 1 -> globalMax=1 -> 1e-6 threshold pinned ~220k DOFs), and enforcePressureBcRhsKernel then ZEROED b at all those rows -> RHS~0 -> phi=0 every step (no flow: u stuck at 0, div never projected). BoomerAMG handles the conditioning without pinning, so gate the pin on solverKind!=Hypre. This was why --solver=hypre ran stable but produced phi=0**
- **fix(pump hypre): force the VELOCITY solve onto in-house CG even under --solver=hypre. Root cause of the dead u=0 run: solverKind==Hypre routed the velocity matrix (M/dt + nu*K, mass-dominated / near-diagonal) through BoomerAMG-PCG, which is the wrong tool for a non-elliptic mass matrix -> exits ~1 iter returning x~0 -> u**=0 -> div(u**) RHS=0 -> phi=0 -> nothing develops. FIX: add forceCG param to solveOneComponent; velocity solves pass forceCG=true so they use the in-house CG (~14 iters, works) regardless of solverKind. Hypre/AMG stays reserved for the ill-conditioned DDT PRESSURE operator -- the only thing that needs it. (Also: pres_r0=0 under hypre is a stale-diagnostic artifact, lastPressR0 only written in the matrix-free path)**
- **poiseuille: --check regression mode + ctest entry, velocity-fit G closure (100.8% of exact), single-station profile CSV + plot script, u-field render script; fix wall-eps node pinning; document the incremental-p artifact (visualize u, not umag/p)**
- **debug(pump hypre): add MARS_SOLVE_TRACE -- prints converged/iters/|xVec|max right after the Hypre solve, to pin down whether phi=0 is (a) converged=false so xVec never scattered to qOut, or (b) xVec~0 itself. The verbose run showed BoomerAMG sets up + runs (b nonzero, L2=15) but only ~2 cycles at conv factor 0.43 -> likely final_res>tol -> converged=false -> no scatter -> phi=0**
- **poiseuille render: pump-style 3-panel validation layout (field + animated profile-vs-exact + centerline development), PIL composite + header**
- **fix(pump hypre): enforce the single pin into the ASSEMBLED DDT matrix (d_valuesDDT), not just the K-path d_valuesPre. ROOT CAUSE of phi=0: the pin row was only applied to d_valuesPre (K-path), so the assembled DDT operator s.AddT stayed SINGULAR (pure-Neumann pump pressure has a constant null mode). BoomerAMG/FlexGMRES on a singular operator returned the null-space solution = 0 -> 'converged in 2 iters', x=0, phi=0 (proven by MARS_SOLVE_TRACE: pressure solve converged=1 iters=2 |xVec|max=0 while velocity solves gave real nonzero x). FIX: enforcePinRowKeepDiagKernel on d_rowPtrDDT/d_colIndDDT/d_valuesDDT too (keepDiag = AMG-friendly). Single pin is the correct null-space removal for the pure-Neumann pump (matches the reference's 'single pressure reference')**
- **fix(pump hypre): accept a best-effort pressure solve (rel-res < MARS_HYPRE_ACCEPT_RES, default 1e-2) instead of requiring final_res<1e-8. Diagnosis via MARS_SOLVE_TRACE+Jacobi: FlexGMRES+Jacobi runs full 2000 iters and produces a NONZERO xVec (1930, growing) but stalls at res~7e-3 -> the strict converged gate rejected it -> not scattered -> phi=0 -> dead. A projection step does not need machine-precision phi; a partial solve removes most divergence. Now accept it. (AMG still falsely converges at x=0 on this near-singular op -- separate, retune next; Jacobi is the working floor)**
- **poiseuille tutorial: starter-level Part 2 (equations, parabola derivation, CVFEM discretization, projection, solvers) + output-files table**
- **pump hypre: make BoomerAMG actually converge (fix the x=0 false convergence). Root cause: (1) the pump single-pin set the pinned DDT row diagonal to 1.0 (10-25x the native ~0.04-0.14), a documented PMIS-coarsening killer -> AMG V-cycle collapses onto the constant null mode -> FlexGMRES exits at 2 iters with x=0; (2) weak AMG settings (l1-Jacobi relax, strong=0.5, aggressive coarsening) for a 3D near-singular Poisson. FIXES: symmetric pin in the assembled DDT (zero row AND column, restore NATIVE diagonal via read/setRowDiagonalKernel -> no spike); AMG retune relax 18->8 (l1 hybrid SSOR), strong 0.5->0.25 (3D), agg 1->0, all env-overridable (MARS_AMG_*); GMRES min-iter floor + optional abstol; null-mode guard (reject converged-but-x=0). Best-effort acceptance now rejects null x**
- **pump hypre: harden the acceptance against the 1e7-phi blowup (multi-agent verification confirmed: cause = convergence/conditioning + loose accept gate admitting under-resolved huge phi; sign correct, removeMean NOT needed/refuted). (BUG2) upper-bound x reject in the Hypre wrapper: reject converged-but-|x|>>|b| (MARS_HYPRE_MAXX_RATIO default 1e6) -- the null-guard only caught x~0, not the observed x=huge. (accept) tighten default MARS_HYPRE_ACCEPT_RES 1e-2 -> 1e-6 so a res~2e-4 partial solve is rejected (phi stays warm-started) instead of scattering garbage. (BUG3) fix misleading 'opening-flux on by default' comments (it is OFF). Path to bounded solve: --pspg (AMG-friendly operator) + retuned BoomerAMG + these guards**
- **fix(pump hypre): BoomerAMG RelaxType 8 -> 18 (l1-Jacobi) -- the cause of AMG returning x=0 with a garbage 1.1e-315 residual. The retune to RelaxType=8 (l1-hybrid-SSOR, GS-family) is NOT GPU-functional: the cuda Hypre build does not implement GS-family smoothers as a real sweep (they no-op / go non-symmetric on GPU), so the V-cycle does nothing -> x=0 on the first cycle. The WORKING PCG wrapper (mars_hypre_pcg_solver.hpp:362-373) uses 18 for exactly this reason ('default GS becomes non-symmetric on GPU'), not merely PCG symmetry -- the GMRES comment misread that. l1-Jacobi-AMG-FlexGMRES is the standard GPU pressure solver. Verified pin/PSPG order is correct (pin enforced after PSPG). Testable via MARS_AMG_RELAX=18 (now the default)**
- **pump hypre: complete the AMG fix -- (1) NumSweeps 1->2 (l1-Jacobi is weaker than SSOR; 2 sweeps restore the smoothing strength). (2) Route the --pspg DDT pressure solve to Hypre PCG instead of GMRES: PSPG's tau*L makes A = D M^-1 D^T + tau*L SPD and the symmetric pin removes the null mode, so CG+AMG (the textbook pressure-Poisson solver, what deal.II/MFEM/Nalu use) is valid and more stable than FlexGMRES. Gated on s.usePSPG -> PCG; pure-DDT SPSD stays GMRES (Hypre PCG rejects SPSD with error 1). The PCG wrapper already uses GPU-safe RelaxType=18. MARS_HYPRE_KRYLOV still overrides for debug. Combined with the RelaxType 8->18 fix, this should give a converging bounded AMG pressure solve**
- **TGV: MARS_PRED_PERSLOT_GRADP toggle -- match predictor grad(p) seam reduction to corrector (Fable wdxg6s3ce: predictor folds, corrector per-slot -> dt-independent feedback gain 1.17)**
- **revert(pump hypre): route pressure back to FlexGMRES (not PCG). Routing --pspg to PCG was a regression: the PCG wrapper has NEITHER the null-mode guard NOR the upper-bound-x reject (only the GMRES wrapper does), so a converged-but-huge phi (PCG 'converged' in 14 iters at |phi|=1e123 on the still-ill-conditioned operator) was scattered -> corrector blew up -> inf predictor -> velocity Hypre-PCG errors downstream. GMRES carries the guards that keep it bounded. The RelaxType=18 fix (AMG now functional) stays. PCG can return once its wrapper has the same guards**
- **TGV: MARS_TGV_NONINCREMENTAL toggle (Fable fallback #3 -- p=phi non-incremental, severs pressure-accumulation feedback, loop gain exactly 0)**
- **pump hypre: PCG+AMG is the working --pspg path (port the guards). EMPIRICAL: on our GPU, PCG+BoomerAMG CONVERGES (16 iters, flow develops steps 1-3, div drops) while GMRES+AMG no-ops to x=0 (separate GMRES-wrapper GPU bug, debug later). PSPG makes the operator SPD + the pin removes the null mode, so CG+AMG is valid + textbook. Ported the null-mode + upper-bound-x guards (+ getEnvDouble, lastSolutionMax_, nullSolutionReturned_, accessors) from the GMRES wrapper to the PCG wrapper so a huge/near-null phi is rejected not scattered. Re-route --pspg pressure to PCG (PSPG off stays GMRES for SPSD). solveOneComponent picks up the guard via the solve() return**
