### PR TITLE
cstone

### DIFF
--- a/TGV_NEXT_SESSION_HANDOFF.md
+++ b/TGV_NEXT_SESSION_HANDOFF.md
@@ -1,6 +1,48 @@
-# TGV Multi-Rank Periodic — Handoff (2026-06-07)
+# TGV Multi-Rank Periodic — Handoff (2026-06-07, BREAKTHROUGH UPDATE)
 
-**Read this before touching code.** Three sessions, ~50 fix attempts, ~25 reverted. The bug is NOT closed but is precisely characterized.
+**Read this before touching code.** The primary feedback loop is FOUND and FIXED. The bug is reframed from "projection won't close" to "two feedback loops amplify the seam residual"; one is fixed, one is precisely localized.
+
+## BREAKTHROUGH (this session)
+
+The reframe that cracked it: stop chasing PROJ-P3 → 0 (the channel never closes it either — see docs/poiseuille_tutorial.md Part 6). The real failure is the **growing div_max feedback loop**, not the nonzero projection residual. Two loops:
+
+**PRIMARY LOOP — FIXED.** The predictor's `grad(p)` used the FOLDED periodic seam reduction (`maybePeriodicSum` at NS:7129-7131) while the corrector/operator under H2 use PER-SLOT (no fold). The mismatch `(G_fold − G_perslot)·p` is LINEAR in accumulated p → dt-independent geometric feedback gain ≈ 1.17 (which is why ~50 projection-side fixes never moved it — the loop is in the predictor↔corrector operator mismatch, not the projection). Fix: `MARS_PRED_PERSLOT_GRADP=1` makes the predictor `grad(p)` per-slot too, matching the corrector. Gain drops 1.17 → ~1.05. (Fable diagnosed this; Opus missed it for two days.)
+
+**SECONDARY LOOP — localized, not yet fixed.** After the primary fix, a weaker loop (gain ~1.05) remains: the skew-symmetric advection's `mdot` at the cross-rank periodic face. Skew (Verstappen) advection conserves discrete KE only when `mdot` telescopes across shared faces; at the periodic seam the master-side and slave-image elements compute `mdot` from slightly-inconsistent `u`, so it does NOT cancel and injects KE each step. PROOF: `--skew=0` (upwind) stays BOUNDED (KE oscillates 200-960, CG healthy through step 200) while `--skew=1` goes to Inf by step 160 — upwind's numerical diffusion damps the injection. CONSTRAINT: the fix is NOT a velocity broadcast — `MARS_TGV_USTART_BCAST=1` (force u[slave]:=u[master] at step start to make mdot consistent) made it WORSE (step 140 vs 160) because broadcasting u re-injects divergence the projection didn't account for. The fix must reconcile `mdot` across the periodic face WITHOUT changing stored `u`.
+
+**Empirical progress:** baseline blew at step ~40 (KE → 1e158). With `MARS_PRED_PERSLOT_GRADP=1 MARS_ROTATIONAL_P=1`: KE decays correctly through step 100, div_max bounded to ~16 at step 100, survives to step ~160. **4× longer survival, clean physics 2.5× longer.** Not stable yet, but a qualitative change.
+
+## Best-known config (env flags, all default OFF, all pump-safe)
+
+```
+MARS_PRED_PERSLOT_GRADP=1   # PRIMARY FIX: predictor grad(p) per-slot at seam (de7e366)
+MARS_ROTATIONAL_P=1         # damps residual pressure accumulation (Timmermans)
+```
+
+Tested combinations on cube16 4-rank (step where KE turns up / blows):
+| Config | Blow-up step |
+|--------|-------------|
+| baseline | ~40 |
+| PRED_PERSLOT only | ~110 |
+| PRED_PERSLOT + ROTATIONAL | **~160 (best)** |
+| PRED_PERSLOT + NONINCREMENTAL | ~110 (non-inc made it worse — loop is NOT pressure-accumulation) |
+| PRED_PERSLOT + ROTATIONAL + H2=0 | ~150 (H2 broadcast helps slightly) |
+| PRED_PERSLOT + ROTATIONAL + USTART_BCAST | ~140 (worse — velocity broadcast re-injects div) |
+| `--skew=0` upwind + PRED_PERSLOT + ROTATIONAL | BOUNDED to step 200 (numerical diffusion damps secondary loop) |
+
+## NEXT SESSION: the secondary-loop fix
+
+The secondary loop is in the skew advection `mdot` at the periodic seam. Read the skew kernel (NS:914-936): per face, `mdot` is computed once and used at both L and R, so per-face KE-conservation is fine WITHIN an element. The leak is that the periodic-image element (slave-owner rank) and the master-side element compute DIFFERENT `mdot` for the SAME physical periodic face (from inconsistent `u`), breaking the cross-element telescoping.
+
+Candidate fixes (untested):
+1. **Reconcile mdot across the periodic face** — after the per-element mdot is computed but before the flux scatter, average/fold the mdot at the periodic seam so master and slave-image faces use the SAME value. This is the mdot-level analog of the grad(p) per-slot fix. Does NOT touch u (avoids the USTART re-injection problem).
+2. **Use the Verstappen rotational advection form explicitly** — `N_skew = N_div − ½ q (div u)` computed so the `div u` term uses the seam-folded divergence. The pump solver mentions this form (NS:961-984).
+3. **Blend upwind dissipation at seam nodes only** — keep skew interior, add first-order upwind within one element of the periodic seam. Pragmatic; `--skew=0` proves it would bound the loop.
+
+The agents (Fable + Opus workflows) hit the session token limit at 4:20pm Zurich; relaunch the secondary-loop diagnosis workflow then if option 1's mdot-reconcile needs the algebra verified.
+
+---
+## ORIGINAL HANDOFF (pre-breakthrough, kept for reference)
 
 ## Current state (HEAD = `25734c7`)
 

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -7916,10 +7916,14 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
             // MARS_HYPRE_USE_DDT=1 falls back to the DDT operator for comparison.
             bool useDDTop = (std::getenv("MARS_HYPRE_USE_DDT") != nullptr);
             auto& pressureMat = useDDTop ? s.AddT : s.Apre;
-            // K is SPD -> PCG works; DDT is indefinite -> GMRES. (Override: KRYLOV.)
-            KrylovHint pk = useDDTop ? KrylovHint::GMRES : KrylovHint::PCG;
+            // GMRES for BOTH operators. K (Apre) is SPD in principle, but PCG
+            // breaks down (pAp<0, HYPRE error 256, ~3 iters) because BoomerAMG-as-
+            // preconditioner is non-symmetric on GPU (GS-family relax) and the
+            // pin row's diag=1 spike disturbs coarsening -> the effective
+            // preconditioned operator isn't SPD for CG. GMRES tolerates that and
+            // was the proven-converging path. (MARS_HYPRE_KRYLOV=pcg to force CG.)
             s.lastPressureIters = solveOneComponent<KeyType, RealType, ElementTag>(
-                s, b, xVec, s.d_phi, pressureMat, pk);
+                s, b, xVec, s.d_phi, pressureMat, KrylovHint::GMRES);
             // DIAGNOSTIC: sample WHOLE vectors via D2H, compute max-abs on
             // host. Lets us see whether the solution actually propagated.
             // Active only when env MARS_DDT_DIAG_AFTER_HYPRE is set.

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -351,6 +351,37 @@ __global__ void enforcePinRowKeepDiagKernel(int pinDof,
     if (!(values[dp] > RealType(0))) values[dp] = RealType(1);
 }
 
+// Pin every OWNED row of an assembled CSR whose diagonal is below `thresh` to an
+// identity row (off-diagonals zeroed, diagonal set to `diagVal`). The degenerate
+// passage/sliver cells give the assembled DDT operator near-zero diagonals ->
+// near-zero eigenvalues -> A^-1 amplifies by ~1e6 -> a CONVERGED solve returns a
+// physically-huge phi (|phi| ~ 1e6*|b|) that blows up the corrector. Pinning
+// those rows to identity removes the near-zero eigenvalues so phi is physical.
+// Returns nothing; count is done separately. diagVal should match the bulk
+// diagonal scale so the pinned rows don't themselves become an AMG spike.
+template<typename RealType>
+__global__ void pinTinyDiagonalRowsKernel(const int* rowPtr, const int* colInd,
+                                          const int* diagPtr, RealType* values,
+                                          uint8_t* isPressureBdryDof,
+                                          RealType thresh, RealType diagVal,
+                                          int numOwnedDofs, int* pinnedCount)
+{
+    int r = blockIdx.x * blockDim.x + threadIdx.x;
+    if (r >= numOwnedDofs) return;
+    int dp = diagPtr[r];
+    if (dp < 0) return;
+    RealType d = values[dp];
+    // Already a BC/pin row, or healthy diagonal -> leave it.
+    if (isPressureBdryDof && isPressureBdryDof[r]) return;
+    if (d >= thresh) return;
+    // Degenerate row: make it identity AND mark it in the pressure mask so the
+    // per-step RHS enforce zeros b there (a pinned identity row needs b=0).
+    for (int j = rowPtr[r]; j < rowPtr[r + 1]; ++j)
+        values[j] = (j == dp) ? diagVal : RealType(0);
+    if (isPressureBdryDof) isPressureBdryDof[r] = 1;
+    atomicAdd(pinnedCount, 1);
+}
+
 // Read the diagonal value of one row into a single-element device buffer.
 // Used to capture the pump pin's NATIVE diagonal before BC enforcement
 // overwrites it, so it can be restored afterwards (keeps AMG-friendly scaling).
@@ -4857,6 +4888,47 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
                     s.pressurePinDof, s.d_rowPtrDDT.data(), s.d_colIndDDT.data(),
                     s.d_diagPtrDDT.data(), s.d_valuesDDT.data());
                 cudaDeviceSynchronize();
