### PR TITLE
cstone

### DIFF
--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -2941,6 +2941,12 @@ struct NSStepper
     // negative feedback so the flow settles instead of running away at high head.
     // pumpDp>0 + --total-pressure only.
     bool useTotalPressureHead = false;
+    // FIX-B #1: route the RAW (un-rescaled) consistent opening flux onto the
+    // divergence RHS as the boundary mass-balance term the Dirichlet face omits
+    // (fixedFluxPressure). The femConsistent net-zero oScale is SKIPPED here --
+    // with two Dirichlet faces the through-flow is free, so forcing net-zero would
+    // re-impose the mass constraint the head sets. pumpDp>0 + --flux-pressure-bc.
+    bool useFluxPressureBc = false;
 
     // Per-node OUTWARD outlet area-vectors (un-normalized, nodeCount-sized, zero
     // off the outlet). Used only by the through-flow diagnostic to measure
@@ -8446,7 +8452,14 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
                                                              : RealType(1);
             Qin_raw  = ramp * sumOwned(s.d_femFluxWin.data());
             Qout_raw = sumOwned(s.d_femFluxWout.data());
-            oScale   = (std::fabs(Qout_raw) > RealType(0)) ? (-Qin_raw / Qout_raw) : RealType(0);
+            // FIX-B #1: with two Dirichlet faces (pumpDp>0) the through-flow is
+            // FREE -- use the RAW per-face flux (oScale=1) as the boundary mass
+            // balance, NOT the net-zero rescale (which would re-impose the mass
+            // constraint the head sets). Net-zero stays for the mass-conserving
+            // prescribed-outlet path.
+            oScale   = s.useFluxPressureBc
+                       ? RealType(1)
+                       : ((std::fabs(Qout_raw) > RealType(0)) ? (-Qin_raw / Qout_raw) : RealType(0));
             addConsistentOpeningFluxKernel<RealType><<<nodeBlocks, s.blockSize>>>(
                 ramp, oScale,
                 s.d_femFluxWin.data(), s.d_femFluxWout.data(),

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -2344,6 +2344,35 @@ __global__ void applyCorrectorPerNodeKernel(RealType* q,
     q[i] = qStarStar[i] - dt * invRho * gPhi;
 }
 
+// FIX-B #3 (pressureInletOutletVelocity): the open-face velocity must NOT keep a
+// free tangential DOF -- that floating mode feeds the dP>=1e4 runaway. After the
+// per-component predictor/corrector has written q at the open nodes, project the
+// node velocity onto its OUTWARD face normal: q <- (q.n_hat) n_hat, tangential->0.
+// n_hat = areaVec/|areaVec| (inlet+outlet are disjoint node sets, so summing the
+// two area-vec arrays gives one branchless normal -- the other is zero there).
+// Runs over ALL nodes incl. ghosts: the normal is owner-complete and the op is
+// node-local + idempotent, so ghosts get the same projected value the owner does.
+template<typename RealType>
+__global__ void projectOpenFaceNormalKernel(RealType* u, RealType* v, RealType* w,
+                                            const RealType* inAx, const RealType* inAy, const RealType* inAz,
+                                            const RealType* outAx, const RealType* outAy, const RealType* outAz,
+                                            const uint8_t* isOpenFaceNode,
+                                            size_t numNodes)
+{
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numNodes) return;
+    if (!isOpenFaceNode[i]) return;
+    RealType ax = inAx[i] + outAx[i];
+    RealType ay = inAy[i] + outAy[i];
+    RealType az = inAz[i] + outAz[i];
+    RealType len2 = ax*ax + ay*ay + az*az;
+    if (len2 <= RealType(0)) return;            // degenerate: leave free (fallback)
+    RealType inv = rsqrt(len2);
+    RealType nx = ax*inv, ny = ay*inv, nz = az*inv;
+    RealType un = u[i]*nx + v[i]*ny + w[i]*nz;
+    u[i] = un * nx;  v[i] = un * ny;  w[i] = un * nz;
+}
+
 // Pressure update: p^{n+1} = p^n + phi on owned nodes (Chorin incremental).
 // Ghosts are refreshed by an explicit halo exchange afterward.
 template<typename RealType>
@@ -2873,6 +2902,10 @@ struct NSStepper
     // Ramp-start fraction for the seeded head (driver sets = 1/sourceRampSteps
     // when ramping, else 1). Avoids a full-head grad(p^n) kick on step 0.
     RealType pumpDpSeedScale = 1;
+    // FIX-B #3: project open-face velocity onto its face normal (zero tangential)
+    // each step -- removes the free tangential DOF that feeds the dP>=1e4 runaway
+    // (pressureInletOutletVelocity). pumpDp>0 + --open-normal-proj only.
+    bool useOpenFaceNormalProj = false;
 
     // Per-node OUTWARD outlet area-vectors (un-normalized, nodeCount-sized, zero
     // off the outlet). Used only by the through-flow diagnostic to measure
@@ -7915,6 +7948,23 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
     runPredictor(s.d_w, s.d_w_nm1, s.d_wStar, s.d_advW_n, s.d_advW_nm1, s.d_gradPz, s.d_wTarget, s.bodyForceZ,
                  s.d_gradWx, s.d_gradWy, s.d_gradWz);
 
+    // FIX-B #3: project q* onto the open-face normal (zero tangential) BEFORE the
+    // q* ghost publish, so the implicit-diffusion RHS and the pressure solve see a
+    // normal-only open-face velocity. Gated on pumpDp>0 + both area-vec fields
+    // owner-complete; no flag -> byte-identical.
+    if (s.useOpenFaceNormalProj
+        && s.d_isOpenFaceNode.size()  == s.nodeCount
+        && s.d_inletAreaVecX.size()   == s.nodeCount
+        && s.d_outletAreaVecX.size()  == s.nodeCount)
+    {
+        projectOpenFaceNormalKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            s.d_uStar.data(), s.d_vStar.data(), s.d_wStar.data(),
+            s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
+            s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data(),
+            s.d_isOpenFaceNode.data(), s.nodeCount);
+        cudaDeviceSynchronize();
+    }
+
     // Sync ghosts of q* so the implicit RHS / CG warm-start read correct ghosts.
     s.domain.exchangeNodeHalo(s.d_uStar);
     s.domain.exchangeNodeHalo(s.d_vStar);
@@ -9228,6 +9278,22 @@ void runCorrectorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
                              if (dof < 0) return;
                              pPtr[i] -= nu * divPtr[i];
                          });
+        cudaDeviceSynchronize();
+    }
+
+    // FIX-B #3: re-project the FINAL velocity onto the open-face normal -- the
+    // corrector's grad(phi) re-adds a tangential component at the open node.
+    // Before the final exchange so ghosts publish the projected value.
+    if (s.useOpenFaceNormalProj
+        && s.d_isOpenFaceNode.size()  == s.nodeCount
+        && s.d_inletAreaVecX.size()   == s.nodeCount
+        && s.d_outletAreaVecX.size()  == s.nodeCount)
+    {
+        projectOpenFaceNormalKernel<RealType><<<nodeBlocks, s.blockSize>>>(
+            s.d_u.data(), s.d_v.data(), s.d_w.data(),
+            s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
+            s.d_outletAreaVecX.data(), s.d_outletAreaVecY.data(), s.d_outletAreaVecZ.data(),
+            s.d_isOpenFaceNode.data(), s.nodeCount);
         cudaDeviceSynchronize();
     }
 

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -508,6 +508,37 @@ __global__ void enforcePressureBcRhsLiftKernel(const uint8_t* isPressureBdryDof,
     rhs[dof] = targetDof[dof] - pn;
 }
 
+// FIX-B #2 (totalPressure / negative-feedback dynamic head). Overlay on the ramped
+// inlet target: p_target = p0 - 0.5*rho*u_in^2 on INFLOW only, u_in = -(u.n_hat)>=0
+// (n OUTWARD via inlet areaVec -> inflow => u.n<0). As inflow accelerates the target
+// DROPS, weakening the drive -> the flow SETTLES instead of running away. baseDof
+// already holds ramp*pumpDp (inlet) / 0 (outlet); outlet nodes have zero inlet
+// areaVec -> pass through to p0 unchanged. dofToNode maps the owned BC DOF to its
+// node for u + areaVec. In-place safe (baseDof == targetDof, one elem per thread).
+template<typename RealType>
+__global__ void applyTotalPressureHeadKernel(const uint8_t* isPressureBdryDof,
+                                             const RealType* baseDof,
+                                             const int* dofToNode,
+                                             const RealType* u, const RealType* v, const RealType* w,
+                                             const RealType* aInX, const RealType* aInY, const RealType* aInZ,
+                                             RealType rho,
+                                             RealType* targetDof, int numDofs)
+{
+    int dof = blockIdx.x * blockDim.x + threadIdx.x;
+    if (dof >= numDofs) return;
+    if (!isPressureBdryDof[dof]) return;
+    int node = dofToNode[dof];
+    RealType p0 = baseDof[dof];
+    if (node < 0) { targetDof[dof] = p0; return; }
+    RealType ax = aInX[node], ay = aInY[node], az = aInZ[node];
+    RealType a2 = ax*ax + ay*ay + az*az;
+    if (a2 <= RealType(0)) { targetDof[dof] = p0; return; }   // outlet/non-inlet
+    RealType inv = rsqrt(a2);
+    RealType un  = (u[node]*ax + v[node]*ay + w[node]*az) * inv;
+    RealType uIn = (un < RealType(0)) ? -un : RealType(0);
+    targetDof[dof] = p0 - RealType(0.5) * rho * uIn * uIn;
+}
+
 // Build a per-NODE pressure-Dirichlet mask from the existing per-DOF mask +
 // optional single-pin DOF. Each owned node maps its dof through the existing
 // boundary flag; ghost nodes get 0 (filled by halo exchange later).
@@ -2906,6 +2937,10 @@ struct NSStepper
     // each step -- removes the free tangential DOF that feeds the dP>=1e4 runaway
     // (pressureInletOutletVelocity). pumpDp>0 + --open-normal-proj only.
     bool useOpenFaceNormalProj = false;
+    // FIX-B #2: dynamic-head inlet target p=p0-0.5*rho*u_in^2 (totalPressure) --
+    // negative feedback so the flow settles instead of running away at high head.
+    // pumpDp>0 + --total-pressure only.
+    bool useTotalPressureHead = false;
 
     // Per-node OUTWARD outlet area-vectors (un-normalized, nodeCount-sized, zero
     // off the outlet). Used only by the through-flow diagnostic to measure