+            }
+        }
+
+        // SLIVER PIN for the ASSEMBLED operator (Hypre path): the degenerate
+        // passage/sliver cells give the assembled DDT near-zero diagonals ->
+        // near-zero eigenvalues -> a CONVERGED GMRES+AMG solve returns a
+        // physically-huge phi (|phi| ~ 1e6*|b|, observed) that blows up the
+        // corrector. Pin every owned row with diag < frac*max_diag to identity
+        // (removes the near-zero eigenvalues) and mark it so the RHS is zeroed
+        // there. frac default 1e-4 (MARS_DDT_ASM_PIN_FRAC); 0 disables.
+        if (s.solverKind == SolverKind::Hypre && s.nnzDDT > 0 && s.numOwnedDofs > 0)
+        {
+            RealType asmPinFrac = RealType(1e-4);
+            if (const char* ev = std::getenv("MARS_DDT_ASM_PIN_FRAC"))
+            { double v = std::atof(ev); if (v >= 0) asmPinFrac = RealType(v); }
+            // max diagonal of the assembled operator (the bulk scale).
+            const int* dpAll = s.d_diagPtrDDT.data();
+            const RealType* vAll = s.d_valuesDDT.data();
+            RealType maxDiag = thrust::transform_reduce(thrust::device,
+                thrust::counting_iterator<int>(0),
+                thrust::counting_iterator<int>(s.numOwnedDofs),
+                [dpAll, vAll] __device__ (int r) -> RealType {
+                    int dp = dpAll[r]; return (dp >= 0) ? vAll[dp] : RealType(0);
+                }, RealType(0), thrust::maximum<RealType>());
+            RealType thresh = asmPinFrac * maxDiag;
+            if (thresh > RealType(0))
+            {
+                cstone::DeviceVector<int> d_pinned(1, 0);
+                int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+                pinTinyDiagonalRowsKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                    s.d_rowPtrDDT.data(), s.d_colIndDDT.data(), s.d_diagPtrDDT.data(),
+                    s.d_valuesDDT.data(), s.d_isPressureBdryDof.data(),
+                    thresh, maxDiag, s.numOwnedDofs, d_pinned.data());
+                cudaDeviceSynchronize();
+                int pinned = 0;
+                cudaMemcpy(&pinned, d_pinned.data(), sizeof(int), cudaMemcpyDeviceToHost);
+                if (s.rank == 0)
+                    std::cout << "  [asm-sliver-pin] pinned " << pinned
+                              << " tiny-diag rows (diag < " << std::scientific << thresh
+                              << " = " << asmPinFrac << " * max_diag " << maxDiag
+                              << ")" << std::defaultfloat << "\n";
             }
         }
         if (s.rank == 0)

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -7903,15 +7903,23 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
                 cudaDeviceSynchronize();
             }
             cudaMemset(xVec.data(), 0, s.numTotalDofs * sizeof(RealType));
-            // GMRES + BoomerAMG is the pressure solver (matching the reference:
-            // (Flex)GMRES with AMG as preconditioner). GMRES tolerates the
-            // assembled DDT+tau*L operator's near-indefiniteness (tiny passage-
-            // cell diagonals) where PCG breaks down (pAp<0, HYPRE error 256).
-            // Both wrappers now carry the null + upper-bound-x guards so a
-            // near-null / under-resolved phi is rejected, not scattered.
-            // (MARS_HYPRE_KRYLOV=pcg overrides to the PCG path for comparison.)
+            // OPERATOR: use the GALERKIN LAPLACIAN K (s.Apre) by default, NOT the
+            // Gram form D M^-1 D^T (s.AddT). Verified root cause of the 1e6-phi
+            // blowup: the DDT diagonal is 0.25*|sum_g sigma_g A_g|^2 / V -- a square
+            // of a CANCELLING signed sum of area-vectors, so it goes near-zero on
+            // GOOD cells (not slivers; a real sliver gives a HUGE diagonal here),
+            // creating near-zero eigenvalues -> A^-1 amplifies ~1e6. The Galerkin
+            // K_ij = integral grad(N_i).grad(N_j) has diagonal ~h (sum of squares,
+            // no cancellation) -> well-conditioned, AMG-friendly, no near-zero
+            // eigenvalue. This is what the reference assembles; switching to it is
+            // the structural fix. K is SPD so PCG is also valid here.
+            // MARS_HYPRE_USE_DDT=1 falls back to the DDT operator for comparison.
+            bool useDDTop = (std::getenv("MARS_HYPRE_USE_DDT") != nullptr);
+            auto& pressureMat = useDDTop ? s.AddT : s.Apre;
+            // K is SPD -> PCG works; DDT is indefinite -> GMRES. (Override: KRYLOV.)
+            KrylovHint pk = useDDTop ? KrylovHint::GMRES : KrylovHint::PCG;
             s.lastPressureIters = solveOneComponent<KeyType, RealType, ElementTag>(
-                s, b, xVec, s.d_phi, s.AddT, KrylovHint::GMRES);
+                s, b, xVec, s.d_phi, pressureMat, pk);
             // DIAGNOSTIC: sample WHOLE vectors via D2H, compute max-abs on
             // host. Lets us see whether the solution actually propagated.
             // Active only when env MARS_DDT_DIAG_AFTER_HYPRE is set.

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -7831,17 +7831,15 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
                 cudaDeviceSynchronize();
             }
             cudaMemset(xVec.data(), 0, s.numTotalDofs * sizeof(RealType));
-            // PSPG ON -> A = D M^-1 D^T + tau*L is SPD (symmetric pin removes the
-            // null mode) -> Hypre PCG+AMG, which EMPIRICALLY converges on our GPU
-            // (16 iters, flow develops) where GMRES+AMG no-ops to x=0 (a separate
-            // GMRES-wrapper GPU bug to fix). CG+AMG is also the textbook pressure-
-            // Poisson solver. The PCG wrapper now carries the same null + upper-x
-            // guards as GMRES, so a huge/near-null phi is rejected, not scattered.
-            // PSPG OFF -> SPSD -> PCG rejects (error 1) -> GMRES.
-            // (MARS_HYPRE_KRYLOV=pcg|gmres overrides for debugging.)
-            KrylovHint pressureKrylov = s.usePSPG ? KrylovHint::PCG : KrylovHint::GMRES;
+            // GMRES + BoomerAMG is the pressure solver (matching the reference:
+            // (Flex)GMRES with AMG as preconditioner). GMRES tolerates the
+            // assembled DDT+tau*L operator's near-indefiniteness (tiny passage-
+            // cell diagonals) where PCG breaks down (pAp<0, HYPRE error 256).
+            // Both wrappers now carry the null + upper-bound-x guards so a
+            // near-null / under-resolved phi is rejected, not scattered.
+            // (MARS_HYPRE_KRYLOV=pcg overrides to the PCG path for comparison.)
             s.lastPressureIters = solveOneComponent<KeyType, RealType, ElementTag>(
-                s, b, xVec, s.d_phi, s.AddT, pressureKrylov);
+                s, b, xVec, s.d_phi, s.AddT, KrylovHint::GMRES);
             // DIAGNOSTIC: sample WHOLE vectors via D2H, compute max-abs on
             // host. Lets us see whether the solution actually propagated.
             // Active only when env MARS_DDT_DIAG_AFTER_HYPRE is set.

--- a/backend/distributed/unstructured/fem/mars_ns_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_solver.hpp
@@ -2071,13 +2071,6 @@ struct NSStepper
     cstone::DeviceVector<int>     d_node_to_dof;
     cstone::DeviceVector<RealType> d_mass;       // per OWNED DOF
     cstone::DeviceVector<RealType> d_massNode;   // per NODE (owned + ghosts halo-exchanged); read by DDT assembler
-    // Per-slot (half-CV) per-node mass: the cross-rank-completed geometric mass
-    // BEFORE the periodic fold/mirror, so each periodic-pair slot keeps its own
-    // m_M / m_S (not m_merged). Used to normalize PER-SLOT gradient/divergence
-    // numerators (MARS_PRED_PERSLOT_*): per-slot numerator / per-slot mass =
-    // full physical gradient. The merged d_massNode would halve it (the
-    // residual factor-of-2 that kept the periodic feedback gain just above 1).
-    cstone::DeviceVector<RealType> d_massNodePerSlot;
     cstone::DeviceVector<uint8_t>  d_isBdryDof;
     // Pressure BC: in cavity mode, use a single corner pin (pressurePinDof).
     // In channel mode, use a Dirichlet mask (d_isPressureBdryDof) over the
@@ -3184,18 +3177,6 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
             cudaDeviceSynchronize();
         }
         s.domain.reverseExchangeNodeHaloAdd(s.d_massNode);
-        // Capture the PER-SLOT (half-CV) mass NOW -- after the cross-rank ghost
-        // contributions are summed in (reverseExchange) but BEFORE the periodic
-        // fold/mirror below collapses it to m_merged. Each periodic-pair slot
-        // keeps its own geometric mass m_M / m_S. Forward-halo so ghost slots
-        // (cross-rank master/slave) carry the owner's per-slot value too. Used
-        // by the per-slot grad/div normalizers (MARS_PRED_PERSLOT_*).
-        s.d_massNodePerSlot.resize(s.nodeCount);
-        thrust::copy(thrust::device,
-                     thrust::device_pointer_cast(s.d_massNode.data()),
-                     thrust::device_pointer_cast(s.d_massNode.data() + s.nodeCount),
-                     thrust::device_pointer_cast(s.d_massNodePerSlot.data()));
-        s.domain.exchangeNodeHalo(s.d_massNodePerSlot);
         maybePeriodicSum<KeyType, RealType, ElementTag>(s, s.d_massNode);
         // Forward halo: ghost slots get owner-rank V values so DDT assembler
         // can read s.d_massNode[ghostNode] and get the correct V.
@@ -5473,21 +5454,7 @@ void applyDDTPerNode(NSStepper<KeyType, RealType, ElementTag>& s,
     // per GRADDUMP empirics), producing FACTOR=1.65 and PROJ-P3=0.508. Enabling
     // this mirrors the RHS path; algebra predicts PROJ-P3 -> 0. SYMPROBE may
     // break (workflow's risk).
-    // MARS_SEAM_MERGED=1 forces the whole seam pipeline onto ONE convention:
-    // every seam quantity is folded to the master and broadcast back to the
-    // slave so both node slots of a periodic pair are bit-identical at every
-    // stage (operator g, corrector gradPhi, predictor grad(p)+advN). Then the
-    // periodic pair behaves as a single DOF replicated on two slots and the
-    // per-slot-vs-folded distinction vanishes: u^{n+1}[M]=u^{n+1}[S] falls out
-    // of the per-slot corrector itself (the H2 u-broadcast becomes a no-op
-    // instead of discarding the slave's projected value), and the operator CG
-    // inverts is the same merged operator the corrector applies. That closes
-    // the discrete divergence/KE balance to loop gain ~0 (vs the ~1+ left by
-    // the per-slot fixes, whose merged-mass denominator never matched their
-    // half-CV numerators). Here it turns the operator's internal g-broadcast on.
-    static const bool seamMerged = (std::getenv("MARS_SEAM_MERGED") != nullptr);
-    static const bool opGbcastReduced =
-        seamMerged || (std::getenv("MARS_OP_GBCAST_REDUCED") != nullptr);
+    static const bool opGbcastReduced = (std::getenv("MARS_OP_GBCAST_REDUCED") != nullptr);
     if ((applyPeriodic || (reducedPeriodicFold && opGbcastReduced))
         && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.periodicMap)
     {
@@ -7189,14 +7156,9 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
         // projection-side fixes never moved it). Matching the operators makes
         // B = A so the accumulated seam bias telescopes out in one step.
         // Gated to multi-rank periodic CG; pump (BCKind::Pump) never enters.
-        // MARS_SEAM_MERGED forces the merged convention: keep the fold on
-        // grad(p) (per-slot OFF) so the predictor's pressure gradient is the
-        // folded full merged-CV value, matching the merged operator/corrector.
-        const bool seamMerged = (std::getenv("MARS_SEAM_MERGED") != nullptr);
         const char* predPerSlotEnv = std::getenv("MARS_PRED_PERSLOT_GRADP");
         const bool predPerSlot =
-            !seamMerged
-            && (predPerSlotEnv && std::string(predPerSlotEnv) == "1")
+            (predPerSlotEnv && std::string(predPerSlotEnv) == "1")
             && s.numRanks > 1
             && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
             && s.solverKind == SolverKind::CG;
@@ -7206,17 +7168,9 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
             maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gyAcc);
             maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gzAcc);
         }
-        // PER-SLOT numerator REQUIRES PER-SLOT mass (workflow w7bapvkdt). When
-        // grad(p) is per-slot, divide by the per-slot half-CV mass so
-        // (per-slot numerator)/(per-slot mass) = full physical gradient. Using
-        // the merged mass would halve it (the residual factor-of-2 keeping the
-        // periodic feedback gain just above 1).
-        const RealType* gradPMass =
-            (predPerSlot && s.d_massNodePerSlot.size() == s.nodeCount)
-            ? s.d_massNodePerSlot.data() : s.d_massNode.data();
         normalizeGradientPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
             d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
-            gradPMass,
+            s.d_massNode.data(),
             s.d_node_to_dof.data(), d_nodeOwnership.data(),
             s.d_gradPx.data(), s.d_gradPy.data(), s.d_gradPz.data(),
             s.nodeCount);
@@ -7410,14 +7364,9 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
         // that the skew advection amplifies (the secondary loop; --skew=0 bounds
         // it, --skew=1 doesn't). Making advN per-slot too makes the whole
         // predictor RHS seam-consistent. Gated to multi-rank periodic CG.
-        // MARS_SEAM_MERGED forces the merged convention: keep the fold on advN
-        // (per-slot OFF) so the predictor's advection is the folded full
-        // merged-CV flux, matching grad(p), the operator, and the corrector.
-        const bool seamMergedAdv = (std::getenv("MARS_SEAM_MERGED") != nullptr);
         const char* predPerSlotAdvEnv = std::getenv("MARS_PRED_PERSLOT_ADV");
         const bool predPerSlotAdv =
-            !seamMergedAdv
-            && (predPerSlotAdvEnv && std::string(predPerSlotAdvEnv) == "1")
+            (predPerSlotAdvEnv && std::string(predPerSlotAdvEnv) == "1")
             && s.numRanks > 1
             && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
             && s.solverKind == SolverKind::CG;
@@ -8563,17 +8512,10 @@ void runCorrectorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
             // Empirical: cube64 PROJ-P3 1.31 -> 0.43, |Du^{n+1}| drops 3x.
             // Paired with u-broadcast before PROJ-P3 probe (search for tgvH2).
             // MARS_TGV_H2=0 reverts to FOLD_G default for ablation.
-            // MARS_SEAM_MERGED forces the merged convention: corrector gradPhi
-            // is folded+broadcast (corrFoldG=true) so gradPhi[M]=gradPhi[S]=
-            // (G_M+G_S)/m_merged, matching the operator's merged g (OP g-bcast
-            // forced on under the same gate). H2 (per-slot g) is the opposite
-            // convention, so it must be off here.
-            const bool seamMergedCorr = (std::getenv("MARS_SEAM_MERGED") != nullptr);
             const char* h2env = std::getenv("MARS_TGV_H2");
-            const bool tgvH2 = !seamMergedCorr && !(h2env && std::string(h2env) == "0");
+            const bool tgvH2 = !(h2env && std::string(h2env) == "0");
             const char* corrFoldGEnv = std::getenv("MARS_CORR_FOLD_G");
-            const bool  corrFoldG    = seamMergedCorr
-                                       || (!tgvH2 && !(corrFoldGEnv && std::string(corrFoldGEnv) == "0"));
+            const bool  corrFoldG    = !tgvH2 && !(corrFoldGEnv && std::string(corrFoldGEnv) == "0");
             if (corrFoldG && s.periodicMap)
             {
                 maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gxAcc);