--- a/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_pump_solver.hpp
@@ -2223,6 +2223,7 @@ __global__ void applyPredictorPerNodeKernel(RealType* qStar,
                                             const RealType* /*lumpedMassNode*/,  // unused; kept for ABI
                                             const RealType* qTarget,
                                             const uint8_t* isBdryDof,
+                                            const uint8_t* isOpenFaceNode,  // FIX-B: null unless pumpDp>0
                                             const int* nodeToDof,
                                             const uint8_t* ownership,
                                             RealType dt,
@@ -2242,10 +2243,21 @@ __global__ void applyPredictorPerNodeKernel(RealType* qStar,
         qStar[i] = qTarget[i];
         return;
     }
+    // FIX-B open-face momentum closure: at a pressure-driven opening the node is
+    // intentionally OUT of d_isBdryDof so its velocity stays free. But its
+    // gradPnq = M^-1 D^T p is a one-cell jump (p clamped to the head, interior
+    // ~0) -> ~head/h, a numerical artifact of the Dirichlet clamp, not the
+    // physical interior pressure gradient. Feeding it into the momentum update
+    // injects a dt*invRho*(head/h) velocity kick that detonates once the head
+    // crosses ~1e4. Drop the pressure-gradient term HERE only; the node is still
+    // driven by advection + the interior gradient one cell in (which IS the
+    // physical pump drive), so through-flow is preserved. The head enters
+    // physically through the pressure Poisson Dirichlet, not this kick.
+    RealType gP = (isOpenFaceNode && isOpenFaceNode[i]) ? RealType(0) : gradPnq[i];
     RealType V = lumpedMass[dof];
     // BDF1: u* = u^n + dt*(-adv/V - invRho*grad p + invRho*f) (interior only)
     qStar[i] = qN[i] + dt * dqdtNode[i] / V
-                    - dt * invRho * gradPnq[i]
+                    - dt * invRho * gP
                     + dt * invRho * bodyForce;
 }
 
@@ -2265,6 +2277,7 @@ __global__ void applyPredictorBdf2PerNodeKernel(RealType* qStar,
                                                 const RealType* lumpedMass,
                                                 const RealType* qTarget,
                                                 const uint8_t* isBdryDof,
+                                                const uint8_t* isOpenFaceNode,  // FIX-B: null unless pumpDp>0
                                                 const int* nodeToDof,
                                                 const uint8_t* ownership,
                                                 RealType dt,
@@ -2283,13 +2296,17 @@ __global__ void applyPredictorBdf2PerNodeKernel(RealType* qStar,
         qStar[i] = qTarget[i];
         return;
     }
+    // FIX-B open-face momentum closure (see applyPredictorPerNodeKernel): drop
+    // the spurious head/h gradient kick at the open face; interior gradient
+    // (the real drive) is untouched.
+    RealType gP      = (isOpenFaceNode && isOpenFaceNode[i]) ? RealType(0) : gradPnq[i];
     RealType V       = lumpedMass[dof];
     RealType adv_ext = RealType(2) * dqdtNode_n[i] - dqdtNode_nm1[i];
     RealType coef    = RealType(2) * dt / RealType(3);
     // BDF2 + EXT2 with body-force source: KIO stencil + coef*invRho*f.
     qStar[i] = (RealType(4) / RealType(3)) * qN[i]
              - (RealType(1) / RealType(3)) * qNm1[i]
-             + coef * (adv_ext / V - invRho * gradPnq[i] + invRho * bodyForce);
+             + coef * (adv_ext / V - invRho * gP + invRho * bodyForce);
 }
 
 // Corrector: q^{n+1} = q** - (dt/rho) (grad phi)_q on interior; snap to
@@ -2301,6 +2318,7 @@ __global__ void applyCorrectorPerNodeKernel(RealType* q,
                                             const RealType* gradPhiq,
                                             const RealType* qTarget,
                                             const uint8_t* isBdryDof,
+                                            const uint8_t* isOpenFaceNode,  // FIX-B: null unless pumpDp>0
                                             const int* nodeToDof,
                                             const uint8_t* ownership,
                                             RealType dt,
@@ -2319,7 +2337,11 @@ __global__ void applyCorrectorPerNodeKernel(RealType* q,
         q[i] = qTarget[i];
         return;
     }
-    q[i] = qStarStar[i] - dt * invRho * gradPhiq[i];
+    // FIX-B open-face momentum closure (see applyPredictorPerNodeKernel): grad(phi)
+    // at the clamped open face carries the same one-cell-jump artifact as grad(p);
+    // drop it here too so the secondary corrector kick can't re-open the loop.
+    RealType gPhi = (isOpenFaceNode && isOpenFaceNode[i]) ? RealType(0) : gradPhiq[i];
+    q[i] = qStarStar[i] - dt * invRho * gPhi;
 }
 
 // Pressure update: p^{n+1} = p^n + phi on owned nodes (Chorin incremental).
@@ -7864,7 +7886,10 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
                 qStar.data(), qN.data(), qNm1.data(),
                 advN.data(), advNm1.data(),
                 gradPnq.data(), s.d_mass.data(), qTarget.data(),
-                s.d_isBdryDof.data(), s.d_node_to_dof.data(),
+                s.d_isBdryDof.data(),
+                s.d_isOpenFaceNode.size() == s.nodeCount
+                    ? s.d_isOpenFaceNode.data() : nullptr,
+                s.d_node_to_dof.data(),
                 d_nodeOwnership.data(),
                 dt, invRho, bodyForce, s.nodeCount, s.numOwnedDofs);
         }
@@ -7873,7 +7898,10 @@ void runPredictorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
             applyPredictorPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
                 qStar.data(), qN.data(), advN.data(),
                 gradPnq.data(), s.d_mass.data(), s.d_massNode.data(), qTarget.data(),
-                s.d_isBdryDof.data(), s.d_node_to_dof.data(),
+                s.d_isBdryDof.data(),
+                s.d_isOpenFaceNode.size() == s.nodeCount
+                    ? s.d_isOpenFaceNode.data() : nullptr,
+                s.d_node_to_dof.data(),
                 d_nodeOwnership.data(),
                 dt, invRho, bodyForce, s.nodeCount, s.numOwnedDofs);
         }
@@ -8980,7 +9008,10 @@ void runCorrectorStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType dt, 
     {
         applyCorrectorPerNodeKernel<RealType><<<nodeBlocks, s.blockSize>>>(
             qOut.data(), qStarStar.data(), gradPhiq.data(), qTarget.data(),
-            s.d_isBdryDof.data(), s.d_node_to_dof.data(),
+            s.d_isBdryDof.data(),
+            s.d_isOpenFaceNode.size() == s.nodeCount
+                ? s.d_isOpenFaceNode.data() : nullptr,
+            s.d_node_to_dof.data(),
             d_nodeOwnership.data(), dtEff, invRho, s.nodeCount, s.numOwnedDofs);
         cudaDeviceSynchronize();
     };