@@ -8852,14 +8794,8 @@ void runCorrectorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
     // (commit 808140e). Gated on Periodic+CG+routeReducedPeriodicCorr because
     // only that branch keeps the per-slot gradient that H2 requires.
     {
-        // Under MARS_SEAM_MERGED the corrector already produced gradPhi[M]=
-        // gradPhi[S] (fold+broadcast), so u^{n+1}[M]=u^{n+1}[S] falls out of
-        // the per-slot update and this H2 broadcast is unnecessary (it would
-        // be a no-op). H2 is the per-slot convention, mutually exclusive with
-        // merged, so disable it here.
-        const bool seamMerged = (std::getenv("MARS_SEAM_MERGED") != nullptr);
         const char* h2env = std::getenv("MARS_TGV_H2");
-        const bool tgvH2 = !seamMerged && !(h2env && std::string(h2env) == "0");
+        const bool tgvH2 = !(h2env && std::string(h2env) == "0");
         if (tgvH2 && routeReducedPeriodicCorr && s.periodicMap)
         {
             const int* dpart = s.periodicMap->d_periodicPartner.data();

--- a/backend/distributed/unstructured/fem/mars_ns_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_solver.hpp
@@ -7078,14 +7078,27 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
     // gate at the velocity-broadcast block below.
     if (s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.periodicMap)
     {
-        const bool routeReducedPeriodicCorr =
+        bool routeReducedPeriodicCorr =
             s.numRanks > 1
             && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
             && s.solverKind == SolverKind::CG;
+        // MARS_TGV_USTART_BCAST=1: force the start-of-step u/v/w master->slave
+        // broadcast even on the reduced path. Rationale (this session): the
+        // skew advection's mdot at the periodic face reads u at seam ghosts; an
+        // inconsistent slave u makes mdot across the periodic face NOT cancel,
+        // breaking the Verstappen discrete-KE-conservation property and
+        // injecting energy each step (the residual secondary loop after the
+        // primary grad(p) mismatch is fixed by MARS_PRED_PERSLOT_GRADP). With
+        // the predictor now per-slot-consistent, broadcasting u here makes mdot
+        // seam-consistent without re-injecting the divergence the old comment
+        // feared. --skew=0 (upwind) bounds the loop via numerical diffusion,
+        // confirming the loop is advective.
+        const char* uStartEnv = std::getenv("MARS_TGV_USTART_BCAST");
+        const bool forceUStartBcast = (uStartEnv && std::string(uStartEnv) == "1");
         int blk = 256, grd = int((s.nodeCount + blk - 1) / blk);
         const int* d_partner = s.periodicMap->d_periodicPartner.data();
         size_t nN            = s.nodeCount;
-        if (!routeReducedPeriodicCorr)
+        if (!routeReducedPeriodicCorr || forceUStartBcast)
         {
             mars::fem::periodicBroadcastKernel<<<grd, blk>>>(d_partner, nN, s.d_u.data());
             mars::fem::periodicBroadcastKernel<<<grd, blk>>>(d_partner, nN, s.d_v.data());
@@ -7093,7 +7106,7 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
         }
         mars::fem::periodicBroadcastKernel<<<grd, blk>>>(d_partner, nN, s.d_p.data());
         cudaDeviceSynchronize();
-        if (!routeReducedPeriodicCorr)
+        if (!routeReducedPeriodicCorr || forceUStartBcast)
         {
             s.domain.exchangeNodeHalo(s.d_u);
             s.domain.exchangeNodeHalo(s.d_v);

--- a/backend/distributed/unstructured/fem/mars_ns_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_solver.hpp
@@ -7356,12 +7356,26 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
             cudaDeviceSynchronize();
         }
         s.domain.reverseExchangeNodeHaloAdd(advN);
-        maybePeriodicSum<KeyType, RealType, ElementTag>(s, advN);
-        // advN[master] is now the full-control-volume advective flux (both half-CVs
-        // summed via the reverse-halo + periodic fold). Under owner-migration the
-        // predictor reads advN ONLY at owned master DOFs (dof<numOwnedDofs); the
-        // cross-rank slave is a ghost it skips, so no master->slave advN broadcast
-        // is needed -- that block was emulation-era scaffolding writing unread slots.
+        // MARS_PRED_PERSLOT_ADV=1: SKIP the maybePeriodicSum fold on advN so the
+        // predictor's advection uses the SAME per-slot seam reduction as its
+        // grad(p) (when MARS_PRED_PERSLOT_GRADP is on). With grad(p) per-slot
+        // (primary-loop fix) but advN still folded, the predictor mixes a folded
+        // advection with a per-slot gradient -> a residual seam inconsistency
+        // that the skew advection amplifies (the secondary loop; --skew=0 bounds
+        // it, --skew=1 doesn't). Making advN per-slot too makes the whole
+        // predictor RHS seam-consistent. Gated to multi-rank periodic CG.
+        const char* predPerSlotAdvEnv = std::getenv("MARS_PRED_PERSLOT_ADV");
+        const bool predPerSlotAdv =
+            (predPerSlotAdvEnv && std::string(predPerSlotAdvEnv) == "1")
+            && s.numRanks > 1
+            && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
+            && s.solverKind == SolverKind::CG;
+        if (!predPerSlotAdv)
+            maybePeriodicSum<KeyType, RealType, ElementTag>(s, advN);
+        // advN[master] is the full-control-volume advective flux (both half-CVs
+        // summed via the reverse-halo + periodic fold), unless per-slot mode.
+        // Under owner-migration the predictor reads advN ONLY at owned master
+        // DOFs (dof<numOwnedDofs); the cross-rank slave is a ghost it skips.
 
         // DIAGNOSTIC: owned-sum of the (folded) advection term. This is a
         // rank-count-INVARIANT physical quantity if the advection scatter +

--- a/backend/distributed/unstructured/fem/mars_ns_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_solver.hpp
@@ -2071,6 +2071,13 @@ struct NSStepper
     cstone::DeviceVector<int>     d_node_to_dof;
     cstone::DeviceVector<RealType> d_mass;       // per OWNED DOF
     cstone::DeviceVector<RealType> d_massNode;   // per NODE (owned + ghosts halo-exchanged); read by DDT assembler
+    // Per-slot (half-CV) per-node mass: the cross-rank-completed geometric mass
+    // BEFORE the periodic fold/mirror, so each periodic-pair slot keeps its own
+    // m_M / m_S (not m_merged). Used to normalize PER-SLOT gradient/divergence
+    // numerators (MARS_PRED_PERSLOT_*): per-slot numerator / per-slot mass =
+    // full physical gradient. The merged d_massNode would halve it (the
+    // residual factor-of-2 that kept the periodic feedback gain just above 1).
+    cstone::DeviceVector<RealType> d_massNodePerSlot;
     cstone::DeviceVector<uint8_t>  d_isBdryDof;
     // Pressure BC: in cavity mode, use a single corner pin (pressurePinDof).
     // In channel mode, use a Dirichlet mask (d_isPressureBdryDof) over the
@@ -3177,6 +3184,18 @@ void setupNSStepper(NSStepper<KeyType, RealType, ElementTag>& s,
             cudaDeviceSynchronize();
         }
         s.domain.reverseExchangeNodeHaloAdd(s.d_massNode);
+        // Capture the PER-SLOT (half-CV) mass NOW -- after the cross-rank ghost
+        // contributions are summed in (reverseExchange) but BEFORE the periodic
+        // fold/mirror below collapses it to m_merged. Each periodic-pair slot
+        // keeps its own geometric mass m_M / m_S. Forward-halo so ghost slots
+        // (cross-rank master/slave) carry the owner's per-slot value too. Used
+        // by the per-slot grad/div normalizers (MARS_PRED_PERSLOT_*).
+        s.d_massNodePerSlot.resize(s.nodeCount);
+        thrust::copy(thrust::device,
+                     thrust::device_pointer_cast(s.d_massNode.data()),
+                     thrust::device_pointer_cast(s.d_massNode.data() + s.nodeCount),
+                     thrust::device_pointer_cast(s.d_massNodePerSlot.data()));
+        s.domain.exchangeNodeHalo(s.d_massNodePerSlot);
         maybePeriodicSum<KeyType, RealType, ElementTag>(s, s.d_massNode);
         // Forward halo: ghost slots get owner-rank V values so DDT assembler
         // can read s.d_massNode[ghostNode] and get the correct V.
@@ -5454,7 +5473,21 @@ void applyDDTPerNode(NSStepper<KeyType, RealType, ElementTag>& s,
     // per GRADDUMP empirics), producing FACTOR=1.65 and PROJ-P3=0.508. Enabling
     // this mirrors the RHS path; algebra predicts PROJ-P3 -> 0. SYMPROBE may
     // break (workflow's risk).
-    static const bool opGbcastReduced = (std::getenv("MARS_OP_GBCAST_REDUCED") != nullptr);
+    // MARS_SEAM_MERGED=1 forces the whole seam pipeline onto ONE convention:
+    // every seam quantity is folded to the master and broadcast back to the
+    // slave so both node slots of a periodic pair are bit-identical at every
+    // stage (operator g, corrector gradPhi, predictor grad(p)+advN). Then the
+    // periodic pair behaves as a single DOF replicated on two slots and the
+    // per-slot-vs-folded distinction vanishes: u^{n+1}[M]=u^{n+1}[S] falls out
+    // of the per-slot corrector itself (the H2 u-broadcast becomes a no-op
+    // instead of discarding the slave's projected value), and the operator CG
+    // inverts is the same merged operator the corrector applies. That closes
+    // the discrete divergence/KE balance to loop gain ~0 (vs the ~1+ left by
+    // the per-slot fixes, whose merged-mass denominator never matched their
+    // half-CV numerators). Here it turns the operator's internal g-broadcast on.
+    static const bool seamMerged = (std::getenv("MARS_SEAM_MERGED") != nullptr);
+    static const bool opGbcastReduced =
+        seamMerged || (std::getenv("MARS_OP_GBCAST_REDUCED") != nullptr);
     if ((applyPeriodic || (reducedPeriodicFold && opGbcastReduced))
         && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic && s.periodicMap)
     {
@@ -7156,9 +7189,14 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
         // projection-side fixes never moved it). Matching the operators makes
         // B = A so the accumulated seam bias telescopes out in one step.
         // Gated to multi-rank periodic CG; pump (BCKind::Pump) never enters.
+        // MARS_SEAM_MERGED forces the merged convention: keep the fold on
+        // grad(p) (per-slot OFF) so the predictor's pressure gradient is the
+        // folded full merged-CV value, matching the merged operator/corrector.
+        const bool seamMerged = (std::getenv("MARS_SEAM_MERGED") != nullptr);
         const char* predPerSlotEnv = std::getenv("MARS_PRED_PERSLOT_GRADP");
         const bool predPerSlot =
-            (predPerSlotEnv && std::string(predPerSlotEnv) == "1")
+            !seamMerged
+            && (predPerSlotEnv && std::string(predPerSlotEnv) == "1")
             && s.numRanks > 1
             && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
             && s.solverKind == SolverKind::CG;
@@ -7168,9 +7206,17 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
             maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gyAcc);
             maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gzAcc);
         }
+        // PER-SLOT numerator REQUIRES PER-SLOT mass (workflow w7bapvkdt). When
+        // grad(p) is per-slot, divide by the per-slot half-CV mass so
+        // (per-slot numerator)/(per-slot mass) = full physical gradient. Using
+        // the merged mass would halve it (the residual factor-of-2 keeping the
+        // periodic feedback gain just above 1).
+        const RealType* gradPMass =
+            (predPerSlot && s.d_massNodePerSlot.size() == s.nodeCount)
+            ? s.d_massNodePerSlot.data() : s.d_massNode.data();
         normalizeGradientPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
             d_gxAcc.data(), d_gyAcc.data(), d_gzAcc.data(),
-            s.d_massNode.data(),
+            gradPMass,
             s.d_node_to_dof.data(), d_nodeOwnership.data(),
             s.d_gradPx.data(), s.d_gradPy.data(), s.d_gradPz.data(),
             s.nodeCount);
@@ -7364,9 +7410,14 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
         // that the skew advection amplifies (the secondary loop; --skew=0 bounds
         // it, --skew=1 doesn't). Making advN per-slot too makes the whole
         // predictor RHS seam-consistent. Gated to multi-rank periodic CG.
+        // MARS_SEAM_MERGED forces the merged convention: keep the fold on advN
+        // (per-slot OFF) so the predictor's advection is the folded full
+        // merged-CV flux, matching grad(p), the operator, and the corrector.
+        const bool seamMergedAdv = (std::getenv("MARS_SEAM_MERGED") != nullptr);
         const char* predPerSlotAdvEnv = std::getenv("MARS_PRED_PERSLOT_ADV");
         const bool predPerSlotAdv =
-            (predPerSlotAdvEnv && std::string(predPerSlotAdvEnv) == "1")
+            !seamMergedAdv
+            && (predPerSlotAdvEnv && std::string(predPerSlotAdvEnv) == "1")
             && s.numRanks > 1
             && s.bcKind == NSStepper<KeyType, RealType, ElementTag>::BCKind::Periodic
             && s.solverKind == SolverKind::CG;
@@ -8512,10 +8563,17 @@ void runCorrectorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
             // Empirical: cube64 PROJ-P3 1.31 -> 0.43, |Du^{n+1}| drops 3x.
             // Paired with u-broadcast before PROJ-P3 probe (search for tgvH2).
             // MARS_TGV_H2=0 reverts to FOLD_G default for ablation.
+            // MARS_SEAM_MERGED forces the merged convention: corrector gradPhi
+            // is folded+broadcast (corrFoldG=true) so gradPhi[M]=gradPhi[S]=
+            // (G_M+G_S)/m_merged, matching the operator's merged g (OP g-bcast
+            // forced on under the same gate). H2 (per-slot g) is the opposite
+            // convention, so it must be off here.
+            const bool seamMergedCorr = (std::getenv("MARS_SEAM_MERGED") != nullptr);
             const char* h2env = std::getenv("MARS_TGV_H2");
-            const bool tgvH2 = !(h2env && std::string(h2env) == "0");
+            const bool tgvH2 = !seamMergedCorr && !(h2env && std::string(h2env) == "0");
             const char* corrFoldGEnv = std::getenv("MARS_CORR_FOLD_G");
-            const bool  corrFoldG    = !tgvH2 && !(corrFoldGEnv && std::string(corrFoldGEnv) == "0");
+            const bool  corrFoldG    = seamMergedCorr
+                                       || (!tgvH2 && !(corrFoldGEnv && std::string(corrFoldGEnv) == "0"));
             if (corrFoldG && s.periodicMap)
             {
                 maybePeriodicSum<KeyType, RealType, ElementTag>(s, d_gxAcc);
@@ -8794,8 +8852,14 @@ void runCorrectorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
     // (commit 808140e). Gated on Periodic+CG+routeReducedPeriodicCorr because
     // only that branch keeps the per-slot gradient that H2 requires.
     {
+        // Under MARS_SEAM_MERGED the corrector already produced gradPhi[M]=
+        // gradPhi[S] (fold+broadcast), so u^{n+1}[M]=u^{n+1}[S] falls out of
+        // the per-slot update and this H2 broadcast is unnecessary (it would
+        // be a no-op). H2 is the per-slot convention, mutually exclusive with
+        // merged, so disable it here.
+        const bool seamMerged = (std::getenv("MARS_SEAM_MERGED") != nullptr);
         const char* h2env = std::getenv("MARS_TGV_H2");
-        const bool tgvH2 = !(h2env && std::string(h2env) == "0");
+        const bool tgvH2 = !seamMerged && !(h2env && std::string(h2env) == "0");
         if (tgvH2 && routeReducedPeriodicCorr && s.periodicMap)
         {
             const int* dpart = s.periodicMap->d_periodicPartner.data();

--- a/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
+++ b/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
@@ -33,14 +33,15 @@ public:
           solver_(nullptr), precond_(nullptr), A_hypre_(nullptr),
           b_hypre_(nullptr), x_hypre_(nullptr), verbose_(true), precondType_(precondType),
           kDim_(kDim) {
-        // FlexGMRES vs plain GMRES. FlexGMRES allows a VARYING (non-fixed)
-        // preconditioner -- the right choice when the preconditioner is itself
-        // an iterative solve (BoomerAMG V-cycles are not a fixed linear op once
-        // you use >1 sweep / aggressive coarsening), which can break plain
-        // GMRES's assumption of a constant M. Default ON for BoomerAMG (where it
-        // matters), OFF for diagonal Jacobi (fixed -> plain GMRES is fine).
-        // Env MARS_HYPRE_FLEXGMRES=1/0 forces it on/off.
-        useFlexGmres_ = (precondType == BOOMERAMG);
+        // Plain GMRES vs FlexGMRES. A 1-V-cycle BoomerAMG preconditioner IS a
+        // fixed linear operator, so plain GMRES (HYPRE_GMRESSetPrecond) is valid
+        // AND is the most battle-tested GPU path. FlexGMRES (varying precond) was
+        // tried as the default but its precond-apply appeared to NO-OP on our GPU
+        // Hypre build (AMG returned x=0 with a denormal ~1e-315 residual), while
+        // plain GMRES+AMG is the standard. Default OFF (plain GMRES). FlexGMRES
+        // only matters if the precond varies (>1 AMG sweep w/ inner tol); enable
+        // with MARS_HYPRE_FLEXGMRES=1.
+        useFlexGmres_ = false;
         const char* fev = std::getenv("MARS_HYPRE_FLEXGMRES");
         if (fev) useFlexGmres_ = (std::string(fev) != "0");
     }


### PR DESCRIPTION
- **fix(pump): revive the pressure outlet (the REAL through-flow fix). outletU was set unconditionally -> always velocity-Dirichlet outlet -> both-ends-Dirichlet admits a flat-pressure tank-recirculation div=0 solution -> NO flow through the passage (confirmed: 1e-10 pressure solve gave identical flat-p, so it's structural not convergence -- AMG would NOT help). Gate outletU on !outletDoNothing so do-nothing (default) leaves outletU<=0 -> solver masks the WHOLE outlet face p=0 + frees outlet velocity (singlePin=false, solver:4080) -> inlet flux against fixed-p outlet FORCES the outlet->suction gradient -> through-flow. The dead --outlet flag now actually works**
- **fix(pump): default outlet back to MASS-CONSERVING (the correct design). Root cause found: the divergence operator only loops interior faces (sum(div)==0 always), so the pressure solve is NEVER told mass enters at the inlet -> a velocity-inlet + free pressure-outlet is UNPROJECTABLE -> no through-flow (flow dies at inlet, pressure parks in body). The code's own comment (solver:2295) flags this. My prior do-nothing default was backwards: the mass-conserving outlet (vel outflow removes Q + single pin) BALANCES the flux so the projection builds the inlet->outlet gradient that drives flow through the passage. The dead-flag gate stays so do-nothing is still selectable (needs a boundary-flux source term to be correct -- separate work)**
- **pump through-flow: (1) default to do-nothing outlet = whole-face p=0 + FREE outlet velocity (the channel-proven pairing that builds the inlet->outlet pressure head; both-ends-velocity-Dirichlet + single pin gave a flat-pressure dead-passage solution). (2) --inlet-flux-source (GUARDED, off): add the prescribed inlet flux as a boundary divergence source -- the exterior opening flux is in no interior SCS so it's never integrated (verified not a double-count); A/B it. (3) [through-flow] Q_in/Q_out/ratio diagnostic each step so we MEASURE through-flow (ratio->1) instead of eyeballing uMax. mass-conserving still selectable. cavity/channel/TGV unaffected**
- **pump: REMOVE the broken --inlet-flux-source (double-counted the inlet flux already registered via interior SCS scatter; full-opening-area x rho/dt -> instant blowup, ratio=garbage) and revert default to MASS-CONSERVING outlet. Verified high-confidence: the inlet flux is already in the divergence for a velocity-Dirichlet inlet, so the only correct inlet boundary source is ZERO. do-nothing (whole-face p=0 + free outlet) does NOT self-drive a small interior outlet -> ratio=0 (no through-flow); the prior do-nothing-default + comments were disproven by the A/B. mass-conserving (U_out=Uin*Ain/Aout + single pin) forces Q_out=Q_in by construction. Kept the [through-flow] Q diagnostic (correct + useful)**
- **pump through-flow REWORK (verified root cause): the reference flows through the pump with ANY scheme (bj/upwind) so the dead passage is OUR bug, not Re/scheme. TWO real defects fixed: FIX1 --opening-flux-source (GUARDED off): inlet/outlet OPENING faces are exterior, in no interior SCS, so the prescribed opening flux never reaches the pressure RHS -> pressure flat -> no through-flow. Add it as a COMPATIBLE surface integral (u.n)*A_share, SAME scale as interior scatter, NOT x rho/dt (RHS does it), net~0 -- verified NOT a double-count (telescoping interior pairs never touch the opening face). FIX2 --dirichlet-lift (default ON): velocity-diffusion col-zero had no Dirichlet lift -> inlet momentum never diffused inward -> jet died at inlet. Add b-=K[row,bdry]*uTarget. FIX3: replace TAUTOLOGICAL Q_out (relocked to prescribed outletU) with an INTERIOR cut-plane flux probe at 25/50/75% -- measures SOLVED through-flow, can't be faked. old line relabeled [bc-sanity]**
- **pump FIX B: pressure-drop drive via --pump-dp=VALUE (gated, off by default -> existing pump byte-identical). Root cause: the divergence operator integrates only INTERIOR SCS faces, so a VELOCITY prescribed on the interior inlet opening is invisible to the pressure solver (exterior opening face never integrated) + the corrector freezes velocity-Dirichlet nodes -> no through-flow (proven: interior-flux mid-cut=0). FIX B masks BOTH openings as pressure-Dirichlet (p=dP inlet, p=0 outlet), frees both velocities, seeds the dP head in d_p -> flow EMERGES from the interior gradient (SCS-captured, VISIBLE). Startup-safe: two Dirichlet faces make the matrix NONSINGULAR -> no compatibility condition -> no FIX-1 source-blowup. inlet velocity becomes an OUTPUT (tune dP to hit ~0.5 m/s). Keeps interior-flux probe to verify mid-cut goes nonzero**
- **pump FIX B phi-lift (the piece that makes dP actually drive flow). Bug: FIX B seeded a one-node dP spike + pinned the phi increment to 0 at both faces -> interior never relaxed into the inlet->outlet gradient -> dP didn't drive flow (identical tiny flow at dP=1000 vs 30000). FIX: pin the SOLVED pressure to the target via rhs=target-p^n at masked DOFs (clamp to constant, NOT additive -> steady+bounded), so the Poisson solve imposes dP->0 Dirichlet data + relaxes the spanning gradient; the already-live predictor grad(p^n) then drives through-flow. LOAD-BEARING: pump runs DDT matrix-free, so the lift goes in solvePressureDDT's boundary-pin lambda (not the K-path). All gated pumpDp>0; pumpDp<=0 byte-identical (cavity/channel/TGV untouched)**
- **pump THROUGH-FLOW fix: prescribed-balanced opening-flux source (default ON). The verified root cause: a velocity-inlet's opening flux is invisible to the pressure solver (divergence integrates interior SCS only) -> flat passage -> dead passage (proven: interior-flux cut@50%=0). FIX: inject the opening flux into divAccNode so the projection SEES the inflow and builds the inlet->outlet gradient that drives the passage. KEY over the broken FIX 1: use PRESCRIBED GLOBAL-direction velocities (Uinf*inletDir, outletU*outletDir) not the solved u** -> inlet sums to -Q_in, outlet to +Q_in (outletU=Uin*Ain/Aout) -> total=0 EXACTLY every step incl step0 -> single-pin Neumann stays compatible -> CANNOT blow up like FIX 1 (which used u**=0 at the step0 outlet -> one-sided -> phi=1e36). Config: mass-conserving velocity inlet+outlet (sustains the jet) + this source (makes it visible). No removeMean (pin handles it). FIX B (pumpDp) abandoned, gated off**
- **pump: default opening-flux-source back OFF -- the prescribed-balanced source STILL blows up at step0 (phi=1e7->inf, CG residual grows = incompatible, same FLT_MAX as FIX 1). The 'sum=0 by construction' startup-safety proof was WRONG: the discrete per-node area shares evidently do not sum to exactly Q, so sum!=0, x rho/dt=1e6 -> explodes even at step0. Revert to the STABLE mass-conserving default (no through-flow, but runs). The opening-flux-source remains a flag for debugging but is NOT a working fix. Through-flow is UNRESOLVED -- see scratch/pump_throughflow_HANDOFF.md**
- **pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B**
- **Revert "pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B"**
- **debug: MARS_OFS_DBG -- print divAccNode |max| before/after the opening-flux source + the global net source sum, to SEE if the source is a giant localized spike (divAcc max jumps) and whether net is actually ~0. Instrumentation only, gated on env. Investigating the repeated step0 phi=1e7 blowup**
- **debug: print Qin_raw/Qout_raw separately -- the [ofs-dbg] net=-Q_in (one-sided) proves the OUTLET source contributes ZERO. Need to see Qin_raw vs Qout_raw to find why the outlet half does not fire (area-vec sign? outletDir?)**
- **pump: adjustPhi rescale FOUND THE BUG via debug -- the discrete inlet/outlet fluxes differ ~1.5% (Qin_raw=-5.975e-3, Qout_raw=+5.884e-3), NOT roundoff: the per-node area-vectors sum to a different value than the analytic areaIn/areaOut used for outletU. That 9e-5 residual x rho/dt=1e6 -> incompatible RHS -> phi=1e7 blowup. FIX: oScale=-Qin_raw/Qout_raw, rescale the outlet source so it EXACTLY cancels the inlet (net->0). The reductions now always run (not just debug). [ofs-dbg2] prints the net to confirm it goes to ~0**
- **pump: removeMean for the opening-flux source -- THE ACTUAL FIX. Debug PROVED the blowup is NOT flux imbalance: with the adjustPhi rescale the net source is bit-exactly 0 (8.67e-19) and it STILL blew up to phi=1e7 identically. Real cause (the code's own comments flag it: lines 897/2209/3333/5145): the single p=0 pin weakly controls the DDT constant null space; a boundary source excites that mode and Jacobi-PCG loses pAp>0 (residual GROWS 0.98->1.46 then garbage phi=1e7). FIX: removeMean the RHS + phi (project the null-space component out) when opening-flux is on -- the same cure the periodic path uses. Gated on useOpeningFluxSource**
- **debug: removeMean did NOT fix the blowup (phi=1e7 identical) -> null-space theory also wrong. KEY realization: the CG CONVERGES (3e-8), so phi=1e7 is the TRUE solution -- the operator+RHS are fine, the answer is legitimately huge. Add [ofs-dbg3] b|max and [ofs-dbg4] phi|max split by OPENING vs INTERIOR nodes, to decide: is phi huge only at the opening nodes (tiny DDT boundary-layer diagonal, b/diag=1e6*1e-4/1e-5=1e7 LOCAL) or everywhere (global)? That picks the final fix**
- **pump: --source-ramp-steps=N gentle startup for the opening-flux source. ROOT CAUSE (measured): the source WORKS (real through-flow, step1 cut@50% nonzero) but starting from rest at full strength dumps the whole inlet->outlet pressure head onto a near-singular interior node (sliver cell, DDT diag=1e-5, 600x below bulk) -> phi spikes to 6e6 there -> grad(phi) spike -> corrector velocity spike -> advection 950x/step -> blowup. NOT fixable by clip (preconditioner-only, phi is the true solution), CFL (structural per-step amplification), or balance/removeMean (all already correct). FIX: ramp Uinf 0->full over N steps so the head + phi + grad stay small while flow develops gently. Scales the inlet velocity target (from a base snapshot) AND the opening-flux source (reads Uinf live) -> balance preserved at every ramp level**
- **pump: allow dt to shrink up to 2x/step (was 5%/step). With the ramp, the flow develops stably for ~16 steps (phi=1e4, u_max bounded+growing, cut@50% nonzero) then a CFL violation at u~100 ran away because the 5%/step shrink cap could not drop dt fast enough to catch it. Fast shrink catches the violation in one step; growth stays gentle (5%/step) so BDF2's constant-dt assumption holds at steady state**
- **pump: targeted operator-diagonal floor on the matrix-free DDT (the sliver-node fix). MEASURED: the ramp fixes startup (steps 1-16 stable, flow developing, cut@50% nonzero) but one sliver interior node (tiny SCS face areas -> DDT diag=1e-5, 600x below bulk) makes phi spike there -> corrector velocity spike -> diffusion CG breaks (pAp<0, u**>>u*) -> blowup, even at dt=5e-8 (so NOT CFL). Jacobi clip is preconditioner-only (no-op on phi). FIX: raise ONLY the degenerate rows to epsFloor=0.05*max_diag in the TRUE matrix-free operator via per-node shift out[i]+=shift_i*phi[i]; 0 on the healthy bulk -> byte-identical there -> cavity/channel/cube16 untouched. Caps phi at b/3.3e-4 (~31x smaller) -> below blowup threshold. Pure positive diagonal add -> keeps SPD. Preconditioner diag floored to match. Velocity diffusion needs NO floor (M/dt keeps it conditioned; its divergence was downstream of the phi spike). Env MARS_DDT_OP_FLOOR_FRAC**
- **debug: MARS_CHECKER -- per-element mean-free pressure RMS diagnostic (the checkerboard mode an inf-sup stabilizer penalizes). Lets us SEE the checkerboard grow + SEE a stabilizer kill it in a few steps, instead of inferring from a full-run blowup. Confirms/quantifies the LBB decoupling diagnosis. Env-gated, tet-only, rank0, free in production. NOTE: adjudication confirmed BD-on-DDT is WRONG (breaks div=0 identity, accumulating divergence); the identity-safe path is VMS/RC on the divergence SOURCE (needs a phi-vs-d_p fix). Checkerboard fix != through-flow fix (separate defects)**
- **fix: checker diagnostic compile error -- a pair-returning __device__ lambda in transform_reduce needs its return type proclaimed in host context. Split into two scalar (double) reductions (mean-free energy + total) -- avoids the trait error, same result**
- **pump: replace the div-BREAKING operator-diagonal floor with an identity-safe MASS floor. The operator floor (out[i]+=shift*phi in applyDDTPerNode) only the OPERATOR saw, not the corrector -> solving (A+S)phi=b left div(u^{n+1})=(dt/rho)*S*phi un-projected -> accumulating residual -> smooth |p| 1e3->1e34 blowup (the SAME div=0-breaking class the code warns against for BD-on-DDT, lines 5602-5610). FIX: floor the lumped mass d_massNode instead -- A=D M^-1 D^T and the corrector ALSO applies M^-1 from the same d_massNode, so flooring mass changes operator AND corrector consistently -> div=0 PRESERVED. Removed d_shiftDDTNode + its apply + the operator-floor build. Env MARS_MASS_FLOOR_FRAC (default 1e-3*max_mass)**
- **pump: implicit PSPG pressure stabilization (--pspg) -- the CORRECT equal-order checkerboard fix. VERIFIED root cause of the checkerboard blowup: the existing VMS adds tau*(-lap p^n) to the RHS = an EXPLICIT forward-Euler Laplacian-of-p update -> unconditionally amplifies the high-freq mode at ANY tau (why 1e-6/1e-5/1e-3 all blew up). FIX: add tau*L*phi IMPLICITLY inside applyDDTPerNode so CG solves (A+tau*L)phi=b. L=sum_e V_e G^T G is symmetric PSD, shares A's constant null mode (removed by the pin) -> SPD, damps checkerboard at ALL tau>0. Acts on phi (the correction, ->0) so it self-extinguishes; post-corrector div relaxes to ~tau*lap(phi)=O(h^2), a CONSISTENT residual that vanishes under refinement -- the textbook PSPG, NOT the inconsistent div-breaking BD/floor. tau=h^2/24 (a LENGTH^2, not dt/rho). Confirm via MARS_CHECKER: frac must shrink. New kernel applyPSPGLaplacianTetKernel; gated --pspg, tau auto or --pspg-tau**
- **pump PSPG: FIX THE SIGN. The DDT operator outAcc = D M^-1 D^T phi ~ -lap(phi) (SPD-positive; A=-lap, matches b=-coef*div). My PSPG scattered +div(grad phi)=+lap(phi) = OPPOSITE sign -> SUBTRACTED definiteness (made conditioning worse, no damping). Flip: scatter -s to iL / +s to iR so it adds +tau*(-lap)phi = positive energy, same orientation as A. This is why the first PSPG run showed frac still growing + cg_p=-2 (wrong-sign term de-conditioned the operator). NOTE: that run ALSO lost the Jacobi clip (diag=6.5e-12) -- must pass MARS_DDT_JACOBI_CLIP_FRAC for the sliver**
- **pump PSPG: add tau*L diagonal to the Jacobi preconditioner (the REAL bug). Numerically verified (host dense-matrix replica): my PSPG sign was CORRECT (-s/+s -> L=+Vol*G^T*G, same sign as A=-lap, A+tau*L more SPD). The cg_p=-2 failure was the PRECONDITIONER mismatch: operator ran A+tau*L but d_diagDDT was built from A only -> worst on the sliver rows (tiny A-diag, large tau*L-diag) -> CG stalls. FIX: computeTetPSPGDiagonalKernel scatters tau*Vol*|dNdx_i|^2 into d_diagAccNode (before halo/gather) so the preconditioner matches the stabilized operator. Gated usePSPG, tet-only. Sign left unchanged (verified correct)**
- **pump: pin the degenerate sliver DOF(s) -- the identity-safe fix for the unsolvable pressure (cg_p=-2). A near-zero-volume tet gives a DDT diagonal ~9 OOM below bulk (1e-12 vs 6e-3); Jacobi-PCG cannot solve it. FIX: mask any owned DOF with diag < MARS_SLIVER_PIN_FRAC*max_diag (default 1e-6) into d_isPressureBdryDof -> the operator forces out=phi (identity row) AND the RHS forces b=0, exactly like the outflow/pin DOFs (verified both paths check maskPtr). One removed equation, div-safe. Makes the pressure solvable so the real physics + PSPG become readable. The mass floor was the wrong lever (sliver diag is AREA-driven, not mass); this pins the node directly**
- **poiseuille validation example: channel-fork NS solver with balanced opening-flux source; parabola matches analytic profile within reference tolerance (RMS 5.8e-3 < 6e-3, interior flux ratio ~1). Plus tutorial.**
- **pump: assembled tet DDT operator + FlexGMRES (toward Hypre AMG pressure solve). (1) ASSEMBLE the matrix-free D M^-1 D^T into CSR for tet (buildDDTSparsityTet + assembleDDTPerNodeKernelTet, node-driven so the per-node M^-1 cross-element face pairs are captured; tet nodeFaces[4][3]={{0,2,3},{0,1,4},{1,2,5},{3,4,5}} derived from d_tetLRSCV). Same operator as matrix-free (verify bit-identical via MARS_DDT_PROBE_DIFF, PSPG off) -> corrector stays div=0-exact. GPU-resident; only host touch is the rank0 setup [DDT-health] print. Matrix-free path UNTOUCHED (gated, additive -- can return to it). (2) FlexGMRES in the Hypre wrapper (default for BoomerAMG, the right Krylov for a varying AMG preconditioner; env MARS_HYPRE_FLEXGMRES). NOT YET COMPILED (no nvcc locally)**
- **pump: assemble PSPG tau*L into the DDT CSR (assemblePSPGStiffnessTetKernel). Element-driven 4x4 tet stiffness tau*Vol*(dNdx_i.dNdx_j) scattered via atomicAddSparseEntry into the existing DDT two-hop sparsity (subset, no new entries). Same tau*L the matrix-free path adds -> assembled A+tau*L == matrix-free A+tau*L. Iterates halo elements (elementCount includes halo) so owned boundary rows get cross-rank stiffness; writes owned rows only. Gated usePSPG. This (a) keeps PSPG on the assembled/Hypre path and (b) regularizes the Gram-form DDT toward diagonal dominance so Jacobi/BoomerAMG can precondition the 9-OOM operator. GPU-resident**
- **pump: activate the assembled DDT pressure solve on --solver=hypre. Re-gate the assembled-DDT block (was MARS_DDT_USE_ASSEMBLED_CG && CG only) to ALSO fire on solverKind==Hypre && nnzDDT>0 -> the SAME operator (D M^-1 D^T + assembled PSPG tau*L) is solved by Hypre FlexGMRES+BoomerAMG instead of matrix-free Jacobi-CG. Matrix-free path UNTOUCHED as the default (no --solver=hypre -> byte-identical). The wrapIntoSparseMatrix(s.AddT) now fires for tet automatically (nnzDDT>0). Global-DOF numbering + MPI partitioning already built at setup for the Hypre path. End-to-end: --solver=hypre -> assembled gate -> solveOneComponent(GMRES) -> FlexGMRES+AMG. Validate via MARS_DDT_PROBE_DIFF (PSPG off) first**
- **fix(pump): remove duplicate template clause before assembleDDTPerNodeKernelTet (my PSPG-kernel insert left an orphan template<> -> 'multiple template clauses' compile error)**
- **pump driver: parse --solver=hypre (was hardcoded SolverKind::CG -> the assembled Hypre path could never activate; explains why --solver=hypre runs were silently matrix-free CG). Sets SolverKind::Hypre -> the assembled DDT + FlexGMRES+BoomerAMG gate fires. --solver=cg restores default. Banner prints the active pressure path**
- **fix(pump hypre): skip the sliver-pin on the Hypre/assembled path. The pin reads the matrix-free d_diagDDT (tiny entries floored to 1 -> globalMax=1 -> 1e-6 threshold pinned ~220k DOFs), and enforcePressureBcRhsKernel then ZEROED b at all those rows -> RHS~0 -> phi=0 every step (no flow: u stuck at 0, div never projected). BoomerAMG handles the conditioning without pinning, so gate the pin on solverKind!=Hypre. This was why --solver=hypre ran stable but produced phi=0**
- **fix(pump hypre): force the VELOCITY solve onto in-house CG even under --solver=hypre. Root cause of the dead u=0 run: solverKind==Hypre routed the velocity matrix (M/dt + nu*K, mass-dominated / near-diagonal) through BoomerAMG-PCG, which is the wrong tool for a non-elliptic mass matrix -> exits ~1 iter returning x~0 -> u**=0 -> div(u**) RHS=0 -> phi=0 -> nothing develops. FIX: add forceCG param to solveOneComponent; velocity solves pass forceCG=true so they use the in-house CG (~14 iters, works) regardless of solverKind. Hypre/AMG stays reserved for the ill-conditioned DDT PRESSURE operator -- the only thing that needs it. (Also: pres_r0=0 under hypre is a stale-diagnostic artifact, lastPressR0 only written in the matrix-free path)**
- **poiseuille: --check regression mode + ctest entry, velocity-fit G closure (100.8% of exact), single-station profile CSV + plot script, u-field render script; fix wall-eps node pinning; document the incremental-p artifact (visualize u, not umag/p)**
- **debug(pump hypre): add MARS_SOLVE_TRACE -- prints converged/iters/|xVec|max right after the Hypre solve, to pin down whether phi=0 is (a) converged=false so xVec never scattered to qOut, or (b) xVec~0 itself. The verbose run showed BoomerAMG sets up + runs (b nonzero, L2=15) but only ~2 cycles at conv factor 0.43 -> likely final_res>tol -> converged=false -> no scatter -> phi=0**
- **poiseuille render: pump-style 3-panel validation layout (field + animated profile-vs-exact + centerline development), PIL composite + header**
- **fix(pump hypre): enforce the single pin into the ASSEMBLED DDT matrix (d_valuesDDT), not just the K-path d_valuesPre. ROOT CAUSE of phi=0: the pin row was only applied to d_valuesPre (K-path), so the assembled DDT operator s.AddT stayed SINGULAR (pure-Neumann pump pressure has a constant null mode). BoomerAMG/FlexGMRES on a singular operator returned the null-space solution = 0 -> 'converged in 2 iters', x=0, phi=0 (proven by MARS_SOLVE_TRACE: pressure solve converged=1 iters=2 |xVec|max=0 while velocity solves gave real nonzero x). FIX: enforcePinRowKeepDiagKernel on d_rowPtrDDT/d_colIndDDT/d_valuesDDT too (keepDiag = AMG-friendly). Single pin is the correct null-space removal for the pure-Neumann pump (matches the reference's 'single pressure reference')**
- **fix(pump hypre): accept a best-effort pressure solve (rel-res < MARS_HYPRE_ACCEPT_RES, default 1e-2) instead of requiring final_res<1e-8. Diagnosis via MARS_SOLVE_TRACE+Jacobi: FlexGMRES+Jacobi runs full 2000 iters and produces a NONZERO xVec (1930, growing) but stalls at res~7e-3 -> the strict converged gate rejected it -> not scattered -> phi=0 -> dead. A projection step does not need machine-precision phi; a partial solve removes most divergence. Now accept it. (AMG still falsely converges at x=0 on this near-singular op -- separate, retune next; Jacobi is the working floor)**
- **poiseuille tutorial: starter-level Part 2 (equations, parabola derivation, CVFEM discretization, projection, solvers) + output-files table**
- **pump hypre: make BoomerAMG actually converge (fix the x=0 false convergence). Root cause: (1) the pump single-pin set the pinned DDT row diagonal to 1.0 (10-25x the native ~0.04-0.14), a documented PMIS-coarsening killer -> AMG V-cycle collapses onto the constant null mode -> FlexGMRES exits at 2 iters with x=0; (2) weak AMG settings (l1-Jacobi relax, strong=0.5, aggressive coarsening) for a 3D near-singular Poisson. FIXES: symmetric pin in the assembled DDT (zero row AND column, restore NATIVE diagonal via read/setRowDiagonalKernel -> no spike); AMG retune relax 18->8 (l1 hybrid SSOR), strong 0.5->0.25 (3D), agg 1->0, all env-overridable (MARS_AMG_*); GMRES min-iter floor + optional abstol; null-mode guard (reject converged-but-x=0). Best-effort acceptance now rejects null x**
- **pump hypre: harden the acceptance against the 1e7-phi blowup (multi-agent verification confirmed: cause = convergence/conditioning + loose accept gate admitting under-resolved huge phi; sign correct, removeMean NOT needed/refuted). (BUG2) upper-bound x reject in the Hypre wrapper: reject converged-but-|x|>>|b| (MARS_HYPRE_MAXX_RATIO default 1e6) -- the null-guard only caught x~0, not the observed x=huge. (accept) tighten default MARS_HYPRE_ACCEPT_RES 1e-2 -> 1e-6 so a res~2e-4 partial solve is rejected (phi stays warm-started) instead of scattering garbage. (BUG3) fix misleading 'opening-flux on by default' comments (it is OFF). Path to bounded solve: --pspg (AMG-friendly operator) + retuned BoomerAMG + these guards**
- **fix(pump hypre): BoomerAMG RelaxType 8 -> 18 (l1-Jacobi) -- the cause of AMG returning x=0 with a garbage 1.1e-315 residual. The retune to RelaxType=8 (l1-hybrid-SSOR, GS-family) is NOT GPU-functional: the cuda Hypre build does not implement GS-family smoothers as a real sweep (they no-op / go non-symmetric on GPU), so the V-cycle does nothing -> x=0 on the first cycle. The WORKING PCG wrapper (mars_hypre_pcg_solver.hpp:362-373) uses 18 for exactly this reason ('default GS becomes non-symmetric on GPU'), not merely PCG symmetry -- the GMRES comment misread that. l1-Jacobi-AMG-FlexGMRES is the standard GPU pressure solver. Verified pin/PSPG order is correct (pin enforced after PSPG). Testable via MARS_AMG_RELAX=18 (now the default)**
- **pump hypre: complete the AMG fix -- (1) NumSweeps 1->2 (l1-Jacobi is weaker than SSOR; 2 sweeps restore the smoothing strength). (2) Route the --pspg DDT pressure solve to Hypre PCG instead of GMRES: PSPG's tau*L makes A = D M^-1 D^T + tau*L SPD and the symmetric pin removes the null mode, so CG+AMG (the textbook pressure-Poisson solver, what deal.II/MFEM/Nalu use) is valid and more stable than FlexGMRES. Gated on s.usePSPG -> PCG; pure-DDT SPSD stays GMRES (Hypre PCG rejects SPSD with error 1). The PCG wrapper already uses GPU-safe RelaxType=18. MARS_HYPRE_KRYLOV still overrides for debug. Combined with the RelaxType 8->18 fix, this should give a converging bounded AMG pressure solve**
- **TGV: MARS_PRED_PERSLOT_GRADP toggle -- match predictor grad(p) seam reduction to corrector (Fable wdxg6s3ce: predictor folds, corrector per-slot -> dt-independent feedback gain 1.17)**
- **revert(pump hypre): route pressure back to FlexGMRES (not PCG). Routing --pspg to PCG was a regression: the PCG wrapper has NEITHER the null-mode guard NOR the upper-bound-x reject (only the GMRES wrapper does), so a converged-but-huge phi (PCG 'converged' in 14 iters at |phi|=1e123 on the still-ill-conditioned operator) was scattered -> corrector blew up -> inf predictor -> velocity Hypre-PCG errors downstream. GMRES carries the guards that keep it bounded. The RelaxType=18 fix (AMG now functional) stays. PCG can return once its wrapper has the same guards**
- **TGV: MARS_TGV_NONINCREMENTAL toggle (Fable fallback #3 -- p=phi non-incremental, severs pressure-accumulation feedback, loop gain exactly 0)**
- **pump hypre: PCG+AMG is the working --pspg path (port the guards). EMPIRICAL: on our GPU, PCG+BoomerAMG CONVERGES (16 iters, flow develops steps 1-3, div drops) while GMRES+AMG no-ops to x=0 (separate GMRES-wrapper GPU bug, debug later). PSPG makes the operator SPD + the pin removes the null mode, so CG+AMG is valid + textbook. Ported the null-mode + upper-bound-x guards (+ getEnvDouble, lastSolutionMax_, nullSolutionReturned_, accessors) from the GMRES wrapper to the PCG wrapper so a huge/near-null phi is rejected not scattered. Re-route --pspg pressure to PCG (PSPG off stays GMRES for SPSD). solveOneComponent picks up the guard via the solve() return**
- **pump hypre: GMRES+AMG is the pressure path (per the reference: GMRES + AMG-preconditioner). (1) Route --pspg pressure to GMRES, not PCG: GMRES tolerates the assembled DDT+tau*L operator's near-indefiniteness (tiny passage-cell diagonals) where PCG breaks down (pAp<0, HYPRE error 256). (2) Default to PLAIN GMRES (HYPRE_GMRESSetPrecond), not FlexGMRES: a 1-V-cycle AMG is a FIXED linear op so plain GMRES is valid AND is the battle-tested GPU path; FlexGMRES's precond-apply appeared to no-op on our GPU build (x=0, denormal residual). MARS_HYPRE_FLEXGMRES=1 / MARS_HYPRE_KRYLOV=pcg still available. All prior work kept (assembled DDT, PSPG-CSR, guards on both wrappers, symmetric pin, velocity-on-CG, RelaxType=18)**
- **TGV: MARS_TGV_USTART_BCAST toggle -- force start-of-step u broadcast on reduced path so skew advection mdot is seam-consistent (secondary loop is advective: --skew=0 bounds it, --skew=1 doesn't)**
- **pump hypre: pin tiny-diagonal rows of the ASSEMBLED DDT operator (the REAL fix for the 1e6 phi). DIAGNOSIS via plain GMRES+AMG: AMG now CONVERGES tight (40 iters, final_res=8e-9) -- FlexGMRES was the no-op -- but the CONVERGED solution is |phi|~1e6*|b| because the degenerate passage/sliver cells give the operator near-zero diagonals -> near-zero eigenvalues -> A^-1 amplifies ~1e6 -> physically-huge phi -> blowup feedback (b grows with div). FIX: pinTinyDiagonalRowsKernel makes every owned row with diag < MARS_DDT_ASM_PIN_FRAC*max_diag (default 1e-4) an identity row + marks it in d_isPressureBdryDof (RHS zeroed there) -> removes the near-zero eigenvalues so phi is physical. Runs on the assembled matrix before the s.AddT wrap, Hypre-path only. This is the assembled analogue of the matrix-free sliver-pin, reading the ACTUAL assembled diagonal**
- **docs: TGV breakthrough -- primary feedback loop (predictor/corrector grad(p) seam mismatch) FIXED via MARS_PRED_PERSLOT_GRADP; secondary loop localized to skew advection mdot at periodic seam. Baseline step-40 blowup -> step-160. Flags stay opt-in until secondary loop fixed.**
- **TGV: MARS_PRED_PERSLOT_ADV toggle -- make predictor advN per-slot to match per-slot grad(p) (predictor RHS seam-consistency; secondary loop is the advN-folded/gradP-perslot mismatch)**
- **pump hypre: use the GALERKIN LAPLACIAN K (s.Apre), not the Gram form D M^-1 D^T (s.AddT), for the assembled pressure solve -- THE STRUCTURAL FIX. Verified (agent + scaling argument): the DDT diagonal 0.25*|sum sigma_g A_g|^2/V is a square of a CANCELLING signed area-vector sum -> near-zero on GOOD cells (a real sliver gives a HUGE diagonal here, not tiny) -> near-zero eigenvalues -> 1e6 phi amplification -> blowup. Collaborator was RIGHT: no bad mesh cells; it's our Gram construction. The Galerkin K_ij=integral grad N_i.grad N_j has diagonal ~h (sum of squares, no cancellation) -> well-conditioned, AMG-friendly, no near-zero eigenvalue -- and is what the reference assembles. K is SPD so default to PCG+AMG (textbook pressure solver, now valid). MARS_HYPRE_USE_DDT=1 reverts to DDT+GMRES for comparison. Corrector stays M^-1 D^T (div relaxes, acceptable). All prior infra kept**
- **pump hypre: use GMRES (not PCG) for the Galerkin K pressure solve too. K (Apre) is SPD in principle but PCG broke down (pAp<0, HYPRE error 256, ~3 iters) -- BoomerAMG-as-preconditioner is non-symmetric on GPU (GS-family relax) + the pin-row diag=1 spike disturbs coarsening, so the preconditioned operator isn't SPD for CG. GMRES tolerates it (the proven-converging path). RESULT of the K switch: |phi| dropped from 1e6 to ~6000-30000 -- the Galerkin operator IS far better conditioned than DDT (no near-zero eigenvalue), confirming the artifact diagnosis. MARS_HYPRE_KRYLOV=pcg to force CG**
- **TGV: per-slot grad(p) divides by per-slot half-CV mass (d_massNodePerSlot), not merged (workflow w7bapvkdt: per-slot numerator/merged mass = half gradient = the residual factor-of-2 keeping feedback gain >1)**
- **Revert "TGV: per-slot grad(p) divides by per-slot half-CV mass (d_massNodePerSlot), not merged (workflow w7bapvkdt: per-slot numerator/merged mass = half gradient = the residual factor-of-2 keeping feedback gain >1)"**