--- a/docs/pump_cfd_tutorial.md
+++ b/docs/pump_cfd_tutorial.md
@@ -101,9 +101,13 @@ Re = U·L/ν
 ```
 
 `Re` measures inertia vs. viscosity — *the* knob that sets the flow regime (smooth
-and laminar at low `Re`, swirling and turbulent at high `Re`). Rather than guess a
-viscosity `ν`, you specify `--Re=` and MARS back-computes `ν = U·L/Re`. (More
-dimensionless diagnostics in Part 5.)
+and laminar at low `Re`, swirling and turbulent at high `Re`). (More dimensionless
+diagnostics in Part 5.)
+
+> **Important:** specify the *physical* fluid properties directly with `--nu`/`--rho`
+> (water: `ρ=1000`, `ν=10⁻⁶`). The legacy `--Re=` flag back-computes `ν = U·L/Re`
+> using the **bounding-box** diagonal as `L` — which is *not* the passage scale, so on
+> a real internal flow it sets a wildly wrong viscosity. See Part 5b.
 
 ---
 
@@ -483,6 +487,74 @@ In short: collocated P1–P1 + a consistent `D M⁻¹ Dᵀ` projection is the si
 most GPU-friendly choice and gives a stable, physical solution — but it carries a
 bounded checkerboard floor. Driving `div` to zero means either *stabilizing* P1–P1
 (PSPG/Bochev–Dohrmann) or moving to an *inf-sup-stable* or *staggered* discretization.
+
+---
+
+## Part 5b — What MARS actually solves now (the production pressure path)
+
+The discussion above is the *theory*. Here is the path that is implemented and
+validated, selected with `--pressure-k --pspg`:
+
+- **The pressure operator is the stabilized Galerkin Laplacian `K + τ·L`**, not the
+  raw `D M⁻¹ Dᵀ` Gram form. The exact Gram operator is the *consistent* conjugate of
+  the divergence, but it is a dense, non-M-matrix product that algebraic multigrid
+  (BoomerAMG) **cannot coarsen** on a non-uniform pump mesh (grid complexity ~1.05 —
+  no real multigrid). The Galerkin stiffness `K` *is* an M-matrix Laplacian that AMG
+  coarsens beautifully (grid complexity ~1.25); `τ·L` is the **PSPG** stabilization
+  (`τ = h²/24`), which both legalizes the equal-order pair and keeps `K+τ·L`
+  well-conditioned. The corrector still uses the consistent FEM weak gradient, so the
+  projection contracts divergence to the bounded floor described above.
+- **Solve it with GMRES, not PCG** (`--solver=hypre` selects Hypre; the K-path forces
+  GMRES). On the pinned pure-Neumann pressure operator, Hypre PCG+BoomerAMG
+  *false-converges* in ~3 iterations (the AMG V-cycle maps the first residual into the
+  near-constant null mode, so the relative residual drops below tolerance while the
+  solution is wrong). GMRES has a minimum-iteration floor that forces it past that
+  deceptive first cycle and a null-solution guard, so it returns a real pressure.
+- **Physical fluid properties matter.** Use `--nu`/`--rho` (water: `ρ=1000`,
+  `ν=10⁻⁶`). The legacy `--Re` flag overrides `ν` using the *bounding-box* diagonal as
+  the length scale, which is not the passage scale — on a real pump it inflates `ν` by
+  ~10³, turning water into molasses and making the passage look "dead." A correct
+  Reynolds number uses the passage length, not the whole geometry.
+
+This path runs a **stable, converging, mass-conserving through-flow** at moderate head,
+single- and multi-rank (the 1-rank and 4-rank results are byte-identical — the
+distributed solve is rank-invariant).
+
+## Part 5c — Driving the flow: the opening boundary conditions
+
+How you *drive* the pump is itself a CFD subtlety, and the openings are where most of
+the difficulty lives.
+
+- **Velocity-inlet (`--inlet-velocity`)** prescribes the inlet speed. The catch on a
+  CVFEM code: a velocity prescribed on the *exterior* opening face is **invisible to
+  the interior pressure solve** (that face is in no interior sub-control-volume face),
+  so it cannot, by itself, drive flow *through* the passage — the inlet velocity is
+  frozen and the interior never sees a passage-spanning pressure gradient.
+- **Pressure-drive (`--pump-dp`, "FIX B")** is the physical way to run a pump: impose
+  `p = Δp` on the inlet face and `p = 0` on the outlet face, leave the velocity **free**
+  at both. The flux then *emerges* from the interior pressure gradient, which the SCS
+  operator does see → real through-flow. Two pressure-Dirichlet faces also remove the
+  pressure null space (no separate pin needed). **Ramp the head** (`--source-ramp-steps`)
+  so the predictor is not shocked by a full head from rest.
+
+A pressure-driven opening with a *free* velocity is, however, a classic
+**positive-feedback trap** (well known in OpenFOAM): a fixed-value pressure has no
+`−½ρ|u|²` dynamic-head term, so more head → more velocity → nothing opposes it → at high
+head it diverges. MARS ports the three standard OpenFOAM stabilizers (all gated off by
+default; pass the flags to enable):
+
+- `--open-normal-proj` — project the open-face velocity onto the face normal (zero
+  tangential), removing the ill-posed free tangential mode (`pressureInletOutletVelocity`).
+- `--total-pressure` — overlay `p = p₀ − ½ρu_n²` on the inlet target: as inflow
+  accelerates the boundary pressure drops, *weakening* the drive → negative feedback, the
+  flow settles (`totalPressure`).
+- `--flux-pressure-bc` — add the consistent opening flux `∮(N_i u·n)` to the continuity
+  right-hand side as the boundary mass-balance term the fixed-pressure face omits
+  (`fixedFluxPressure`).
+
+These extend the stable operating range substantially. The fully robust high-head BC
+(a true flux-consistent *Neumann* pressure row, replacing the fixed-pressure face) is
+the remaining step for the full water-Reynolds / high-Mach passage regime.
 
 ---
 

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -444,8 +444,12 @@ int main(int argc, char** argv)
     // outletU>0, so the prescribed outlet term (+Q_out) balances the inlet term
     // (-Q_in). A do-nothing outlet leaves outletU<=0 -> outlet term ~0 -> one-sided
     // imbalance -> the single-pin Neumann pressure solve goes incompatible -> blowup.
-    // Disable the source (with a warning) rather than blow up.
-    if (s.useOpeningFluxSource && s.outletDoNothing)
+    // Disable the source (with a warning) rather than blow up -- EXCEPT for the
+    // FIX-B #1 flux-pressure path, which deliberately uses the RAW flux (oScale=1)
+    // on a do-nothing outlet: the balance comes from the FREE through-flow the
+    // pressure head drives, not a prescribed outlet velocity. The old guard was
+    // for the lumped/net-zero path that needs outletU>0 to cancel the inlet flux.
+    if (s.useOpeningFluxSource && s.outletDoNothing && !s.useFluxPressureBc)
     {
         if (rank == 0)
             std::cerr << "WARNING: --opening-flux-source needs the mass-conserving outlet "

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -121,6 +121,7 @@ int main(int argc, char** argv)
     // Opening-flux source is OFF by default; enable with --opening-flux-source.
     // Dirichlet lift ON (a correctness fix); --no-dirichlet-lift disables for comparison.
     bool        openingFluxSource = false;
+    bool        openNormalProj    = false;   // FIX-B #3: project open-face velocity to normal-only
     bool        dirichletLift     = true;
     // FIX B -- pressure-drop drive. >0 activates FIX B: prescribe p=pumpDp on the
     // inlet face, p=0 on the outlet face, velocities FREE at both, so the flux
@@ -171,6 +172,7 @@ int main(int argc, char** argv)
         else if (a.rfind("--max-iter=", 0) == 0)     maxIter   = std::stoi(a.substr(11));
         else if (a.rfind("--tol=", 0) == 0)          tolerance = std::stod(a.substr(6));
         else if (a.rfind("--ic-perturb=", 0) == 0)   icPerturb = std::stod(a.substr(13));
+        else if (a == "--open-normal-proj")           openNormalProj = true;      // FIX-B #3: zero tangential open-face velocity (pressureInletOutletVelocity)
         else if (a == "--opening-flux-source")        openingFluxSource = true;   // FIX 1: add inlet+outlet boundary surface flux to the pressure RHS
         else if (a == "--no-opening-flux-source")     openingFluxSource = false;
         else if (a == "--dirichlet-lift")             dirichletLift = true;       // FIX 2: lift inlet momentum into interior diffusion (default ON)
@@ -393,6 +395,7 @@ int main(int argc, char** argv)
     s.useOpeningFluxSource = openingFluxSource;   // FIX 1 (OFF by default; --opening-flux-source enables)
     s.useDirichletLift     = dirichletLift;       // FIX 2 (on by default)
     s.pumpDp               = RealType(pumpDp);    // FIX B: pressure-drop drive (>0 active)
+    s.useOpenFaceNormalProj = (pumpDp > 0.0) && openNormalProj;  // FIX-B #3
     // Seed the head at the ramp-start strength (1/rampSteps) so step-0 grad(p^n)
     // is small; the per-step ramp builds it to full. No ramp -> seed full head.
     s.pumpDpSeedScale      = (sourceRampSteps > 0)
@@ -724,9 +727,10 @@ int main(int argc, char** argv)
         // FIX 1: push the per-node OUTWARD inlet area-vectors to the device so the
         // opening-flux source can add ( Uprescribed . areaVec ) at each inlet node.
         // Same owner-complete field used for the inward normals above; outlet area-vecs
-        // are uploaded separately below. Gated on openingFluxSource (ON by default), so
-        // fires only when --opening-flux-source is passed (OFF by default).
-        if (openingFluxSource && areaIn > 1e-30)
+        // are uploaded separately below. Uploaded whenever the inlet has area -- the
+        // open-face normal projection (FIX-B #3) needs these independent of the
+        // opening-flux source, and they're harmless (read only by opted-in paths).
+        if (areaIn > 1e-30)
         {
             const size_t nNodes = amr.domain().getNodeCount();
             s.d_inletAreaVecX.resize(nNodes);

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -123,6 +123,7 @@ int main(int argc, char** argv)
     bool        openingFluxSource = false;
     bool        openNormalProj    = false;   // FIX-B #3: project open-face velocity to normal-only
     bool        totalPressure     = false;   // FIX-B #2: dynamic-head inlet target (totalPressure)
+    bool        fluxPressureBc    = false;   // FIX-B #1: opening-flux RHS coexists with the head (boundary mass balance)
     bool        dirichletLift     = true;
     // FIX B -- pressure-drop drive. >0 activates FIX B: prescribe p=pumpDp on the
     // inlet face, p=0 on the outlet face, velocities FREE at both, so the flux
@@ -175,6 +176,7 @@ int main(int argc, char** argv)
         else if (a.rfind("--ic-perturb=", 0) == 0)   icPerturb = std::stod(a.substr(13));
         else if (a == "--open-normal-proj")           openNormalProj = true;      // FIX-B #3: zero tangential open-face velocity (pressureInletOutletVelocity)
         else if (a == "--total-pressure")             totalPressure = true;       // FIX-B #2: dynamic-head inlet target (totalPressure negative feedback)
+        else if (a == "--flux-pressure-bc")           fluxPressureBc = true;      // FIX-B #1: opening-flux RHS + head coexist (boundary mass balance; fixedFluxPressure)
         else if (a == "--opening-flux-source")        openingFluxSource = true;   // FIX 1: add inlet+outlet boundary surface flux to the pressure RHS
         else if (a == "--no-opening-flux-source")     openingFluxSource = false;
         else if (a == "--dirichlet-lift")             dirichletLift = true;       // FIX 2: lift inlet momentum into interior diffusion (default ON)
@@ -404,14 +406,25 @@ int main(int argc, char** argv)
     s.pumpDpSeedScale      = (sourceRampSteps > 0)
                              ? RealType(1.0 / double(sourceRampSteps)) : RealType(1);
     s.rhieChowTau = rhieTau;   // <=0 -> kernel falls back to dt/rho
-    // FIX B and FIX 1 are mutually exclusive drives: the pressure drop already
-    // creates the through-flow, and adding the opening-flux source on top double-
-    // counts the inlet flux (the FIX-1 blowup). Warn and disable FIX 1 if both set.
-    if (pumpDp > 0.0 && openingFluxSource)
+    // FIX-B #1 (--flux-pressure-bc): the opening-flux RHS is the boundary mass-
+    // balance term the Dirichlet face omits (fixedFluxPressure). With BOTH faces
+    // Dirichlet (pumpDp>0) the pressure is fully anchored, so the flux source is
+    // NOT a second drive that double-counts -- it carries the FLUX continuity
+    // needs, orthogonal to the head (which enters via the Dirichlet target). Force
+    // the source ON and use the RAW (un-rescaled) flux (see useFluxPressureBc in
+    // the solver). Without this flag the two remain mutually exclusive (the FIX-1
+    // double-count blowup for the velocity-inlet/lumped path).
+    s.useFluxPressureBc = (pumpDp > 0.0) && fluxPressureBc;   // FIX-B #1
+    if (pumpDp > 0.0 && fluxPressureBc)
+    {
+        s.useOpeningFluxSource = true;   // the head needs the boundary mass balance
+    }
+    else if (pumpDp > 0.0 && openingFluxSource)
     {
         if (rank == 0)
             std::cerr << "WARNING: --pump-dp>0 (FIX B) and --opening-flux-source (FIX 1) "
-                         "are incompatible; disabling the opening-flux source.\n";
+                         "are incompatible without --flux-pressure-bc; disabling the "
+                         "opening-flux source.\n";
         s.useOpeningFluxSource = false;
     }
     // Cavity = lid-driven cavity (geometric BC, no side-sets) -- a controlled

--- a/examples/distributed/unstructured/mars_pump.cu
+++ b/examples/distributed/unstructured/mars_pump.cu
@@ -122,6 +122,7 @@ int main(int argc, char** argv)
     // Dirichlet lift ON (a correctness fix); --no-dirichlet-lift disables for comparison.
     bool        openingFluxSource = false;
     bool        openNormalProj    = false;   // FIX-B #3: project open-face velocity to normal-only
+    bool        totalPressure     = false;   // FIX-B #2: dynamic-head inlet target (totalPressure)
     bool        dirichletLift     = true;
     // FIX B -- pressure-drop drive. >0 activates FIX B: prescribe p=pumpDp on the
     // inlet face, p=0 on the outlet face, velocities FREE at both, so the flux
@@ -173,6 +174,7 @@ int main(int argc, char** argv)
         else if (a.rfind("--tol=", 0) == 0)          tolerance = std::stod(a.substr(6));
         else if (a.rfind("--ic-perturb=", 0) == 0)   icPerturb = std::stod(a.substr(13));
         else if (a == "--open-normal-proj")           openNormalProj = true;      // FIX-B #3: zero tangential open-face velocity (pressureInletOutletVelocity)
+        else if (a == "--total-pressure")             totalPressure = true;       // FIX-B #2: dynamic-head inlet target (totalPressure negative feedback)
         else if (a == "--opening-flux-source")        openingFluxSource = true;   // FIX 1: add inlet+outlet boundary surface flux to the pressure RHS
         else if (a == "--no-opening-flux-source")     openingFluxSource = false;
         else if (a == "--dirichlet-lift")             dirichletLift = true;       // FIX 2: lift inlet momentum into interior diffusion (default ON)
@@ -396,6 +398,7 @@ int main(int argc, char** argv)
     s.useDirichletLift     = dirichletLift;       // FIX 2 (on by default)
     s.pumpDp               = RealType(pumpDp);    // FIX B: pressure-drop drive (>0 active)
     s.useOpenFaceNormalProj = (pumpDp > 0.0) && openNormalProj;  // FIX-B #3
+    s.useTotalPressureHead  = (pumpDp > 0.0) && totalPressure;   // FIX-B #2
     // Seed the head at the ramp-start strength (1/rampSteps) so step-0 grad(p^n)
     // is small; the per-step ramp builds it to full. No ramp -> seed full head.
     s.pumpDpSeedScale      = (sourceRampSteps > 0)
@@ -1169,6 +1172,26 @@ int main(int argc, char** argv)
             // pump (--pump-dp) starts gently instead of shocking the advection.
             if (s.pumpDp > RealType(0))
                 rescalePumpDpTarget<KeyType, RealType, TetTag>(s, ramp);
+        }
+        // FIX-B #2 (totalPressure): overlay the dynamic head on the (possibly
+        // ramped) inlet target using the CURRENT inflow speed -> negative feedback
+        // so the flow settles instead of running away. Runs EVERY step (the ramp
+        // block above only fires when sourceRampSteps>0). Reads the just-ramped p0
+        // in d_pPhiTargetDof (or the seeded full head when no ramp); overlays
+        // in-place. At u_n=0 reduces to the static clamp -> byte-identical baseline.
+        if (s.pumpDp > RealType(0) && s.useTotalPressureHead
+            && s.d_inletAreaVecX.size() == s.nodeCount
+            && s.d_isPressureBdryDof.size() == size_t(s.numOwnedDofs)
+            && s.d_pPhiTargetDof.size()  == size_t(s.numOwnedDofs))
+        {
+            int dofBlocks = (s.numOwnedDofs + s.blockSize - 1) / s.blockSize;
+            applyTotalPressureHeadKernel<RealType><<<dofBlocks, s.blockSize>>>(
+                s.d_isPressureBdryDof.data(), s.d_pPhiTargetDof.data(),
+                s.d_dofToNode.data(),
+                s.d_u.data(), s.d_v.data(), s.d_w.data(),
+                s.d_inletAreaVecX.data(), s.d_inletAreaVecY.data(), s.d_inletAreaVecZ.data(),
+                RealType(rho), s.d_pPhiTargetDof.data(), s.numOwnedDofs);
+            cudaDeviceSynchronize();
         }
         runNsStep<KeyType, RealType, TetTag>(s, RealType(dt), RealType(nu), RealType(rho));
         simTime += dt;

--- a/scripts/render_pump_flow.py
+++ b/scripts/render_pump_flow.py
@@ -64,6 +64,10 @@ def main():
     ap.add_argument("--mark-io", action="store_true",
                     help="auto-detect inlet (most inward boundary flow) + outlet (most outward) and mark "
                          "them with a green/red sphere + a legend, so the intended flow path is clear")
+    ap.add_argument("--side-set-io", action="store_true",
+                    help="RELIABLE inlet/outlet markers from the side_set_id field (the real openings the "
+                         "solver used), instead of the --mark-io flow auto-detect which can mis-place both "
+                         "markers on one tank. Marks the CENTROID of each nonzero side_set_id group.")
     ap.add_argument("--marker-size", type=float, default=0.025,
                     help="inlet/outlet marker sphere size as a fraction of the bbox diagonal (default 0.025)")
     ap.add_argument("--orbit-deg", type=float, default=0.0,
@@ -378,6 +382,59 @@ def main():
                 print("[render] marked inlet (green sphere) + outlet (red sphere) + 3D labels")
         except Exception as e:  # noqa: BLE001
             print("[render] inlet/outlet marking skipped (%s)" % e)
+
+    # ---- RELIABLE inlet/outlet markers from side_set_id (the real openings) ----
+    if args.side_set_io:
+        try:
+            from paraview import servermanager as _sm
+            reader.UpdatePipeline(tvals[-1])
+            data = _sm.Fetch(reader)
+            pts = data.GetPoints()
+            ss = data.GetPointData().GetArray("side_set_id")
+            if pts and ss:
+                # group node coords by side_set_id; mark each nonzero group's centroid
+                from collections import defaultdict
+                acc = defaultdict(lambda: [0.0, 0.0, 0.0, 0])
+                n = ss.GetNumberOfTuples()
+                st = max(1, n // 400000)
+                for i in range(0, n, st):
+                    sid = int(round(ss.GetValue(i)))
+                    if sid == 0:
+                        continue
+                    p = pts.GetPoint(i)
+                    a = acc[sid]
+                    a[0] += p[0]; a[1] += p[1]; a[2] += p[2]; a[3] += 1
+                # palette: distinct, water-friendly (gold, magenta, cyan, lime...)
+                pal = [[1.0, 0.85, 0.1], [1.0, 0.2, 0.8], [0.2, 0.9, 0.9],
+                       [0.6, 1.0, 0.3], [1.0, 0.6, 0.2]]
+                keys = sorted(acc.keys())
+                print("[render] side_set_id groups found: %s" % keys)
+                legend_txt = []
+                for idx, sid in enumerate(keys):
+                    a = acc[sid]
+                    if a[3] == 0:
+                        continue
+                    c = [a[0]/a[3], a[1]/a[3], a[2]/a[3]]
+                    col = pal[idx % len(pal)]
+                    ball = Sphere()
+                    ball.Center = c
+                    ball.Radius = diag * args.marker_size
+                    ball.ThetaResolution = 24; ball.PhiResolution = 24
+                    bd = Show(ball, view)
+                    bd.DiffuseColor = col; bd.AmbientColor = col; bd.Specular = 0.5
+                    cname = {1: "RGB", }  # noop, keep col readable in legend
+                    legend_txt.append("side_set %d" % sid)
+                    print("[render]   side_set %d centroid=%s color=%s (n=%d)" % (sid, c, col, a[3]))
+                try:
+                    legend = Text()
+                    legend.Text = "spheres = side sets (openings): " + ", ".join(legend_txt)
+                    ld = Show(legend, view)
+                    ld.Color = [1, 1, 1]; ld.FontSize = 15
+                    ld.WindowLocation = "Upper Right Corner"
+                except Exception:
+                    pass
+        except Exception as e:  # noqa: BLE001
+            print("[render] side-set-io marking skipped (%s)" % e)
 
     # ---- flow visualization ----
     # The pump is a small jet into a big mostly-stagnant chamber: a plain clip is


### PR DESCRIPTION
- **fix(pump): revive the pressure outlet (the REAL through-flow fix). outletU was set unconditionally -> always velocity-Dirichlet outlet -> both-ends-Dirichlet admits a flat-pressure tank-recirculation div=0 solution -> NO flow through the passage (confirmed: 1e-10 pressure solve gave identical flat-p, so it's structural not convergence -- AMG would NOT help). Gate outletU on !outletDoNothing so do-nothing (default) leaves outletU<=0 -> solver masks the WHOLE outlet face p=0 + frees outlet velocity (singlePin=false, solver:4080) -> inlet flux against fixed-p outlet FORCES the outlet->suction gradient -> through-flow. The dead --outlet flag now actually works**
- **fix(pump): default outlet back to MASS-CONSERVING (the correct design). Root cause found: the divergence operator only loops interior faces (sum(div)==0 always), so the pressure solve is NEVER told mass enters at the inlet -> a velocity-inlet + free pressure-outlet is UNPROJECTABLE -> no through-flow (flow dies at inlet, pressure parks in body). The code's own comment (solver:2295) flags this. My prior do-nothing default was backwards: the mass-conserving outlet (vel outflow removes Q + single pin) BALANCES the flux so the projection builds the inlet->outlet gradient that drives flow through the passage. The dead-flag gate stays so do-nothing is still selectable (needs a boundary-flux source term to be correct -- separate work)**
- **pump through-flow: (1) default to do-nothing outlet = whole-face p=0 + FREE outlet velocity (the channel-proven pairing that builds the inlet->outlet pressure head; both-ends-velocity-Dirichlet + single pin gave a flat-pressure dead-passage solution). (2) --inlet-flux-source (GUARDED, off): add the prescribed inlet flux as a boundary divergence source -- the exterior opening flux is in no interior SCS so it's never integrated (verified not a double-count); A/B it. (3) [through-flow] Q_in/Q_out/ratio diagnostic each step so we MEASURE through-flow (ratio->1) instead of eyeballing uMax. mass-conserving still selectable. cavity/channel/TGV unaffected**
- **pump: REMOVE the broken --inlet-flux-source (double-counted the inlet flux already registered via interior SCS scatter; full-opening-area x rho/dt -> instant blowup, ratio=garbage) and revert default to MASS-CONSERVING outlet. Verified high-confidence: the inlet flux is already in the divergence for a velocity-Dirichlet inlet, so the only correct inlet boundary source is ZERO. do-nothing (whole-face p=0 + free outlet) does NOT self-drive a small interior outlet -> ratio=0 (no through-flow); the prior do-nothing-default + comments were disproven by the A/B. mass-conserving (U_out=Uin*Ain/Aout + single pin) forces Q_out=Q_in by construction. Kept the [through-flow] Q diagnostic (correct + useful)**
- **pump through-flow REWORK (verified root cause): the reference flows through the pump with ANY scheme (bj/upwind) so the dead passage is OUR bug, not Re/scheme. TWO real defects fixed: FIX1 --opening-flux-source (GUARDED off): inlet/outlet OPENING faces are exterior, in no interior SCS, so the prescribed opening flux never reaches the pressure RHS -> pressure flat -> no through-flow. Add it as a COMPATIBLE surface integral (u.n)*A_share, SAME scale as interior scatter, NOT x rho/dt (RHS does it), net~0 -- verified NOT a double-count (telescoping interior pairs never touch the opening face). FIX2 --dirichlet-lift (default ON): velocity-diffusion col-zero had no Dirichlet lift -> inlet momentum never diffused inward -> jet died at inlet. Add b-=K[row,bdry]*uTarget. FIX3: replace TAUTOLOGICAL Q_out (relocked to prescribed outletU) with an INTERIOR cut-plane flux probe at 25/50/75% -- measures SOLVED through-flow, can't be faked. old line relabeled [bc-sanity]**
- **pump FIX B: pressure-drop drive via --pump-dp=VALUE (gated, off by default -> existing pump byte-identical). Root cause: the divergence operator integrates only INTERIOR SCS faces, so a VELOCITY prescribed on the interior inlet opening is invisible to the pressure solver (exterior opening face never integrated) + the corrector freezes velocity-Dirichlet nodes -> no through-flow (proven: interior-flux mid-cut=0). FIX B masks BOTH openings as pressure-Dirichlet (p=dP inlet, p=0 outlet), frees both velocities, seeds the dP head in d_p -> flow EMERGES from the interior gradient (SCS-captured, VISIBLE). Startup-safe: two Dirichlet faces make the matrix NONSINGULAR -> no compatibility condition -> no FIX-1 source-blowup. inlet velocity becomes an OUTPUT (tune dP to hit ~0.5 m/s). Keeps interior-flux probe to verify mid-cut goes nonzero**
- **pump FIX B phi-lift (the piece that makes dP actually drive flow). Bug: FIX B seeded a one-node dP spike + pinned the phi increment to 0 at both faces -> interior never relaxed into the inlet->outlet gradient -> dP didn't drive flow (identical tiny flow at dP=1000 vs 30000). FIX: pin the SOLVED pressure to the target via rhs=target-p^n at masked DOFs (clamp to constant, NOT additive -> steady+bounded), so the Poisson solve imposes dP->0 Dirichlet data + relaxes the spanning gradient; the already-live predictor grad(p^n) then drives through-flow. LOAD-BEARING: pump runs DDT matrix-free, so the lift goes in solvePressureDDT's boundary-pin lambda (not the K-path). All gated pumpDp>0; pumpDp<=0 byte-identical (cavity/channel/TGV untouched)**
- **pump THROUGH-FLOW fix: prescribed-balanced opening-flux source (default ON). The verified root cause: a velocity-inlet's opening flux is invisible to the pressure solver (divergence integrates interior SCS only) -> flat passage -> dead passage (proven: interior-flux cut@50%=0). FIX: inject the opening flux into divAccNode so the projection SEES the inflow and builds the inlet->outlet gradient that drives the passage. KEY over the broken FIX 1: use PRESCRIBED GLOBAL-direction velocities (Uinf*inletDir, outletU*outletDir) not the solved u** -> inlet sums to -Q_in, outlet to +Q_in (outletU=Uin*Ain/Aout) -> total=0 EXACTLY every step incl step0 -> single-pin Neumann stays compatible -> CANNOT blow up like FIX 1 (which used u**=0 at the step0 outlet -> one-sided -> phi=1e36). Config: mass-conserving velocity inlet+outlet (sustains the jet) + this source (makes it visible). No removeMean (pin handles it). FIX B (pumpDp) abandoned, gated off**
- **pump: default opening-flux-source back OFF -- the prescribed-balanced source STILL blows up at step0 (phi=1e7->inf, CG residual grows = incompatible, same FLT_MAX as FIX 1). The 'sum=0 by construction' startup-safety proof was WRONG: the discrete per-node area shares evidently do not sum to exactly Q, so sum!=0, x rho/dt=1e6 -> explodes even at step0. Revert to the STABLE mass-conserving default (no through-flow, but runs). The opening-flux-source remains a flag for debugging but is NOT a working fix. Through-flow is UNRESOLVED -- see scratch/pump_throughflow_HANDOFF.md**
- **pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B**
- **Revert "pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B"**
- **debug: MARS_OFS_DBG -- print divAccNode |max| before/after the opening-flux source + the global net source sum, to SEE if the source is a giant localized spike (divAcc max jumps) and whether net is actually ~0. Instrumentation only, gated on env. Investigating the repeated step0 phi=1e7 blowup**
- **debug: print Qin_raw/Qout_raw separately -- the [ofs-dbg] net=-Q_in (one-sided) proves the OUTLET source contributes ZERO. Need to see Qin_raw vs Qout_raw to find why the outlet half does not fire (area-vec sign? outletDir?)**
- **pump: adjustPhi rescale FOUND THE BUG via debug -- the discrete inlet/outlet fluxes differ ~1.5% (Qin_raw=-5.975e-3, Qout_raw=+5.884e-3), NOT roundoff: the per-node area-vectors sum to a different value than the analytic areaIn/areaOut used for outletU. That 9e-5 residual x rho/dt=1e6 -> incompatible RHS -> phi=1e7 blowup. FIX: oScale=-Qin_raw/Qout_raw, rescale the outlet source so it EXACTLY cancels the inlet (net->0). The reductions now always run (not just debug). [ofs-dbg2] prints the net to confirm it goes to ~0**
- **pump: removeMean for the opening-flux source -- THE ACTUAL FIX. Debug PROVED the blowup is NOT flux imbalance: with the adjustPhi rescale the net source is bit-exactly 0 (8.67e-19) and it STILL blew up to phi=1e7 identically. Real cause (the code's own comments flag it: lines 897/2209/3333/5145): the single p=0 pin weakly controls the DDT constant null space; a boundary source excites that mode and Jacobi-PCG loses pAp>0 (residual GROWS 0.98->1.46 then garbage phi=1e7). FIX: removeMean the RHS + phi (project the null-space component out) when opening-flux is on -- the same cure the periodic path uses. Gated on useOpeningFluxSource**
- **debug: removeMean did NOT fix the blowup (phi=1e7 identical) -> null-space theory also wrong. KEY realization: the CG CONVERGES (3e-8), so phi=1e7 is the TRUE solution -- the operator+RHS are fine, the answer is legitimately huge. Add [ofs-dbg3] b|max and [ofs-dbg4] phi|max split by OPENING vs INTERIOR nodes, to decide: is phi huge only at the opening nodes (tiny DDT boundary-layer diagonal, b/diag=1e6*1e-4/1e-5=1e7 LOCAL) or everywhere (global)? That picks the final fix**
- **pump: --source-ramp-steps=N gentle startup for the opening-flux source. ROOT CAUSE (measured): the source WORKS (real through-flow, step1 cut@50% nonzero) but starting from rest at full strength dumps the whole inlet->outlet pressure head onto a near-singular interior node (sliver cell, DDT diag=1e-5, 600x below bulk) -> phi spikes to 6e6 there -> grad(phi) spike -> corrector velocity spike -> advection 950x/step -> blowup. NOT fixable by clip (preconditioner-only, phi is the true solution), CFL (structural per-step amplification), or balance/removeMean (all already correct). FIX: ramp Uinf 0->full over N steps so the head + phi + grad stay small while flow develops gently. Scales the inlet velocity target (from a base snapshot) AND the opening-flux source (reads Uinf live) -> balance preserved at every ramp level**
- **pump: allow dt to shrink up to 2x/step (was 5%/step). With the ramp, the flow develops stably for ~16 steps (phi=1e4, u_max bounded+growing, cut@50% nonzero) then a CFL violation at u~100 ran away because the 5%/step shrink cap could not drop dt fast enough to catch it. Fast shrink catches the violation in one step; growth stays gentle (5%/step) so BDF2's constant-dt assumption holds at steady state**
- **pump: targeted operator-diagonal floor on the matrix-free DDT (the sliver-node fix). MEASURED: the ramp fixes startup (steps 1-16 stable, flow developing, cut@50% nonzero) but one sliver interior node (tiny SCS face areas -> DDT diag=1e-5, 600x below bulk) makes phi spike there -> corrector velocity spike -> diffusion CG breaks (pAp<0, u**>>u*) -> blowup, even at dt=5e-8 (so NOT CFL). Jacobi clip is preconditioner-only (no-op on phi). FIX: raise ONLY the degenerate rows to epsFloor=0.05*max_diag in the TRUE matrix-free operator via per-node shift out[i]+=shift_i*phi[i]; 0 on the healthy bulk -> byte-identical there -> cavity/channel/cube16 untouched. Caps phi at b/3.3e-4 (~31x smaller) -> below blowup threshold. Pure positive diagonal add -> keeps SPD. Preconditioner diag floored to match. Velocity diffusion needs NO floor (M/dt keeps it conditioned; its divergence was downstream of the phi spike). Env MARS_DDT_OP_FLOOR_FRAC**
- **debug: MARS_CHECKER -- per-element mean-free pressure RMS diagnostic (the checkerboard mode an inf-sup stabilizer penalizes). Lets us SEE the checkerboard grow + SEE a stabilizer kill it in a few steps, instead of inferring from a full-run blowup. Confirms/quantifies the LBB decoupling diagnosis. Env-gated, tet-only, rank0, free in production. NOTE: adjudication confirmed BD-on-DDT is WRONG (breaks div=0 identity, accumulating divergence); the identity-safe path is VMS/RC on the divergence SOURCE (needs a phi-vs-d_p fix). Checkerboard fix != through-flow fix (separate defects)**
- **fix: checker diagnostic compile error -- a pair-returning __device__ lambda in transform_reduce needs its return type proclaimed in host context. Split into two scalar (double) reductions (mean-free energy + total) -- avoids the trait error, same result**
- **pump: replace the div-BREAKING operator-diagonal floor with an identity-safe MASS floor. The operator floor (out[i]+=shift*phi in applyDDTPerNode) only the OPERATOR saw, not the corrector -> solving (A+S)phi=b left div(u^{n+1})=(dt/rho)*S*phi un-projected -> accumulating residual -> smooth |p| 1e3->1e34 blowup (the SAME div=0-breaking class the code warns against for BD-on-DDT, lines 5602-5610). FIX: floor the lumped mass d_massNode instead -- A=D M^-1 D^T and the corrector ALSO applies M^-1 from the same d_massNode, so flooring mass changes operator AND corrector consistently -> div=0 PRESERVED. Removed d_shiftDDTNode + its apply + the operator-floor build. Env MARS_MASS_FLOOR_FRAC (default 1e-3*max_mass)**
- **pump: implicit PSPG pressure stabilization (--pspg) -- the CORRECT equal-order checkerboard fix. VERIFIED root cause of the checkerboard blowup: the existing VMS adds tau*(-lap p^n) to the RHS = an EXPLICIT forward-Euler Laplacian-of-p update -> unconditionally amplifies the high-freq mode at ANY tau (why 1e-6/1e-5/1e-3 all blew up). FIX: add tau*L*phi IMPLICITLY inside applyDDTPerNode so CG solves (A+tau*L)phi=b. L=sum_e V_e G^T G is symmetric PSD, shares A's constant null mode (removed by the pin) -> SPD, damps checkerboard at ALL tau>0. Acts on phi (the correction, ->0) so it self-extinguishes; post-corrector div relaxes to ~tau*lap(phi)=O(h^2), a CONSISTENT residual that vanishes under refinement -- the textbook PSPG, NOT the inconsistent div-breaking BD/floor. tau=h^2/24 (a LENGTH^2, not dt/rho). Confirm via MARS_CHECKER: frac must shrink. New kernel applyPSPGLaplacianTetKernel; gated --pspg, tau auto or --pspg-tau**
- **pump PSPG: FIX THE SIGN. The DDT operator outAcc = D M^-1 D^T phi ~ -lap(phi) (SPD-positive; A=-lap, matches b=-coef*div). My PSPG scattered +div(grad phi)=+lap(phi) = OPPOSITE sign -> SUBTRACTED definiteness (made conditioning worse, no damping). Flip: scatter -s to iL / +s to iR so it adds +tau*(-lap)phi = positive energy, same orientation as A. This is why the first PSPG run showed frac still growing + cg_p=-2 (wrong-sign term de-conditioned the operator). NOTE: that run ALSO lost the Jacobi clip (diag=6.5e-12) -- must pass MARS_DDT_JACOBI_CLIP_FRAC for the sliver**
- **pump PSPG: add tau*L diagonal to the Jacobi preconditioner (the REAL bug). Numerically verified (host dense-matrix replica): my PSPG sign was CORRECT (-s/+s -> L=+Vol*G^T*G, same sign as A=-lap, A+tau*L more SPD). The cg_p=-2 failure was the PRECONDITIONER mismatch: operator ran A+tau*L but d_diagDDT was built from A only -> worst on the sliver rows (tiny A-diag, large tau*L-diag) -> CG stalls. FIX: computeTetPSPGDiagonalKernel scatters tau*Vol*|dNdx_i|^2 into d_diagAccNode (before halo/gather) so the preconditioner matches the stabilized operator. Gated usePSPG, tet-only. Sign left unchanged (verified correct)**
- **pump: pin the degenerate sliver DOF(s) -- the identity-safe fix for the unsolvable pressure (cg_p=-2). A near-zero-volume tet gives a DDT diagonal ~9 OOM below bulk (1e-12 vs 6e-3); Jacobi-PCG cannot solve it. FIX: mask any owned DOF with diag < MARS_SLIVER_PIN_FRAC*max_diag (default 1e-6) into d_isPressureBdryDof -> the operator forces out=phi (identity row) AND the RHS forces b=0, exactly like the outflow/pin DOFs (verified both paths check maskPtr). One removed equation, div-safe. Makes the pressure solvable so the real physics + PSPG become readable. The mass floor was the wrong lever (sliver diag is AREA-driven, not mass); this pins the node directly**
- **poiseuille validation example: channel-fork NS solver with balanced opening-flux source; parabola matches analytic profile within reference tolerance (RMS 5.8e-3 < 6e-3, interior flux ratio ~1). Plus tutorial.**
- **pump: assembled tet DDT operator + FlexGMRES (toward Hypre AMG pressure solve). (1) ASSEMBLE the matrix-free D M^-1 D^T into CSR for tet (buildDDTSparsityTet + assembleDDTPerNodeKernelTet, node-driven so the per-node M^-1 cross-element face pairs are captured; tet nodeFaces[4][3]={{0,2,3},{0,1,4},{1,2,5},{3,4,5}} derived from d_tetLRSCV). Same operator as matrix-free (verify bit-identical via MARS_DDT_PROBE_DIFF, PSPG off) -> corrector stays div=0-exact. GPU-resident; only host touch is the rank0 setup [DDT-health] print. Matrix-free path UNTOUCHED (gated, additive -- can return to it). (2) FlexGMRES in the Hypre wrapper (default for BoomerAMG, the right Krylov for a varying AMG preconditioner; env MARS_HYPRE_FLEXGMRES). NOT YET COMPILED (no nvcc locally)**
- **pump: assemble PSPG tau*L into the DDT CSR (assemblePSPGStiffnessTetKernel). Element-driven 4x4 tet stiffness tau*Vol*(dNdx_i.dNdx_j) scattered via atomicAddSparseEntry into the existing DDT two-hop sparsity (subset, no new entries). Same tau*L the matrix-free path adds -> assembled A+tau*L == matrix-free A+tau*L. Iterates halo elements (elementCount includes halo) so owned boundary rows get cross-rank stiffness; writes owned rows only. Gated usePSPG. This (a) keeps PSPG on the assembled/Hypre path and (b) regularizes the Gram-form DDT toward diagonal dominance so Jacobi/BoomerAMG can precondition the 9-OOM operator. GPU-resident**
- **pump: activate the assembled DDT pressure solve on --solver=hypre. Re-gate the assembled-DDT block (was MARS_DDT_USE_ASSEMBLED_CG && CG only) to ALSO fire on solverKind==Hypre && nnzDDT>0 -> the SAME operator (D M^-1 D^T + assembled PSPG tau*L) is solved by Hypre FlexGMRES+BoomerAMG instead of matrix-free Jacobi-CG. Matrix-free path UNTOUCHED as the default (no --solver=hypre -> byte-identical). The wrapIntoSparseMatrix(s.AddT) now fires for tet automatically (nnzDDT>0). Global-DOF numbering + MPI partitioning already built at setup for the Hypre path. End-to-end: --solver=hypre -> assembled gate -> solveOneComponent(GMRES) -> FlexGMRES+AMG. Validate via MARS_DDT_PROBE_DIFF (PSPG off) first**
- **fix(pump): remove duplicate template clause before assembleDDTPerNodeKernelTet (my PSPG-kernel insert left an orphan template<> -> 'multiple template clauses' compile error)**
- **pump driver: parse --solver=hypre (was hardcoded SolverKind::CG -> the assembled Hypre path could never activate; explains why --solver=hypre runs were silently matrix-free CG). Sets SolverKind::Hypre -> the assembled DDT + FlexGMRES+BoomerAMG gate fires. --solver=cg restores default. Banner prints the active pressure path**
- **fix(pump hypre): skip the sliver-pin on the Hypre/assembled path. The pin reads the matrix-free d_diagDDT (tiny entries floored to 1 -> globalMax=1 -> 1e-6 threshold pinned ~220k DOFs), and enforcePressureBcRhsKernel then ZEROED b at all those rows -> RHS~0 -> phi=0 every step (no flow: u stuck at 0, div never projected). BoomerAMG handles the conditioning without pinning, so gate the pin on solverKind!=Hypre. This was why --solver=hypre ran stable but produced phi=0**
- **fix(pump hypre): force the VELOCITY solve onto in-house CG even under --solver=hypre. Root cause of the dead u=0 run: solverKind==Hypre routed the velocity matrix (M/dt + nu*K, mass-dominated / near-diagonal) through BoomerAMG-PCG, which is the wrong tool for a non-elliptic mass matrix -> exits ~1 iter returning x~0 -> u**=0 -> div(u**) RHS=0 -> phi=0 -> nothing develops. FIX: add forceCG param to solveOneComponent; velocity solves pass forceCG=true so they use the in-house CG (~14 iters, works) regardless of solverKind. Hypre/AMG stays reserved for the ill-conditioned DDT PRESSURE operator -- the only thing that needs it. (Also: pres_r0=0 under hypre is a stale-diagnostic artifact, lastPressR0 only written in the matrix-free path)**
- **poiseuille: --check regression mode + ctest entry, velocity-fit G closure (100.8% of exact), single-station profile CSV + plot script, u-field render script; fix wall-eps node pinning; document the incremental-p artifact (visualize u, not umag/p)**
- **debug(pump hypre): add MARS_SOLVE_TRACE -- prints converged/iters/|xVec|max right after the Hypre solve, to pin down whether phi=0 is (a) converged=false so xVec never scattered to qOut, or (b) xVec~0 itself. The verbose run showed BoomerAMG sets up + runs (b nonzero, L2=15) but only ~2 cycles at conv factor 0.43 -> likely final_res>tol -> converged=false -> no scatter -> phi=0**
- **poiseuille render: pump-style 3-panel validation layout (field + animated profile-vs-exact + centerline development), PIL composite + header**
- **fix(pump hypre): enforce the single pin into the ASSEMBLED DDT matrix (d_valuesDDT), not just the K-path d_valuesPre. ROOT CAUSE of phi=0: the pin row was only applied to d_valuesPre (K-path), so the assembled DDT operator s.AddT stayed SINGULAR (pure-Neumann pump pressure has a constant null mode). BoomerAMG/FlexGMRES on a singular operator returned the null-space solution = 0 -> 'converged in 2 iters', x=0, phi=0 (proven by MARS_SOLVE_TRACE: pressure solve converged=1 iters=2 |xVec|max=0 while velocity solves gave real nonzero x). FIX: enforcePinRowKeepDiagKernel on d_rowPtrDDT/d_colIndDDT/d_valuesDDT too (keepDiag = AMG-friendly). Single pin is the correct null-space removal for the pure-Neumann pump (matches the reference's 'single pressure reference')**
- **fix(pump hypre): accept a best-effort pressure solve (rel-res < MARS_HYPRE_ACCEPT_RES, default 1e-2) instead of requiring final_res<1e-8. Diagnosis via MARS_SOLVE_TRACE+Jacobi: FlexGMRES+Jacobi runs full 2000 iters and produces a NONZERO xVec (1930, growing) but stalls at res~7e-3 -> the strict converged gate rejected it -> not scattered -> phi=0 -> dead. A projection step does not need machine-precision phi; a partial solve removes most divergence. Now accept it. (AMG still falsely converges at x=0 on this near-singular op -- separate, retune next; Jacobi is the working floor)**
- **poiseuille tutorial: starter-level Part 2 (equations, parabola derivation, CVFEM discretization, projection, solvers) + output-files table**
- **pump hypre: make BoomerAMG actually converge (fix the x=0 false convergence). Root cause: (1) the pump single-pin set the pinned DDT row diagonal to 1.0 (10-25x the native ~0.04-0.14), a documented PMIS-coarsening killer -> AMG V-cycle collapses onto the constant null mode -> FlexGMRES exits at 2 iters with x=0; (2) weak AMG settings (l1-Jacobi relax, strong=0.5, aggressive coarsening) for a 3D near-singular Poisson. FIXES: symmetric pin in the assembled DDT (zero row AND column, restore NATIVE diagonal via read/setRowDiagonalKernel -> no spike); AMG retune relax 18->8 (l1 hybrid SSOR), strong 0.5->0.25 (3D), agg 1->0, all env-overridable (MARS_AMG_*); GMRES min-iter floor + optional abstol; null-mode guard (reject converged-but-x=0). Best-effort acceptance now rejects null x**
- **pump hypre: harden the acceptance against the 1e7-phi blowup (multi-agent verification confirmed: cause = convergence/conditioning + loose accept gate admitting under-resolved huge phi; sign correct, removeMean NOT needed/refuted). (BUG2) upper-bound x reject in the Hypre wrapper: reject converged-but-|x|>>|b| (MARS_HYPRE_MAXX_RATIO default 1e6) -- the null-guard only caught x~0, not the observed x=huge. (accept) tighten default MARS_HYPRE_ACCEPT_RES 1e-2 -> 1e-6 so a res~2e-4 partial solve is rejected (phi stays warm-started) instead of scattering garbage. (BUG3) fix misleading 'opening-flux on by default' comments (it is OFF). Path to bounded solve: --pspg (AMG-friendly operator) + retuned BoomerAMG + these guards**
- **fix(pump hypre): BoomerAMG RelaxType 8 -> 18 (l1-Jacobi) -- the cause of AMG returning x=0 with a garbage 1.1e-315 residual. The retune to RelaxType=8 (l1-hybrid-SSOR, GS-family) is NOT GPU-functional: the cuda Hypre build does not implement GS-family smoothers as a real sweep (they no-op / go non-symmetric on GPU), so the V-cycle does nothing -> x=0 on the first cycle. The WORKING PCG wrapper (mars_hypre_pcg_solver.hpp:362-373) uses 18 for exactly this reason ('default GS becomes non-symmetric on GPU'), not merely PCG symmetry -- the GMRES comment misread that. l1-Jacobi-AMG-FlexGMRES is the standard GPU pressure solver. Verified pin/PSPG order is correct (pin enforced after PSPG). Testable via MARS_AMG_RELAX=18 (now the default)**
- **pump hypre: complete the AMG fix -- (1) NumSweeps 1->2 (l1-Jacobi is weaker than SSOR; 2 sweeps restore the smoothing strength). (2) Route the --pspg DDT pressure solve to Hypre PCG instead of GMRES: PSPG's tau*L makes A = D M^-1 D^T + tau*L SPD and the symmetric pin removes the null mode, so CG+AMG (the textbook pressure-Poisson solver, what deal.II/MFEM/Nalu use) is valid and more stable than FlexGMRES. Gated on s.usePSPG -> PCG; pure-DDT SPSD stays GMRES (Hypre PCG rejects SPSD with error 1). The PCG wrapper already uses GPU-safe RelaxType=18. MARS_HYPRE_KRYLOV still overrides for debug. Combined with the RelaxType 8->18 fix, this should give a converging bounded AMG pressure solve**
- **TGV: MARS_PRED_PERSLOT_GRADP toggle -- match predictor grad(p) seam reduction to corrector (Fable wdxg6s3ce: predictor folds, corrector per-slot -> dt-independent feedback gain 1.17)**
- **revert(pump hypre): route pressure back to FlexGMRES (not PCG). Routing --pspg to PCG was a regression: the PCG wrapper has NEITHER the null-mode guard NOR the upper-bound-x reject (only the GMRES wrapper does), so a converged-but-huge phi (PCG 'converged' in 14 iters at |phi|=1e123 on the still-ill-conditioned operator) was scattered -> corrector blew up -> inf predictor -> velocity Hypre-PCG errors downstream. GMRES carries the guards that keep it bounded. The RelaxType=18 fix (AMG now functional) stays. PCG can return once its wrapper has the same guards**
- **TGV: MARS_TGV_NONINCREMENTAL toggle (Fable fallback #3 -- p=phi non-incremental, severs pressure-accumulation feedback, loop gain exactly 0)**
- **pump hypre: PCG+AMG is the working --pspg path (port the guards). EMPIRICAL: on our GPU, PCG+BoomerAMG CONVERGES (16 iters, flow develops steps 1-3, div drops) while GMRES+AMG no-ops to x=0 (separate GMRES-wrapper GPU bug, debug later). PSPG makes the operator SPD + the pin removes the null mode, so CG+AMG is valid + textbook. Ported the null-mode + upper-bound-x guards (+ getEnvDouble, lastSolutionMax_, nullSolutionReturned_, accessors) from the GMRES wrapper to the PCG wrapper so a huge/near-null phi is rejected not scattered. Re-route --pspg pressure to PCG (PSPG off stays GMRES for SPSD). solveOneComponent picks up the guard via the solve() return**
- **pump hypre: GMRES+AMG is the pressure path (per the reference: GMRES + AMG-preconditioner). (1) Route --pspg pressure to GMRES, not PCG: GMRES tolerates the assembled DDT+tau*L operator's near-indefiniteness (tiny passage-cell diagonals) where PCG breaks down (pAp<0, HYPRE error 256). (2) Default to PLAIN GMRES (HYPRE_GMRESSetPrecond), not FlexGMRES: a 1-V-cycle AMG is a FIXED linear op so plain GMRES is valid AND is the battle-tested GPU path; FlexGMRES's precond-apply appeared to no-op on our GPU build (x=0, denormal residual). MARS_HYPRE_FLEXGMRES=1 / MARS_HYPRE_KRYLOV=pcg still available. All prior work kept (assembled DDT, PSPG-CSR, guards on both wrappers, symmetric pin, velocity-on-CG, RelaxType=18)**
- **TGV: MARS_TGV_USTART_BCAST toggle -- force start-of-step u broadcast on reduced path so skew advection mdot is seam-consistent (secondary loop is advective: --skew=0 bounds it, --skew=1 doesn't)**
- **pump hypre: pin tiny-diagonal rows of the ASSEMBLED DDT operator (the REAL fix for the 1e6 phi). DIAGNOSIS via plain GMRES+AMG: AMG now CONVERGES tight (40 iters, final_res=8e-9) -- FlexGMRES was the no-op -- but the CONVERGED solution is |phi|~1e6*|b| because the degenerate passage/sliver cells give the operator near-zero diagonals -> near-zero eigenvalues -> A^-1 amplifies ~1e6 -> physically-huge phi -> blowup feedback (b grows with div). FIX: pinTinyDiagonalRowsKernel makes every owned row with diag < MARS_DDT_ASM_PIN_FRAC*max_diag (default 1e-4) an identity row + marks it in d_isPressureBdryDof (RHS zeroed there) -> removes the near-zero eigenvalues so phi is physical. Runs on the assembled matrix before the s.AddT wrap, Hypre-path only. This is the assembled analogue of the matrix-free sliver-pin, reading the ACTUAL assembled diagonal**
- **docs: TGV breakthrough -- primary feedback loop (predictor/corrector grad(p) seam mismatch) FIXED via MARS_PRED_PERSLOT_GRADP; secondary loop localized to skew advection mdot at periodic seam. Baseline step-40 blowup -> step-160. Flags stay opt-in until secondary loop fixed.**
- **TGV: MARS_PRED_PERSLOT_ADV toggle -- make predictor advN per-slot to match per-slot grad(p) (predictor RHS seam-consistency; secondary loop is the advN-folded/gradP-perslot mismatch)**
- **pump hypre: use the GALERKIN LAPLACIAN K (s.Apre), not the Gram form D M^-1 D^T (s.AddT), for the assembled pressure solve -- THE STRUCTURAL FIX. Verified (agent + scaling argument): the DDT diagonal 0.25*|sum sigma_g A_g|^2/V is a square of a CANCELLING signed area-vector sum -> near-zero on GOOD cells (a real sliver gives a HUGE diagonal here, not tiny) -> near-zero eigenvalues -> 1e6 phi amplification -> blowup. Collaborator was RIGHT: no bad mesh cells; it's our Gram construction. The Galerkin K_ij=integral grad N_i.grad N_j has diagonal ~h (sum of squares, no cancellation) -> well-conditioned, AMG-friendly, no near-zero eigenvalue -- and is what the reference assembles. K is SPD so default to PCG+AMG (textbook pressure solver, now valid). MARS_HYPRE_USE_DDT=1 reverts to DDT+GMRES for comparison. Corrector stays M^-1 D^T (div relaxes, acceptable). All prior infra kept**
- **pump hypre: use GMRES (not PCG) for the Galerkin K pressure solve too. K (Apre) is SPD in principle but PCG broke down (pAp<0, HYPRE error 256, ~3 iters) -- BoomerAMG-as-preconditioner is non-symmetric on GPU (GS-family relax) + the pin-row diag=1 spike disturbs coarsening, so the preconditioned operator isn't SPD for CG. GMRES tolerates it (the proven-converging path). RESULT of the K switch: |phi| dropped from 1e6 to ~6000-30000 -- the Galerkin operator IS far better conditioned than DDT (no near-zero eigenvalue), confirming the artifact diagnosis. MARS_HYPRE_KRYLOV=pcg to force CG**
- **TGV: per-slot grad(p) divides by per-slot half-CV mass (d_massNodePerSlot), not merged (workflow w7bapvkdt: per-slot numerator/merged mass = half gradient = the residual factor-of-2 keeping feedback gain >1)**
- **Revert "TGV: per-slot grad(p) divides by per-slot half-CV mass (d_massNodePerSlot), not merged (workflow w7bapvkdt: per-slot numerator/merged mass = half gradient = the residual factor-of-2 keeping feedback gain >1)"**
- **pump: --pressure-k flag = the reference collocated Galerkin setup (the K-path fix). Solves the well-conditioned Galerkin stiffness K (s.Apre, AMG-able, physical phi) AND corrects with the CONJUGATE SCS Green-Gauss gradient (useLegacyGradient=true -> useDivT=false) -- the pairing that makes the K projection consistent. The old 'nearly orthogonal' K-failure was K solved but corrected with D^T (the gradient conjugate to DDT, not K). Pair with --vms-stab (divergence-side checkerboard stabilization, keeps K clean) + --solver=hypre -> the trifecta: well-conditioned + checkerboard-stable + projection-consistent, exactly what the reference does. DDT stays the default (no flag = byte-identical). Workflow-verified high-confidence**
- **fix(pump K-path): use GMRES for the Hypre K pressure solve. The PressureSolveKind::K branch called solveOneComponent with the default KrylovHint (PCG); under --solver=hypre that routes to Hypre PCG, which false-converges in ~2 iters (cg_p=2) on this operator (BoomerAMG non-symmetric on GPU + pin spike) -> garbage phi -> the (now conjugate) corrector amplifies it -> blowup. Pass KrylovHint::GMRES when solverKind==Hypre, matching the DDT branch (cg_p=33-60, converges). This was why --pressure-k --vms-stab blew up despite all 3 fixes being active: the K solve never actually solved**
- **pump: FEM-consistent weak div/grad projection (--pressure-k v2). The SCS divergence/gradient pair has cancellation null modes (the verified artifact), so part of the divergence is INVISIBLE to the correction -> accumulates ~1.2x/step -> blowup ~step 15 regardless of solver (falsified pairings: DDT+D^T exact but 1e6 phi; K+D^T leaks; K+SCS-grad 44x/step). FIX: standard P1 weak-form pair, matched to K -- divergence b_i=-(V/4)dNdx_i.sum(u_j) per element (boundary term = existing opening-flux source), corrector gradient = mass-normalized (V/4)-weighted element-gradient average (the exact adjoint). D_fem M^-1 D_fem^T is a no-cancellation Gram form spectrally equivalent to K -> per-step divergence removal is a contraction on ALL modes. Numerically verified (host replica): exact weak integrals, +grad sign, adjointness. Predictor grad(p^n) switched too. K+Hypre GMRES solve unchanged. New mars_fem_projection.hpp; gated useFemProjection; no flag = byte-identical**
- **pump: consistent P1 face-quadrature opening flux for the FEM projection (the destabilizer fix). DISCRIMINATOR: source OFF -> first STABLE run (phi 219->51 decaying, u bounded, div falling); source ON -> geometric blowup from step 1. The weak form requires oint(N_i u.n) as a consistent face integral; the lumped per-node source (u_i.areaVec_i, global dir) mismatches it node-by-node (rim + per-node-normal curvature) -> fixed-location spurious mass source -> hot spot. FIX: host-side setup weights w_i = (1/12)(2u_i+u_j+u_k).A_f over the side-set triangles using the velocity the BC ACTUALLY imposes per node, uploaded once (d_femFluxWin/Wout); per step divAcc += ramp*w_in + oScale*w_out (net=0 machine-exact, same ramp/oScale algebra). Gated useFemProjection; lumped path untouched otherwise. Verified: exact integral, signs, balance, uniform-velocity == lumped**
- **poiseuille multirank: fix DDT pressure solve across the streamwise rank seam. Three matrix-free fixes (column-zero for SPD, per-iter ghost exchange of p, Jacobi diagonal built matrix-free with reverse-halo fold) + route inlet BCs through the pump path (built inside setup, rank-consistent). 4-rank pressure CG now converges (was non-SPD/diverging). Single-rank byte-identical.**
- **pump: PISO inner pressure corrections (--correctors=N, FEM-projection path). Measured defect: one K-solve contracts the weak divergence only ~0.5-0.6x (K vs the D_fem M^-1 D_fem^T Gram spectral gap), so the un-removed residual + the re-presented boundary flux compound ~1.2-1.3x/step -> blowup ~step 12. FIX: iterate div->solve->correct on the CURRENT velocity iterate within the step; the interior divergence progressively cancels the (constant) boundary source so the SUM shrinks ~0.5x/pass (2-3 passes -> ~10-25% leftover -> contraction). runPressureSolveStep takes optional velocity-iterate ptrs (default u**); computeGradPhi/runCorrector extracted to lambdas, phiTotal accumulated + published so p+=phi and predictor grad(p^n) see the full increment. Honest [fem-div k=..] residual print (the SCS [CORR] div_max mismeasures the FEM path). N=1 byte-identical. gated useFemProjection+TetTag. NOT YET COMPILED**
- **pump: assemble the FEM-Gram pressure operator A_fem = D_fem M^-1 D_fem^T (the EXACT conjugate of the FEM div/grad corrector). Root cause of the un-removable divergence (flat PISO): K != D_fem M^-1 D_fem^T, so solving K leaves a residual the FEM corrector cannot project out. A_fem is the operator the projection identity requires: solve A_fem phi = (rho/dt) D_fem u**, correct u^{n+1}=u**-(dt/rho)M^-1 D_fem^T phi -> D_fem u^{n+1}=0 EXACTLY in one pass (host replica: div 0.173 -> 2.4e-16). Built from the FEM stencil a_i=-(V/4)dNdx_i (NOT SCS area-vectors -> NO cancellation, healthy SPD diagonal ~K/valence, AMG-friendly -- unlike the abandoned SCS DDT). Node-driven assembly factored as sum_i (1/M_i)(S_a.S_b), reuses buildDDTSparsityTet (same two-hop pattern), symmetric pin, wrapped s.AFemGram, solved with Hypre GMRES instead of s.Apre when useFemProjection. [FemGram-health] diag print. Gated; no flag byte-identical. NOT YET COMPILED**
- **pump --pressure-k: solve K + SCS Green-Gauss corrector + rely on --vms-stab (the reference collocated method). PROVEN this session: exact projection is impossible with a well-conditioned operator -- ANY conjugate D M^-1 D^T Gram form (SCS or FEM-Gram) has near-zero interior diagonals because sum_e grad N_a = 0 on a closed 1-ring (divergence theorem); FEM-Gram failed identically to SCS (diag 0.00, |x|=2.3e6, guard-rejected; host 2-tet replica missed it -- no closed-ring node). The reference does NOT drive div=0; it solves the well-conditioned K and stabilizes the residual divergence (--vms-stab). So --pressure-k now = K + useLegacyGradient=true (SCS corrector, K-consistent) + useFemProjection=false (FEM-Gram off). Pair with --vms-stab + --solver=hypre. FEM-Gram/projection kernels kept in tree (gated off) but no longer used by --pressure-k**
- **pump: scale-aware [FemGram-health] diagnostic. The old print flagged diag range [0.00, 0.02] as a fault, but A_fem = D_gal M^-1 D_gal^T is a Gram-Laplacian that correctly scales O(h) in 3D -- 0.02 IS healthy on a fine mesh, not near-zero. Host replica (closed-ring interior node, octahedron) verified: the kernel computes the correct operator to machine precision (brute-force D M^-1 D^T == factored form, diff 0); A_fem[0][0]=h exactly; one correction drops weak div 1e-1 -> 3e-17. The self-term (j==a) IS the cancelling closed-ring sum (~0) but the off-intermediate neighbor terms keep the diagonal positive O(h). New invariants: minDiag/sum|offdiag| (~1 healthy, <<1 = SCS collapse) + max|rowsum|/diag (~0 = constant null mode). Route A (FEM-Gram, --pressure-k) is structurally CORRECT; the earlier blowup was NOT the operator**
- **fix(pump): --pressure-k = Route A (FEM-Gram), the VERIFIED-correct config -- not the proven-bad K+SCS. Host replica proved A_fem = D_gal M^-1 D_gal^T is the correct SPD operator (assembly==brute-force diff 0; one correction drops div 1e-1->3e-17; the [0.00] diagonal was a MISREAD of the healthy O(h) scale). K+SCS gradient AMPLIFIES divergence 100x (25.9->2637, measured) -- that mix is what blew up. Now --pressure-k sets useFemProjection=true -> solver routes to s.AFemGram (GMRES+AMG) + FEM corrector gradient. Consistent weak-Galerkin family throughout**
- **fix(pump): silent neighbor-cap overflow made A_fem near-singular on the real mesh (the actual bug -- NOT the mesh). On the production tet mesh, high-valence interior nodes (40-70+, tets are high-valence) exceeded the hardcoded 48-neighbor caps in buildDDTSparsityTet + assembleFemGramPerNodeKernelTet, which SILENTLY DROPPED couplings -> A_fem rows lost off-diagonals -> near-singular (minDiag/sum|offdiag|=0.02) -> Hypre converges to |x|=2.3e6 for |b|=1.7 (eigenvalue ~1e-6) -> guard-rejects -> phi=0 -> blowup. Host replica (small clean patches, low valence) never hit it. FIX: (1) restructured assembleFemGramPerNodeKernelTet to scatter-direct into the CSR via atomicAddSparseEntry (element-pair double sum, math bit-identical to the verified Sum_i(1/M_i)S_a.S_b) -- NO partner buffer, cannot overflow at any valence, no register pressure; setup-only so the O(m^2) atomics cost nothing. (2) sparsity cap 48->96 (shared macro MARS_DDT_TET_MAX_OTHERS, single source of truth) + overflow COUNTER that prints [FemGram-assembly] N nodes exceeded cap (max valence) -- never silent again. Expect minDiag/sum|offdiag|~1, physical phi, div_max drops**
- **poiseuille: strip failed fork-local multirank seam attempts (ghost-row fold, promoted-ownership assembly, debug probes); keep the working pressure-solve seam fixes + --bdf1. Velocity multirank seam needs element-halo widening in domain.cu (proven: off-rank stiffness lives in elements this rank lacks; not foldable).**
- **pump: symmetric Jacobi scaling of A_fem so AMG solves it on the BIG mesh. A/B PROVED the method works (small mesh: minDiag/sum|offdiag|=0.07, phi physical 74, div_max contracts 9->5, flow develops) but the BIG mesh is near-singular (minDiag=0.02, |x|=2.3e6 for |b|=1.7, accepting it -> div 7->22->161->29869 blowup). The near-zero eigenvalue is from the lumped mass M^-1 spanning a wider range on the bigger non-uniform (but VALID, production-run) mesh -- pure operator conditioning. FIX (textbook for variable-mass B M^-1 B^T): solve A_hat y = b_hat, A_hat = D^-1/2 A_fem D^-1/2 (unit diagonal), recover x = D^-1/2 y (solution identical, just AMG-conditionable). Scale CSR in place at setup (col factor via dofToNode + halo for ghosts), scale b / unscale x per solve, gated useFemGramSolve, MARS_FEMGRAM_NOSCALE for A/B. Expect big-mesh minDiag~1, physical phi, div_max contracts like small. NOT YET COMPILED**
- **docs: confirm secondary loop = skew advection KE injection at non-solenoidal seam (hand-derived energy identity mdot*(qR^2-qL^2))**
- **TGV: MARS_TGV_EMAC -- energy-stable advection correction (advN -= q*div(u)) for non-solenoidal periodic seam; cancels the skew KE-injection (hand-derived residual mdot*(qR^2-qL^2)) without touching u or mass**
- **TGV EMAC: tunable coefficient MARS_TGV_EMAC_C (default -1) to sweep the q*div correction sign/magnitude empirically**
- **pump: --pressure-k default = K-solve + FEM weak gradient (drop the AMG-hostile Gram operator)**
- **docs: node-EMAC negative result; real fix is per-face mdot reconcile at periodic seam (skew is per-element energy-conserving; leak is cross-element mdot mismatch at the shared periodic face)**
- **TGV: MARS_TGV_SEAM_UPWIND -- seam-localized upwind dissipation for the periodic advective loop. PROVEN: per-face energy-zero impossible for conservative flux (production F*(qR-qL)); skew needs div u=0 to telescope; reduced projection leaves per-slot seam div by design -> must dissipate. Surgical upwind blend at seam faces only (derived coeff 0.5a|mdot|(qL-qR), production -0.5a|mdot|(qL-qR)^2<=0). --skew=0 (result 9) proves it bounds; this localizes it.**
- **docs: CORE WALL identified -- reduced periodic projection leaves per-slot seam divergence by design (proven: upwind delays but cannot cure -> continuous div source). NOT advection/corrector/feedback. Same 'boundary-complete divergence' open item as wing/pump. Feedback loops fixed (step40->190). Next = projection completeness, not more correction terms.**
- **docs: final handoff -- most promising untested fix is fold+broadcast CORRECTOR gradPhi (single-rank does this and is clean; differs from result-7 u-broadcast). Plus DOF over-collapse + per-slot residual r_M=-r_S leads. Core wall = projection leaves per-slot seam div.**
- **pump: AMG-on-K preconditioned solve of the Gram operator A_fem (Schur fix)**
- **pump: scale K by A_fem's D^-1/2 for the Schur preconditioner (the consistent fix)**
- **pump: stabilized-K pressure path -- add PSPG tau*L into K (the production method)**
- **pump: GMRES for both Hypre pressure paths (fixes cg_p=3 PCG false-convergence)**
- **pump: ramp the FIX-B pressure head (--pump-dp) with --source-ramp-steps**
- **pump: open-face momentum closure for FIX-B (fixes the advection detonation)**
- **multirank velocity solve: force Jacobi preconditioner diagonal positive (|diag|) so rho=(r,z)>0 -- seam DOFs had negative assembled diagonal, breaking CG conjugacy. Plus domain.hpp halo-factor knob (MARS_HALO_FACTOR, default 1.0) and MARS_NS_DEBUG_STEPS/MARS_CG_TRACE diagnostics. Channel multirank velocity operator still asymmetric at seam (pAp<0) -- next.**
- **pump: cap dt by the pressure-gradient kick too (fixes the head-ramp blowup)**
- **pump: MARS_NS_DEBUG_STEPS env to extend the [ns-dbg] window (watch late-step transitions)**
- **pump: clamp open-face grad(p)/grad(phi) in the predictor+corrector (closes the head-runaway)**
- **render: --side-set-io marks inlet/outlet from the side_set_id field (reliable, not the flow auto-detect)**
- **pump: FIX-B #3 open-face normal-velocity projection (--open-normal-proj)**
- **pump: FIX-B #2 dynamic-head inlet target (--total-pressure, totalPressure BC)**
- **pump: FIX-B #1 flux-consistent pressure BC (--flux-pressure-bc, closes the high-head div-creep)**
- **pump: exempt --flux-pressure-bc from the do-nothing-outlet source guard (the bug that no-op'd #1)**
- **docs: update pump tutorial to the implemented solver + add private deep-dive**
