### PR TITLE
cstone

### DIFF
--- a/backend/distributed/unstructured/solvers/mars_acm_coarsen.hpp
+++ b/backend/distributed/unstructured/solvers/mars_acm_coarsen.hpp
@@ -1,0 +1,134 @@
+#ifndef MARS_ACM_COARSEN_HPP
+#define MARS_ACM_COARSEN_HPP
+
+// ACM Stage 3: GPU coarse-operator + grid-transfer kernels for the agglomeration
+// additive-correction multigrid (Darwish-Saad-Hamdan 2008).
+//
+// The coarse operator is the sum-of-fine Galerkin operator (paper Eqs 27-28): for a 0/1 block
+// aggregate-membership P, A_coarse == P^T A P. The host replica (scripts/acm_stage0_galerkin_gate.py)
+// proved this to machine precision. We build it the GPU way: map every fine nonzero (r,c) to its
+// coarse (cr,cc), sort by a linear key, reduce_by_key to sum duplicates, split back to CSR. Internal
+// faces (both endpoints in the same aggregate) fold into the coarse diagonal for free, because their
+// (cr,cc) lands on a diagonal block. This is the same sort/reduce_by_key idiom the unstructured
+// backend already uses for CSR construction.
+//
+// DOF layout is interleaved 4*node+comp (the coupled [u,v,w,p] block). Aggregation is NODE-granular
+// (all 4 components of a node share an aggregate), so the coarse dof of fine dof r is
+// 4*agg[r/4] + (r%4). The aggregation map agg[] is an INPUT here (host-once for now; the GPU
+// directional aggregation is Stage 5).
+
+#include <thrust/device_vector.h>
+#include <thrust/sort.h>
+#include <thrust/reduce.h>
+#include <thrust/binary_search.h>
+#include <thrust/iterator/counting_iterator.h>
+
+namespace mars {
+
+// per fine row r: coarse row cr = 4*agg[r/4] + r%4; emit key = NDc*cr + cc for each nz in the row.
+template<typename RealType>
+__global__ void acmEmitCoarseKeyKernel(const int* frowOff, const int* fcolInd, const int* agg,
+                                        int NDf, long long NDc, long long* key)
+{
+    int r = blockIdx.x * blockDim.x + threadIdx.x;
+    if (r >= NDf) return;
+    long long cr = 4LL * agg[r >> 2] + (r & 3);
+    for (int k = frowOff[r]; k < frowOff[r + 1]; ++k) {
+        int c = fcolInd[k];
+        long long cc = 4LL * agg[c >> 2] + (c & 3);
+        key[k] = NDc * cr + cc;
+    }
+}
+
+// templated only for weak linkage (header included in multiple TUs); RealType is unused
+template<typename RealType>
+__global__ void acmSplitKeyKernel(const long long* ukey, long long NDc, int cnnz,
+                                   int* crow, int* ccol)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= cnnz) return;
+    crow[i] = static_cast<int>(ukey[i] / NDc);
+    ccol[i] = static_cast<int>(ukey[i] % NDc);
+}
+
+// order-zero (injection) prolongation: xf[4*node+c] = xc[4*agg[node]+c]
+template<typename RealType>
+__global__ void acmInjectKernel(const RealType* xc, RealType* xf, const int* agg, int nFine)
+{
+    int node = blockIdx.x * blockDim.x + threadIdx.x;
+    if (node >= nFine) return;
+    int I = agg[node];
+    for (int c = 0; c < 4; ++c) xf[4 * node + c] = xc[4 * I + c];
+}
+
+// sum restriction (P^T): xc[4*agg[node]+c] += xf[4*node+c]  (xc must be pre-zeroed)
+template<typename RealType>
+__global__ void acmRestrictAddKernel(const RealType* xf, RealType* xc, const int* agg, int nFine)
+{
+    int node = blockIdx.x * blockDim.x + threadIdx.x;
+    if (node >= nFine) return;
+    int I = agg[node];
+    for (int c = 0; c < 4; ++c) atomicAdd(&xc[4 * I + c], xf[4 * node + c]);
+}
+
+// Build the coarse CSR (NDc=4*nCoarse) from the fine CSR (NDf=4*nFine) + aggregation map.
+// Output CSR is column-sorted within each row on device (the linear key sorts cc ascending
+// within a fixed cr), so no host sortColumns round-trip is needed.
+template<typename RealType>
+void buildCoarseOperator(const thrust::device_vector<int>& d_frowOff,
+                         const thrust::device_vector<int>& d_fcolInd,
+                         const thrust::device_vector<RealType>& d_fvals,
+                         const thrust::device_vector<int>& d_agg,   // size nFine
+                         int nFine, int nCoarse,
+                         thrust::device_vector<int>& d_crowOff,
+                         thrust::device_vector<int>& d_ccolInd,
+                         thrust::device_vector<RealType>& d_cvals)
+{
+    const int NDf = 4 * nFine;
+    const long long NDc = 4LL * nCoarse;
+    const int nnzF = static_cast<int>(d_fvals.size());
+
+    // 1) one key per fine nonzero = NDc*coarse_row + coarse_col
+    thrust::device_vector<long long> d_key(nnzF);
+    thrust::device_vector<RealType>  d_val(d_fvals);            // values move with their key
+    {
+        int blk = 256, grd = (NDf + blk - 1) / blk;
+        acmEmitCoarseKeyKernel<RealType><<<grd, blk>>>(
+            thrust::raw_pointer_cast(d_frowOff.data()),
+            thrust::raw_pointer_cast(d_fcolInd.data()),
+            thrust::raw_pointer_cast(d_agg.data()), NDf, NDc,
+            thrust::raw_pointer_cast(d_key.data()));
+        cudaDeviceSynchronize();
+    }
+
+    // 2) sort by key, 3) sum duplicates (the segmented reduce = Eqs 27-28)
+    thrust::sort_by_key(d_key.begin(), d_key.end(), d_val.begin());
+    thrust::device_vector<long long> d_ukey(nnzF);
+    thrust::device_vector<RealType>  d_uval(nnzF);
+    auto end = thrust::reduce_by_key(d_key.begin(), d_key.end(), d_val.begin(),
+                                     d_ukey.begin(), d_uval.begin());
+    int cnnz = static_cast<int>(end.first - d_ukey.begin());
+    d_ukey.resize(cnnz); d_uval.resize(cnnz);
+
+    // 4) split unique keys -> (coarse_row, coarse_col); values are the coarse vals
+    d_ccolInd.resize(cnnz);
+    d_cvals = d_uval;
+    thrust::device_vector<int> d_crow(cnnz);
+    {
+        int blk = 256, grd = (cnnz + blk - 1) / blk;
+        acmSplitKeyKernel<RealType><<<grd, blk>>>(thrust::raw_pointer_cast(d_ukey.data()), NDc, cnnz,
+                                        thrust::raw_pointer_cast(d_crow.data()),
+                                        thrust::raw_pointer_cast(d_ccolInd.data()));
+        cudaDeviceSynchronize();
+    }
+
+    // rowOff via lower_bound of each row id in the sorted coarse-row array (keys are sorted, so
+    // d_crow is non-decreasing): rowOff[r] = #entries with crow < r.
+    d_crowOff.resize(NDc + 1);
+    thrust::counting_iterator<int> rows(0);
+    thrust::lower_bound(d_crow.begin(), d_crow.end(), rows, rows + (NDc + 1), d_crowOff.begin());
+}
+
+}  // namespace mars
+
+#endif  // MARS_ACM_COARSEN_HPP

--- a/backend/distributed/unstructured/solvers/mars_acm_vcycle.hpp
+++ b/backend/distributed/unstructured/solvers/mars_acm_vcycle.hpp
@@ -1,0 +1,234 @@
+#ifndef MARS_ACM_VCYCLE_HPP
+#define MARS_ACM_VCYCLE_HPP
+
+// ACM Stage 4a: GPU multilevel V-cycle (Darwish-Saad-Hamdan 2008), single rank.
+//
+// Hierarchy = host-once greedy aggregation per level (the aggregation MAP is setup, not the hot
+// cycle; the GPU DIRECTIONAL aggregation is Stage 5) + the Stage-3 GPU coarse operator
+// (sum-of-fine == P^T A P) + order-zero injection / sum restriction. Smoother = damped point-Jacobi
+// (Stage 1 showed block-Jacobi is unnecessary on the PSPG operator -- its pressure diagonal is O(0.1-1),
+// not ~0). Coarsest = many Jacobi sweeps (the paper's serial V-cycle; the parallel master-gather
+// direct solve is Stage 6). The whole apply path runs on the GPU (no D2H inside the cycle).
+//
+// This header also carries a HOST V-cycle replica (acmHostVcycle) built from the same hierarchy, used
+// only as the Stage-4a validation oracle: one GPU cycle must equal one host cycle to round-off. We do
+// NOT validate via standalone MG iteration -- stationary MG can diverge on an indefinite saddle
+// operator for legitimate reasons; Krylov acceleration (FlexGMRES, Stage 4b) is the real harness.
+
+#include "backend/distributed/unstructured/solvers/mars_acm_coarsen.hpp"
+#include <thrust/device_vector.h>
+#include <thrust/fill.h>
+#include <vector>
+#include <set>
+#include <cmath>
+
+namespace mars {
+
+template<class V> inline auto acmRaw(V& v) { return thrust::raw_pointer_cast(v.data()); }
+
+template<typename RealType>
+__global__ void acmSpmvKernel(const int* rowOff, const int* colInd, const RealType* vals,
+                              const RealType* x, RealType* y, int ND)
+{
+    int r = blockIdx.x * blockDim.x + threadIdx.x; if (r >= ND) return;
+    RealType s = 0;
+    for (int k = rowOff[r]; k < rowOff[r + 1]; ++k) s += vals[k] * x[colInd[k]];
+    y[r] = s;
+}
+
+template<typename RealType>
+__global__ void acmDinvKernel(const int* rowOff, const int* colInd, const RealType* vals,
+                              RealType* dinv, int ND)
+{
+    int r = blockIdx.x * blockDim.x + threadIdx.x; if (r >= ND) return;
+    RealType d = 0;
+    for (int k = rowOff[r]; k < rowOff[r + 1]; ++k) if (colInd[k] == r) { d = vals[k]; break; }
+    dinv[r] = (fabs((double)d) > 1e-30) ? RealType(1) / d : RealType(0);
+}
+
+// one damped point-Jacobi sweep: xout = xin + omega * dinv * (b - A xin)   (proper Jacobi, ping-pong)
+template<typename RealType>
+__global__ void acmJacobiKernel(const int* rowOff, const int* colInd, const RealType* vals,
+                                const RealType* dinv, const RealType* b,
+                                const RealType* xin, RealType* xout, RealType omega, int ND)
+{
+    int r = blockIdx.x * blockDim.x + threadIdx.x; if (r >= ND) return;
+    RealType s = 0;
+    for (int k = rowOff[r]; k < rowOff[r + 1]; ++k) s += vals[k] * xin[colInd[k]];
+    xout[r] = xin[r] + omega * dinv[r] * (b[r] - s);
+}
+
+template<typename RealType>
+__global__ void acmSubKernel(const RealType* a, const RealType* b, RealType* y, int ND)
+{ int r = blockIdx.x * blockDim.x + threadIdx.x; if (r < ND) y[r] = a[r] - b[r]; }
+
+template<typename RealType>
+__global__ void acmAddKernel(RealType* x, const RealType* y, int ND)
+{ int r = blockIdx.x * blockDim.x + threadIdx.x; if (r < ND) x[r] += y[r]; }
+
+template<typename RealType>
+struct AcmLevel {
+    int nNodes = 0, ND = 0, nCoarse = 0;
+    thrust::device_vector<int> rowOff, colInd;
+    thrust::device_vector<RealType> vals, dinv;
+    thrust::device_vector<int> agg;                            // nNodes -> parent (empty on coarsest)
+    thrust::device_vector<RealType> bvec, xvec, rtmp, xtmp;    // per-level cycle work vectors
+};
+
+// host-once greedy aggregation on the block graph of a coupled (4*node+comp) CSR
+inline void acmHostAggregate(const std::vector<int>& rowOff, const std::vector<int>& colInd,
+                             int nNodes, int kmax, std::vector<int>& agg, int& nCoarse)
+{
+    const int ND = 4 * nNodes;
+    std::vector<std::set<int>> nb(nNodes);
+    for (int r = 0; r < ND; ++r) {
+        int I = r >> 2;
+        for (int k = rowOff[r]; k < rowOff[r + 1]; ++k) nb[I].insert(colInd[k] >> 2);
+    }
+    agg.assign(nNodes, -1); nCoarse = 0;
+    for (int i = 0; i < nNodes; ++i) {
+        if (agg[i] != -1) continue;
+        agg[i] = nCoarse; int cnt = 1;
+        for (int j : nb[i]) { if (cnt >= kmax) break; if (j != i && agg[j] == -1) { agg[j] = nCoarse; ++cnt; } }
+        ++nCoarse;
+    }
+}
+
+template<typename RealType>
+void acmBuildHierarchy(const thrust::device_vector<int>& rowOff0,
+                       const thrust::device_vector<int>& colInd0,
+                       const thrust::device_vector<RealType>& vals0, int nNodes0,
+                       int kmax, int maxCoarseND, std::vector<AcmLevel<RealType>>& levels)
+{
+    levels.clear();
+    {
+        AcmLevel<RealType> L;
+        L.nNodes = nNodes0; L.ND = 4 * nNodes0;
+        L.rowOff = rowOff0; L.colInd = colInd0; L.vals = vals0;
+        levels.push_back(std::move(L));
+    }
+    for (int idx = 0; ; ++idx) {
+        const int blk = 256, grd = (levels[idx].ND + blk - 1) / blk;
+        levels[idx].dinv.resize(levels[idx].ND);
+        acmDinvKernel<RealType><<<grd, blk>>>(acmRaw(levels[idx].rowOff), acmRaw(levels[idx].colInd),
+                                              acmRaw(levels[idx].vals), acmRaw(levels[idx].dinv), levels[idx].ND);
+        levels[idx].bvec.assign(levels[idx].ND, 0); levels[idx].xvec.assign(levels[idx].ND, 0);
+        levels[idx].rtmp.assign(levels[idx].ND, 0); levels[idx].xtmp.assign(levels[idx].ND, 0);
+        if (levels[idx].ND <= maxCoarseND) break;
+
+        std::vector<int> hro(levels[idx].rowOff.size()), hci(levels[idx].colInd.size());
+        thrust::copy(levels[idx].rowOff.begin(), levels[idx].rowOff.end(), hro.begin());
+        thrust::copy(levels[idx].colInd.begin(), levels[idx].colInd.end(), hci.begin());
+        std::vector<int> agg; int nCoarse;
+        acmHostAggregate(hro, hci, levels[idx].nNodes, kmax, agg, nCoarse);
+        if (nCoarse >= levels[idx].nNodes) break;            // no coarsening progress
+
+        levels[idx].agg.assign(agg.begin(), agg.end());
+        levels[idx].nCoarse = nCoarse;
+        AcmLevel<RealType> C; C.nNodes = nCoarse; C.ND = 4 * nCoarse;
+        buildCoarseOperator<RealType>(levels[idx].rowOff, levels[idx].colInd, levels[idx].vals,
+                                      levels[idx].agg, levels[idx].nNodes, nCoarse,
+                                      C.rowOff, C.colInd, C.vals);
+        levels.push_back(std::move(C));
+    }
+}
+
+template<typename RealType>
+inline void acmSmoothGpu(AcmLevel<RealType>& L, int sweeps, RealType omega)
+{
+    const int blk = 256, grd = (L.ND + blk - 1) / blk;
+    for (int s = 0; s < sweeps; ++s) {
+        acmJacobiKernel<RealType><<<grd, blk>>>(acmRaw(L.rowOff), acmRaw(L.colInd), acmRaw(L.vals),
+            acmRaw(L.dinv), acmRaw(L.bvec), acmRaw(L.xvec), acmRaw(L.xtmp), omega, L.ND);
+        L.xvec.swap(L.xtmp);                                 // O(1) pointer swap; xvec holds the new iterate
+    }
+}
+
+// one V-cycle on levels[Lidx], operating on its bvec (in) / xvec (in-out)
+template<typename RealType>
+void acmVcycleGpu(std::vector<AcmLevel<RealType>>& levels, int Lidx,
+                  int pre, int post, int coarse, RealType omega)
+{
+    AcmLevel<RealType>& L = levels[Lidx];
+    const int blk = 256, grd = (L.ND + blk - 1) / blk;
+    if (Lidx == (int)levels.size() - 1) { acmSmoothGpu(L, coarse, omega); return; }
+
+    acmSmoothGpu(L, pre, omega);
+    acmSpmvKernel<RealType><<<grd, blk>>>(acmRaw(L.rowOff), acmRaw(L.colInd), acmRaw(L.vals),
+                                          acmRaw(L.xvec), acmRaw(L.rtmp), L.ND);
+    acmSubKernel<RealType><<<grd, blk>>>(acmRaw(L.bvec), acmRaw(L.rtmp), acmRaw(L.rtmp), L.ND);
+
+    AcmLevel<RealType>& C = levels[Lidx + 1];
+    thrust::fill(C.bvec.begin(), C.bvec.end(), RealType(0));
+    thrust::fill(C.xvec.begin(), C.xvec.end(), RealType(0));
+    const int gN = (L.nNodes + blk - 1) / blk;
+    acmRestrictAddKernel<RealType><<<gN, blk>>>(acmRaw(L.rtmp), acmRaw(C.bvec), acmRaw(L.agg), L.nNodes);
+
+    acmVcycleGpu(levels, Lidx + 1, pre, post, coarse, omega);
+
+    acmInjectKernel<RealType><<<gN, blk>>>(acmRaw(C.xvec), acmRaw(L.xtmp), acmRaw(L.agg), L.nNodes);
+    acmAddKernel<RealType><<<grd, blk>>>(acmRaw(L.xvec), acmRaw(L.xtmp), L.ND);
+    acmSmoothGpu(L, post, omega);
+}
+
+// ---- host replica (validation oracle): same hierarchy, same arithmetic, on the CPU ----
+template<typename RealType>
+struct AcmLevelHost {
+    int nNodes, ND, nCoarse;
+    std::vector<int> rowOff, colInd, agg;
+    std::vector<RealType> vals, dinv;
+};
+
+template<typename RealType>
+void acmHierarchyToHost(const std::vector<AcmLevel<RealType>>& g, std::vector<AcmLevelHost<RealType>>& h)
+{
+    h.resize(g.size());
+    for (size_t l = 0; l < g.size(); ++l) {
+        h[l].nNodes = g[l].nNodes; h[l].ND = g[l].ND; h[l].nCoarse = g[l].nCoarse;
+        h[l].rowOff.resize(g[l].rowOff.size()); h[l].colInd.resize(g[l].colInd.size());
+        h[l].vals.resize(g[l].vals.size());     h[l].dinv.resize(g[l].dinv.size());
+        h[l].agg.resize(g[l].agg.size());
+        thrust::copy(g[l].rowOff.begin(), g[l].rowOff.end(), h[l].rowOff.begin());
+        thrust::copy(g[l].colInd.begin(), g[l].colInd.end(), h[l].colInd.begin());
+        thrust::copy(g[l].vals.begin(),   g[l].vals.end(),   h[l].vals.begin());
+        thrust::copy(g[l].dinv.begin(),   g[l].dinv.end(),   h[l].dinv.begin());
+        thrust::copy(g[l].agg.begin(),    g[l].agg.end(),    h[l].agg.begin());
+    }
+}
+
+template<typename RealType>
+void acmHostVcycle(const std::vector<AcmLevelHost<RealType>>& Ls, int L,
+                   std::vector<RealType>& x, const std::vector<RealType>& b,
+                   int pre, int post, int coarse, RealType omega)
+{
+    const AcmLevelHost<RealType>& lv = Ls[L];
+    auto smooth = [&](std::vector<RealType>& xx, const std::vector<RealType>& bb, int sw) {
+        std::vector<RealType> t(lv.ND);
+        for (int s = 0; s < sw; ++s) {
+            for (int r = 0; r < lv.ND; ++r) {
+                RealType sm = 0;
+                for (int k = lv.rowOff[r]; k < lv.rowOff[r + 1]; ++k) sm += lv.vals[k] * xx[lv.colInd[k]];
+                t[r] = xx[r] + omega * lv.dinv[r] * (bb[r] - sm);
+            }
+            xx.swap(t);
+        }
+    };
+    if (L == (int)Ls.size() - 1) { smooth(x, b, coarse); return; }
+    smooth(x, b, pre);
+    std::vector<RealType> r(lv.ND);
+    for (int i = 0; i < lv.ND; ++i) {
+        RealType sm = 0;
+        for (int k = lv.rowOff[i]; k < lv.rowOff[i + 1]; ++k) sm += lv.vals[k] * x[lv.colInd[k]];
+        r[i] = b[i] - sm;
+    }
+    const AcmLevelHost<RealType>& cv = Ls[L + 1];
+    std::vector<RealType> bc(cv.ND, 0), xc(cv.ND, 0);
+    for (int i = 0; i < lv.nNodes; ++i) for (int c = 0; c < 4; ++c) bc[4 * lv.agg[i] + c] += r[4 * i + c];
+    acmHostVcycle(Ls, L + 1, xc, bc, pre, post, coarse, omega);
+    for (int i = 0; i < lv.nNodes; ++i) for (int c = 0; c < 4; ++c) x[4 * i + c] += xc[4 * lv.agg[i] + c];
+    smooth(x, b, post);
+}
+
+}  // namespace mars
+
+#endif  // MARS_ACM_VCYCLE_HPP

--- a/backend/distributed/unstructured/solvers/mars_cg_solver_with_preconditioner.hpp
+++ b/backend/distributed/unstructured/solvers/mars_cg_solver_with_preconditioner.hpp
@@ -64,6 +64,23 @@ private:
     Vector diag_;
 };
 
+// Identity preconditioner (z = r). Makes flexible GMRES reduce EXACTLY to plain GMRES, so it serves
+// as a convergence-independent unit test of the FGMRES Z-basis reconstruction.
+template<typename RealType, typename IndexType, typename AcceleratorTag>
+class IdentityPreconditioner : public Preconditioner<RealType, IndexType, AcceleratorTag> {
+public:
+    using Matrix = SparseMatrix<IndexType, RealType, AcceleratorTag>;
+    using Vector = typename mars::VectorSelector<RealType, AcceleratorTag>::type;
+
+    void setup(const Matrix&) override {}
+    void apply(const Vector& r, Vector& z) override {
+        if (z.size() != r.size()) z.resize(r.size());
+        thrust::copy(thrust::device_pointer_cast(r.data()),
+                     thrust::device_pointer_cast(r.data() + r.size()),
+                     thrust::device_pointer_cast(z.data()));
+    }
+};
+
 // Conjugate Gradient solver with pluggable preconditioners
 template<typename RealType, typename IndexType, typename AcceleratorTag>
 class PreconditionedConjugateGradientSolver

--- a/backend/distributed/unstructured/solvers/mars_gmres_solver.hpp
+++ b/backend/distributed/unstructured/solvers/mars_gmres_solver.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../fem/mars_sparse_matrix.hpp"
+#include "mars_cg_solver_with_preconditioner.hpp"   // Preconditioner base (pluggable + flexible GMRES)
 #include <cusparse.h>
 #include <cublas_v2.h>
 #include <iostream>
@@ -19,6 +20,7 @@ class GMRESSolver
 public:
     using Matrix = SparseMatrix<IndexType, RealType, AcceleratorTag>;
     using Vector = typename mars::VectorSelector<RealType, AcceleratorTag>::type;
+    using Precond = Preconditioner<RealType, IndexType, AcceleratorTag>;
 
     GMRESSolver(int maxIter = 1000, RealType tolerance = 1e-6, int restart = 30)
         : maxIter_(maxIter)
@@ -38,6 +40,10 @@ public:
 
     bool solve(const Matrix& A, const Vector& b, Vector& x, bool usePreconditioner = false)
     {
+        // flexible GMRES path (Z-basis) for a pluggable / non-stationary preconditioner; the
+        // stationary path below is left untouched so existing callers are unaffected.
+        if (flexible_ && precond_) return solveFlexible(A, b, x);
+
         size_t n = A.numRows();
         int m = restart_;
 
@@ -65,6 +71,7 @@ public:
             if (verbose_) {
                 std::cout << "GMRES: RHS is zero\n";
             }
+            lastIters_ = 0;
             return true;
         }
 
@@ -117,6 +124,7 @@ public:
                     std::cout << "GMRES converged in " << totalIter
                              << " iterations, residual = " << beta / b_norm << std::endl;
                 }
+                lastIters_ = totalIter;
                 return true;
             }
 
@@ -220,10 +228,12 @@ public:
                     std::cout << "GMRES converged in " << totalIter
                              << " iterations, residual = " << std::abs(s[m]) / b_norm << std::endl;
                 }
+                lastIters_ = totalIter;
                 return true;
             }
         }
 
+        lastIters_ = totalIter;
         if (verbose_) {
             std::cout << "GMRES did not converge in " << maxIter_ << " iterations\n";
         }
@@ -234,6 +244,9 @@ public:
     void setMaxIterations(int maxIter) { maxIter_ = maxIter; }
     void setTolerance(RealType tol) { tolerance_ = tol; }
     void setRestart(int restart) { restart_ = restart; }
+    void setPreconditioner(Precond* M) { precond_ = M; }   // opt-in pluggable preconditioner
+    void setFlexible(bool f) { flexible_ = f; }            // FGMRES (Z-basis) -- needs a preconditioner set
+    int getLastIterations() const { return lastIters_; }
 
 private:
     int maxIter_;
@@ -242,6 +255,93 @@ private:
     bool verbose_;
     cublasHandle_t cublasHandle_;
     cusparseHandle_t cusparseHandle_;
+    Precond* precond_ = nullptr;   // not owned; nullptr -> stationary path (inline Jacobi / none)
+    bool flexible_ = false;
+    int lastIters_ = 0;
+
+    // Flexible GMRES: store the preconditioned basis Z_j = M^-1 V_j, build the Krylov space on
+    // A*Z_j, and reconstruct x = x0 + Z*y. This captures a varying/non-stationary preconditioner
+    // (the ACM V-cycle) per-column, where stationary GMRES (fixed-M assumption) stagnates.
+    bool solveFlexible(const Matrix& A, const Vector& b, Vector& x)
+    {
+        size_t n = A.numRows();
+        int m = restart_;
+        if (x.size() != n) x.resize(n);
+        thrust::fill(thrust::device_pointer_cast(x.data()),
+                    thrust::device_pointer_cast(x.data() + x.size()), RealType(0));
+
+        precond_->setup(A);   // build / refresh M once
+
+        RealType b_norm = std::sqrt(dot(b, b));
+        if (b_norm < 1e-14) { lastIters_ = 0; if (verbose_) std::cout << "FGMRES: RHS is zero\n"; return true; }
+
+        std::vector<Vector> V(m + 1), Z(m);
+        for (int i = 0; i <= m; ++i) V[i].resize(n);
+        for (int i = 0; i < m; ++i)  Z[i].resize(n);
+        std::vector<std::vector<RealType>> H(m + 1, std::vector<RealType>(m, 0.0));
+        std::vector<RealType> s(m + 1), cs(m), sn(m);
+        Vector r(n), w(n);
+        int totalIter = 0;
+
+        for (int outer = 0; outer < maxIter_ / m; ++outer)
+        {
+            spmv(A, x, r);                                          // r = A x
+            thrust::transform(thrust::device_pointer_cast(b.data()),
+                             thrust::device_pointer_cast(b.data() + b.size()),
+                             thrust::device_pointer_cast(r.data()),
+                             thrust::device_pointer_cast(r.data()),
+                             thrust::minus<RealType>());            // r = b - A x  (NOT preconditioned: flexible convention)
+            RealType beta = std::sqrt(dot(r, r));
+            if (beta / b_norm < tolerance_) {
+                lastIters_ = totalIter;
+                if (verbose_) std::cout << "FGMRES converged in " << totalIter << " iters, res=" << beta / b_norm << "\n";
+                return true;
+            }
+            thrust::copy(thrust::device_pointer_cast(r.data()),
+                        thrust::device_pointer_cast(r.data() + r.size()),
+                        thrust::device_pointer_cast(V[0].data()));
+            scale(1.0 / beta, V[0]);
+            s[0] = beta; for (int i = 1; i <= m; ++i) s[i] = 0.0;
+
+            int j;
+            for (j = 0; j < m; ++j, ++totalIter)
+            {
+                precond_->apply(V[j], Z[j]);                       // Z[j] = M^-1 V[j]
+                spmv(A, Z[j], w);                                  // w = A Z[j]
+                for (int i = 0; i <= j; ++i) { H[i][j] = dot(w, V[i]); axpy(-H[i][j], V[i], w, w); }
+                H[j + 1][j] = std::sqrt(dot(w, w));
+                if (std::abs(H[j + 1][j]) < 1e-14) { m = j + 1; break; }
+                thrust::copy(thrust::device_pointer_cast(w.data()),
+                            thrust::device_pointer_cast(w.data() + w.size()),
+                            thrust::device_pointer_cast(V[j + 1].data()));
+                scale(1.0 / H[j + 1][j], V[j + 1]);
+                for (int i = 0; i < j; ++i) {
+                    RealType t = cs[i] * H[i][j] + sn[i] * H[i + 1][j];
+                    H[i + 1][j] = -sn[i] * H[i][j] + cs[i] * H[i + 1][j];
+                    H[i][j] = t;
+                }
+                RealType hn = std::sqrt(H[j][j] * H[j][j] + H[j + 1][j] * H[j + 1][j]);
+                cs[j] = H[j][j] / hn; sn[j] = H[j + 1][j] / hn;
+                H[j][j] = cs[j] * H[j][j] + sn[j] * H[j + 1][j]; H[j + 1][j] = 0.0;
+                s[j + 1] = -sn[j] * s[j]; s[j] = cs[j] * s[j];
+                if (std::abs(s[j + 1]) / b_norm < tolerance_) { m = j + 1; break; }
+            }
+
+            std::vector<RealType> y(m);
+            for (int i = m - 1; i >= 0; --i) { y[i] = s[i]; for (int k = i + 1; k < m; ++k) y[i] -= H[i][k] * y[k]; y[i] /= H[i][i]; }
+            for (int i = 0; i < m; ++i) axpy(y[i], Z[i], x, x);    // x += Z*y  (flexible: accumulate the PRECONDITIONED basis)
+
+            if (std::abs(s[m]) / b_norm < tolerance_) {
+                lastIters_ = totalIter;
+                if (verbose_) std::cout << "FGMRES converged in " << totalIter << " iters\n";
+                return true;
+            }
+            m = restart_;   // restore restart depth for the next cycle (a break may have shrunk it)
+        }
+        lastIters_ = totalIter;
+        if (verbose_) std::cout << "FGMRES did not converge in " << maxIter_ << " iters\n";
+        return false;
+    }
 
     void spmv(const Matrix& A, const Vector& x, Vector& y)
     {

--- a/backend/distributed/unstructured/solvers/mars_gpu_acm_preconditioner.hpp
+++ b/backend/distributed/unstructured/solvers/mars_gpu_acm_preconditioner.hpp
@@ -1,0 +1,76 @@
+#ifndef MARS_GPU_ACM_PRECONDITIONER_HPP
+#define MARS_GPU_ACM_PRECONDITIONER_HPP
+
+// ACM Stage 4b: the GPU agglomeration V-cycle (Stage 3 coarse-op + Stage 4a cycle) wrapped as a
+// pluggable Preconditioner for FlexGMRES. setup() builds the multilevel hierarchy ONCE; apply(r,z)
+// runs ONE V-cycle (z = M^-1 r): load r into the finest bvec, zero xvec, cycle, read xvec back.
+//
+// The coarsest damped-Jacobi is non-contractive on the indefinite saddle operator (Stage 4a note),
+// so M is approximate / non-stationary -> it MUST be driven by FLEXIBLE GMRES (the Z-basis), not
+// stationary GMRES. apply() re-zeros xvec and reloads bvec every call, so z is output-only with no
+// state carried between Krylov iterations.
+
+#include "mars_cg_solver_with_preconditioner.hpp"   // Preconditioner base (mars::fem)
+#include "mars_acm_vcycle.hpp"                       // AcmLevel, acmBuildHierarchy, acmVcycleGpu (mars)
+#include <thrust/copy.h>
+#include <thrust/fill.h>
+#include <vector>
+
+namespace mars
+{
+namespace fem
+{
+
+template<typename RealType, typename IndexType, typename AcceleratorTag>
+class GpuAcmPreconditioner : public Preconditioner<RealType, IndexType, AcceleratorTag>
+{
+public:
+    using Matrix = SparseMatrix<IndexType, RealType, AcceleratorTag>;
+    using Vector = typename mars::VectorSelector<RealType, AcceleratorTag>::type;
+
+    GpuAcmPreconditioner(int kmax = 4, int maxCoarseND = 64,
+                         int pre = 2, int post = 1, int coarse = 10, RealType omega = RealType(0.7))
+        : kmax_(kmax), maxCoarseND_(maxCoarseND), pre_(pre), post_(post), coarse_(coarse), omega_(omega) {}
+
+    // build the multilevel hierarchy once from the finest coupled CSR (interleaved 4*node+comp)
+    void setup(const Matrix& A) override
+    {
+        const int ND = static_cast<int>(A.numRows());
+        const int nz = static_cast<int>(A.nnz());
+        thrust::device_vector<IndexType> ro(ND + 1), ci(nz);
+        thrust::device_vector<RealType>  va(nz);
+        thrust::copy(thrust::device_pointer_cast(A.rowOffsetsPtr()),
+                     thrust::device_pointer_cast(A.rowOffsetsPtr() + ND + 1), ro.begin());
+        thrust::copy(thrust::device_pointer_cast(A.colIndicesPtr()),
+                     thrust::device_pointer_cast(A.colIndicesPtr() + nz), ci.begin());
+        thrust::copy(thrust::device_pointer_cast(A.valuesPtr()),
+                     thrust::device_pointer_cast(A.valuesPtr() + nz), va.begin());
+        // acmBuildHierarchy wants int CSR; IndexType is int in this driver's instantiation.
+        mars::acmBuildHierarchy<RealType>(ro, ci, va, ND / 4, kmax_, maxCoarseND_, levels_);
+        nd_ = ND;
+    }
+
+    // z = M^-1 r  (one V-cycle, fresh zero initial guess)
+    void apply(const Vector& r, Vector& z) override
+    {
+        if (static_cast<int>(z.size()) != nd_) z.resize(nd_);
+        thrust::copy(thrust::device_pointer_cast(r.data()),
+                     thrust::device_pointer_cast(r.data() + nd_), levels_[0].bvec.begin());
+        thrust::fill(levels_[0].xvec.begin(), levels_[0].xvec.end(), RealType(0));
+        mars::acmVcycleGpu<RealType>(levels_, 0, pre_, post_, coarse_, omega_);
+        thrust::copy(levels_[0].xvec.begin(), levels_[0].xvec.end(),
+                     thrust::device_pointer_cast(z.data()));
+    }
+
+    int numLevels() const { return static_cast<int>(levels_.size()); }
+
+private:
+    int kmax_, maxCoarseND_, pre_, post_, coarse_, nd_ = 0;
+    RealType omega_;
+    std::vector<mars::AcmLevel<RealType>> levels_;
+};
+
+}  // namespace fem
+}  // namespace mars
+
+#endif  // MARS_GPU_ACM_PRECONDITIONER_HPP

--- a/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
+++ b/backend/distributed/unstructured/solvers/mars_hypre_gmres_solver.hpp
@@ -180,6 +180,12 @@ public:
     // above tol) is visible in the step log instead of buried in Hypre's own
     // print output.
     int    getLastIterations()    const { return lastNumIters_; }
+
+    // Opt-in systems / point-block AMG: with N>1 and node-major interleaved DOFs
+    // (dof = N*node + comp), BoomerAMG auto-generates dof_func[i] = i % N, so a
+    // single SetNumFunctions(N) call enables point-block coarsening. Default N=1
+    // (scalar) -> no behavior change for existing callers.
+    void   setPointBlock(int n)         { pointBlock_ = (n > 1) ? n : 1; }
     double getLastFinalResidual() const { return lastFinalRes_; }
     double getLastSolutionMax()   const { return lastSolutionMax_; }
     bool   lastReturnedNullSolution() const { return nullSolutionReturned_; }
@@ -338,6 +344,13 @@ public:
             HYPRE_BoomerAMGSetPMaxElmts(precond_, amgPMax);
             HYPRE_BoomerAMGSetAggNumLevels(precond_, amgAgg);
             HYPRE_BoomerAMGSetNumSweeps(precond_, amgSweeps);
+            // Systems / point-block AMG: coarsen the N-DOF nodal block together
+            // (Hypre auto-builds dof_func = i % N for node-major interleaved DOFs).
+            if (pointBlock_ > 1) {
+                HYPRE_BoomerAMGSetNumFunctions(precond_, pointBlock_);
+                if (verbose_ && rank == 0)
+                    std::cout << "  [BoomerAMG] point-block NumFunctions=" << pointBlock_ << std::endl;
+            }
             HYPRE_BoomerAMGSetMaxLevels(precond_, 25);
             HYPRE_BoomerAMGSetMinCoarseSize(precond_, 32);  // avoid too-small coarse grid on small problems
             HYPRE_BoomerAMGSetMaxCoarseSize(precond_, 128); // upper bound on coarsest direct solve
@@ -861,6 +874,7 @@ private:
     // GMRES(k) restart length.
     int kDim_;
     bool useFlexGmres_ = false;  // FlexGMRES (varying precond) vs plain GMRES
+    int  pointBlock_   = 1;      // >1: systems/point-block BoomerAMG via SetNumFunctions
 };
 
 } // namespace fem

--- a/examples/distributed/unstructured/mars_coupled_model_operator.cu
+++ b/examples/distributed/unstructured/mars_coupled_model_operator.cu
@@ -26,6 +26,7 @@ using namespace mars::amr;
 // and resolve Tet4CVFEM / ElemTraits unqualified (header is not standalone).
 #include "backend/distributed/unstructured/fem/mars_fem_projection.hpp"
 #include "backend/distributed/unstructured/solvers/mars_acm_coarsen.hpp"  // ACM Stage 3 coarse-op + transfers
+#include "backend/distributed/unstructured/solvers/mars_acm_vcycle.hpp"   // ACM Stage 4a V-cycle
 
 #include <thrust/device_vector.h>
 #include <thrust/inner_product.h>
@@ -166,6 +167,7 @@ int main(int argc, char** argv)
     bool doSolve    = false;     // --solve: BC elimination + cusolverSp QR direct reference solve (implies --assemble)
     bool doHypre    = false;     // --hypre: Phase-1 1a -- Hypre point-block BoomerAMG GMRES iters vs cusolver ref (implies --assemble)
     bool doAcm3     = false;      // --acm-stage3: GPU coarse-operator + transfers vs host P^T A P (implies --assemble)
+    bool doAcm4     = false;      // --acm-stage4: GPU multilevel V-cycle vs host V-cycle replica (implies --assemble)
     double beta     = 45.0;      // --beta: skew-cavity angle (deg), used only for the --solve BC geometry
     int    Re       = 100;       // --Re: Reynolds number for the lid-driven solve (3b)
     int    picard   = 30;        // --picard: max Picard outer iterations
@@ -180,6 +182,7 @@ int main(int argc, char** argv)
         else if (a == "--solve")                  { doAssemble = true; doSolve  = true; }
         else if (a == "--hypre")                  { doAssemble = true; doHypre  = true; }
         else if (a == "--acm-stage3")             { doAssemble = true; doAcm3   = true; }
+        else if (a == "--acm-stage4")             { doAssemble = true; doAcm4   = true; }
         else if (a.rfind("--beta=", 0) == 0)        beta       = std::stod(a.substr(7));
         else if (a.rfind("--Re=", 0) == 0)          Re         = std::stoi(a.substr(5));
         else if (a.rfind("--picard=", 0) == 0)      picard     = std::stoi(a.substr(9));
@@ -509,6 +512,49 @@ int main(int argc, char** argv)
             std::cout << "[phase0][acm3] GPU restrict == host        : " << dRes    << "  " << pf2(dRes    < ctol) << "\n";
             std::cout << "[phase0][acm3] -> "
                       << ((dRecipe < ctol && dGal < ctol && dInj < ctol && dRes < ctol) ? "ALL PASS" : "FAIL") << "\n";
+        }
+
+        // ---- ACM Stage 4a: GPU multilevel V-cycle vs host V-cycle replica (one cycle, exact match) ----
+        if (doAcm4)
+        {
+            std::vector<AcmLevel<RealType>> levels;
+            acmBuildHierarchy<RealType>(d_rowOff, d_colInd, d_vals, (int)nNodes,
+                                        /*kmax=*/4, /*maxCoarseND=*/64, levels);
+
+            std::vector<RealType> hb(ND);
+            for (int i = 0; i < ND; ++i) hb[i] = std::sin(RealType(0.3) * i + RealType(0.5));   // deterministic test RHS
+
+            // GPU: one V-cycle on (b, x=0)
+            // coarsest = 10 Jacobi sweeps (the paper's value). NOTE: Jacobi is non-contractive on the
+            // indefinite coarse operator (it mildly amplifies) -- a Stage-4a stopgap; Algorithm A's
+            // direct coarsest solve (Stage 6) is the proper treatment, and GMRES (Stage 4b) makes the
+            // cycle effective regardless.
+            thrust::copy(hb.begin(), hb.end(), levels[0].bvec.begin());
+            thrust::fill(levels[0].xvec.begin(), levels[0].xvec.end(), RealType(0));
+            acmVcycleGpu<RealType>(levels, 0, /*pre=*/2, /*post=*/1, /*coarse=*/10, RealType(0.7));
+            cudaDeviceSynchronize();
+            std::vector<RealType> gx(ND);
+            thrust::copy(levels[0].xvec.begin(), levels[0].xvec.end(), gx.begin());
+
+            // host replica: same hierarchy + same arithmetic, one V-cycle on (b, x=0)
+            std::vector<AcmLevelHost<RealType>> hLevels;
+            acmHierarchyToHost<RealType>(levels, hLevels);
+            std::vector<RealType> hx(ND, RealType(0));
+            acmHostVcycle<RealType>(hLevels, 0, hx, hb, 2, 1, 10, RealType(0.7));
+
+            // GPU SpMV/Jacobi contract to FMA, the host does not -> compare RELATIVE to ||x|| (a logic
+            // bug gives O(1), not ~1e-9; this gate validates kernel correctness, not FP-bit-equality).
+            RealType dCycle = 0, mhx = 0;
+            for (int i = 0; i < ND; ++i) { dCycle = std::max(dCycle, std::abs(gx[i] - hx[i])); mhx = std::max(mhx, std::abs(hx[i])); }
+            const RealType dRel = dCycle / std::max(RealType(1e-30), mhx);
+
+            std::cout << "[phase0][acm4] V-cycle levels=" << levels.size() << "  sizes(ND):";
+            for (auto& L : levels) std::cout << " " << L.ND;
+            std::cout << "\n";
+            const RealType ctol = 1e-7;
+            std::cout << "[phase0][acm4] GPU V-cycle == host replica : abs=" << dCycle << " rel=" << dRel
+                      << "  " << (dRel < ctol ? "PASS" : "FAIL") << "\n";
+            std::cout << "[phase0][acm4] -> " << (dRel < ctol ? "ALL PASS" : "FAIL") << "\n";
         }
 
         // ---- Phase 1, 1a: Hypre point-block BoomerAMG GMRES (iters vs mesh) vs cusolver reference ----

--- a/examples/distributed/unstructured/mars_coupled_model_operator.cu
+++ b/examples/distributed/unstructured/mars_coupled_model_operator.cu
@@ -163,6 +163,7 @@ int main(int argc, char** argv)
     bool doAssemble = false;     // --assemble: also run the coupled Stokes block assembly + gates
     bool doAdvect   = false;     // --advect: add frozen-velocity convection into a^uu (implies --assemble)
     bool doSolve    = false;     // --solve: BC elimination + cusolverSp QR direct reference solve (implies --assemble)
+    bool doHypre    = false;     // --hypre: Phase-1 1a -- Hypre point-block BoomerAMG GMRES iters vs cusolver ref (implies --assemble)
     double beta     = 45.0;      // --beta: skew-cavity angle (deg), used only for the --solve BC geometry
     int    Re       = 100;       // --Re: Reynolds number for the lid-driven solve (3b)
     int    picard   = 30;        // --picard: max Picard outer iterations
@@ -175,6 +176,7 @@ int main(int argc, char** argv)
         else if (a == "--assemble")                 doAssemble = true;
         else if (a == "--advect")                 { doAssemble = true; doAdvect = true; }
         else if (a == "--solve")                  { doAssemble = true; doSolve  = true; }
+        else if (a == "--hypre")                  { doAssemble = true; doHypre  = true; }
         else if (a.rfind("--beta=", 0) == 0)        beta       = std::stod(a.substr(7));
         else if (a.rfind("--Re=", 0) == 0)          Re         = std::stoi(a.substr(5));
         else if (a.rfind("--picard=", 0) == 0)      picard     = std::stoi(a.substr(9));
@@ -422,6 +424,88 @@ int main(int argc, char** argv)
             assemblePass = (e1 < atol) && (e2 < atol) && (e3 < atol) && (e4 < atol);
         }
         std::cout << "[phase0][assemble] -> " << (assemblePass ? "ALL PASS" : "FAIL") << "\n";
+
+        // ---- Phase 1, 1a: Hypre point-block BoomerAMG GMRES (iters vs mesh) vs cusolver reference ----
+        if (doHypre)
+        {
+            const RealType nuS  = RealType(1) / static_cast<RealType>(Re);
+            const RealType hpar = RealType(1) / std::sqrt(static_cast<RealType>(nNodes) * RealType(0.5));
+            const RealType tauS = hpar * hpar / (RealType(4) * nuS);
+            // re-assemble Stokes (advection off; matches the host pyamg study)
+            thrust::fill(d_vals.begin(), d_vals.end(), RealType(0));
+            assembleCoupledStokesKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+                c0, c1, c2, c3, nx, ny, nz,
+                thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
+                thrust::raw_pointer_cast(d_vals.data()), nuS, tauS, nullptr, nullptr, nullptr,
+                startEl, numLocal);
+            cudaDeviceSynchronize();
+            // BC tags + eliminate (lid u=1 / walls / w=0 / pressure pin)
+            const double bb = beta * M_PI / 180.0;
+            const RealType sinb = std::sin(bb), cotb = std::cos(bb) / std::sin(bb), eps = 1e-6;
+            std::vector<uint8_t> bcF(ND, 0); std::vector<RealType> bcV(ND, RealType(0));
+            for (size_t i = 0; i < nNodes; ++i) {
+                RealType y0 = hy[i] / sinb, x0 = hx[i] - hy[i] * cotb;
+                bcF[4 * i + 2] = 1;
+                if (y0 > 1.0 - eps) { bcF[4 * i + 0] = 1; bcV[4 * i + 0] = RealType(1); bcF[4 * i + 1] = 1; }
+                else if (x0 < eps || x0 > 1.0 - eps || y0 < eps) { bcF[4 * i + 0] = 1; bcF[4 * i + 1] = 1; }
+            }
+            bcF[3] = 1;
+            thrust::device_vector<uint8_t> d_bcF(bcF.begin(), bcF.end());
+            thrust::device_vector<RealType> d_bcV(bcV.begin(), bcV.end());
+            thrust::device_vector<RealType> d_rhs(ND, RealType(0));
+            const int dblk = (ND + blockSize - 1) / blockSize;
+            applyBCKernel<RealType><<<dblk, blockSize>>>(
+                thrust::raw_pointer_cast(d_bcF.data()), thrust::raw_pointer_cast(d_bcV.data()),
+                thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
+                thrust::raw_pointer_cast(d_vals.data()), thrust::raw_pointer_cast(d_rhs.data()), ND);
+            cudaDeviceSynchronize();
+            // cusolver reference solution
+            thrust::device_vector<RealType> d_xref(ND, RealType(0));
+            { cusolverSpHandle_t cs = nullptr; cusolverSpCreate(&cs);
+              cusparseMatDescr_t de = nullptr; cusparseCreateMatDescr(&de);
+              cusparseSetMatType(de, CUSPARSE_MATRIX_TYPE_GENERAL);
+              cusparseSetMatIndexBase(de, CUSPARSE_INDEX_BASE_ZERO); int sg = -2;
+              cusolverSpDcsrlsvqr(cs, ND, nnz, de,
+                  thrust::raw_pointer_cast(d_vals.data()), thrust::raw_pointer_cast(d_rowOff.data()),
+                  thrust::raw_pointer_cast(d_colInd.data()), thrust::raw_pointer_cast(d_rhs.data()),
+                  1e-12, 1, thrust::raw_pointer_cast(d_xref.data()), &sg);
+              cudaDeviceSynchronize(); cusparseDestroyMatDescr(de); cusolverSpDestroy(cs); }
+            // Hypre point-block BoomerAMG + GMRES (wrap CSR into a SparseMatrix)
+            SparseMatrix<int, RealType, cstone::GpuTag> Am; Am.allocate(ND, ND, nnz);
+            thrust::copy(d_rowOff.begin(), d_rowOff.end(), thrust::device_pointer_cast(Am.rowOffsetsPtr()));
+            thrust::copy(d_colInd.begin(), d_colInd.end(), thrust::device_pointer_cast(Am.colIndicesPtr()));
+            thrust::copy(d_vals.begin(),   d_vals.end(),   thrust::device_pointer_cast(Am.valuesPtr()));
+            cstone::DeviceVector<RealType> bH, xH; bH.resize(ND); xH.resize(ND);
+            thrust::copy(d_rhs.begin(), d_rhs.end(), thrust::device_pointer_cast(bH.data()));
+            HypreGMRESSolver<RealType, int, cstone::GpuTag> hg(
+                MPI_COMM_WORLD, 1000, 1e-8,
+                HypreGMRESSolver<RealType, int, cstone::GpuTag>::BOOMERAMG, 50);
+            hg.setVerbose(false);
+            hg.setPointBlock(4);
+            hg.solve(Am, bH, xH, 0, ND, 0, ND, std::vector<int>{});
+            const int iters = hg.getLastIterations();
+            // compare to cusolver reference (guards the false-x=0 convergence mode)
+            thrust::device_vector<RealType> d_xh(ND), d_df(ND);
+            thrust::copy(thrust::device_pointer_cast(xH.data()),
+                         thrust::device_pointer_cast(xH.data() + ND), d_xh.begin());
+            thrust::transform(d_xh.begin(), d_xh.end(), d_xref.begin(), d_df.begin(),
+                [] __device__ (RealType a, RealType c) { return fabs(a - c); });
+            RealType dmax = thrust::reduce(d_df.begin(), d_df.end(), RealType(0), thrust::maximum<RealType>());
+            thrust::transform(d_xref.begin(), d_xref.end(), d_df.begin(),
+                [] __device__ (RealType c) { return fabs(c); });
+            RealType rmax = thrust::reduce(d_df.begin(), d_df.end(), RealType(0), thrust::maximum<RealType>());
+            RealType rel = dmax / (rmax > 0 ? rmax : RealType(1));
+            // rel guards the false-x=0 collapse (rel~1 = AMG returned ~0). A real
+            // GMRES solve to a 1e-8 RESIDUAL tol on a kappa-growing saddle operator
+            // legitimately differs from the direct solve by ~kappa*1e-8, so allow a
+            // generous band; it is NOT a precision check.
+            bool hyOk = (iters > 0) && (rel < 5e-2);
+            std::cout << std::scientific << std::setprecision(3);
+            std::cout << "[phase0][hypre] Re=" << Re << " point-block BoomerAMG GMRES iters=" << iters
+                      << " nnz=" << nnz << " |x_hypre-x_qr|rel=" << rel
+                      << "  -> " << (hyOk ? "PASS (converged + matches reference)" : "CHECK") << "\n";
+            assemblePass = assemblePass && hyOk;
+        }
 
         // ---- 3b: Picard loop + cusolverSp QR direct reference solve + benchmark match ----
         if (doSolve)

--- a/examples/distributed/unstructured/mars_coupled_model_operator.cu
+++ b/examples/distributed/unstructured/mars_coupled_model_operator.cu
@@ -25,6 +25,7 @@ using namespace mars::amr;
 // Must follow the usings: the projection kernels live in the global namespace
 // and resolve Tet4CVFEM / ElemTraits unqualified (header is not standalone).
 #include "backend/distributed/unstructured/fem/mars_fem_projection.hpp"
+#include "backend/distributed/unstructured/solvers/mars_acm_coarsen.hpp"  // ACM Stage 3 coarse-op + transfers
 
 #include <thrust/device_vector.h>
 #include <thrust/inner_product.h>
@@ -164,6 +165,7 @@ int main(int argc, char** argv)
     bool doAdvect   = false;     // --advect: add frozen-velocity convection into a^uu (implies --assemble)
     bool doSolve    = false;     // --solve: BC elimination + cusolverSp QR direct reference solve (implies --assemble)
     bool doHypre    = false;     // --hypre: Phase-1 1a -- Hypre point-block BoomerAMG GMRES iters vs cusolver ref (implies --assemble)
+    bool doAcm3     = false;      // --acm-stage3: GPU coarse-operator + transfers vs host P^T A P (implies --assemble)
     double beta     = 45.0;      // --beta: skew-cavity angle (deg), used only for the --solve BC geometry
     int    Re       = 100;       // --Re: Reynolds number for the lid-driven solve (3b)
     int    picard   = 30;        // --picard: max Picard outer iterations
@@ -177,6 +179,7 @@ int main(int argc, char** argv)
         else if (a == "--advect")                 { doAssemble = true; doAdvect = true; }
         else if (a == "--solve")                  { doAssemble = true; doSolve  = true; }
         else if (a == "--hypre")                  { doAssemble = true; doHypre  = true; }
+        else if (a == "--acm-stage3")             { doAssemble = true; doAcm3   = true; }
         else if (a.rfind("--beta=", 0) == 0)        beta       = std::stod(a.substr(7));
         else if (a.rfind("--Re=", 0) == 0)          Re         = std::stoi(a.substr(5));
         else if (a.rfind("--picard=", 0) == 0)      picard     = std::stoi(a.substr(9));
@@ -424,6 +427,89 @@ int main(int argc, char** argv)
             assemblePass = (e1 < atol) && (e2 < atol) && (e3 < atol) && (e4 < atol);
         }
         std::cout << "[phase0][assemble] -> " << (assemblePass ? "ALL PASS" : "FAIL") << "\n";
+
+        // ---- ACM Stage 3: GPU coarse-operator (sum-of-fine == P^T A P) + grid transfers ----
+        if (doAcm3)
+        {
+            // host-once aggregation (node-granular, greedy over the 1-ring). The map is an INPUT to
+            // Stage 3 -- any valid map validates the GPU coarse-operator recipe; the GPU directional
+            // aggregation is Stage 5.
+            const int KMAX = 4;
+            std::vector<int> agg(nNodes, -1);
+            int nCoarse = 0;
+            for (size_t i = 0; i < nNodes; ++i) {
+                if (agg[i] != -1) continue;
+                agg[i] = nCoarse; int cnt = 1;
+                for (int j : ring[i]) {
+                    if (cnt >= KMAX) break;
+                    if (j != (int)i && agg[j] == -1) { agg[j] = nCoarse; ++cnt; }
+                }
+                ++nCoarse;
+            }
+            const int NDc = 4 * nCoarse;
+
+            thrust::device_vector<int> d_agg(agg.begin(), agg.end());
+            thrust::device_vector<int> d_crowOff, d_ccolInd;
+            thrust::device_vector<RealType> d_cvals;
+            buildCoarseOperator<RealType>(d_rowOff, d_colInd, d_vals, d_agg,
+                                          (int)nNodes, nCoarse, d_crowOff, d_ccolInd, d_cvals);
+
+            // host reference: the same map applied to the fine CSR by an independent accumulation
+            auto cdof = [&](int r) { return 4 * agg[r >> 2] + (r & 3); };
+            std::map<std::pair<int, int>, RealType> Aref;
+            for (int r = 0; r < ND; ++r)
+                for (int k = h_rowOff[r]; k < h_rowOff[r + 1]; ++k)
+                    Aref[{cdof(r), cdof(h_colInd[k])}] += hv[k];
+
+            const int ccnnz = (int)d_cvals.size();
+            std::vector<int> hcrow(NDc + 1), hccol(ccnnz);
+            std::vector<RealType> hcval(ccnnz);
+            thrust::copy(d_crowOff.begin(), d_crowOff.end(), hcrow.begin());
+            thrust::copy(d_ccolInd.begin(), d_ccolInd.end(), hccol.begin());
+            thrust::copy(d_cvals.begin(),   d_cvals.end(),   hcval.begin());
+            std::map<std::pair<int, int>, RealType> Agpu;
+            for (int r = 0; r < NDc; ++r)
+                for (int k = hcrow[r]; k < hcrow[r + 1]; ++k) Agpu[{r, hccol[k]}] = hcval[k];
+            RealType dRecipe = 0;
+            for (auto& kv : Aref) { auto it = Agpu.find(kv.first); dRecipe = std::max(dRecipe, std::abs(kv.second - (it == Agpu.end() ? RealType(0) : it->second))); }
+            for (auto& kv : Agpu) { auto it = Aref.find(kv.first); dRecipe = std::max(dRecipe, std::abs(kv.second - (it == Aref.end() ? RealType(0) : it->second))); }
+
+            // Galerkin consistency: P^T (A (P x)) == A_coarse x for a random coarse x (host)
+            std::vector<RealType> xc(NDc), xf(ND, 0), yf(ND, 0), yc(NDc, 0), zc(NDc, 0), rc(NDc, 0);
+            for (int i = 0; i < NDc; ++i) xc[i] = std::sin(RealType(0.7) * i + RealType(1));
+            for (size_t i = 0; i < nNodes; ++i) for (int c = 0; c < 4; ++c) xf[4 * i + c] = xc[4 * agg[i] + c];   // P xc
+            for (size_t i = 0; i < nNodes; ++i) for (int c = 0; c < 4; ++c) rc[4 * agg[i] + c] += xf[4 * i + c];  // P^T xf (restrict-kernel ref)
+            for (int r = 0; r < ND; ++r) { RealType s = 0; for (int k = h_rowOff[r]; k < h_rowOff[r + 1]; ++k) s += hv[k] * xf[h_colInd[k]]; yf[r] = s; }  // A xf
+            for (size_t i = 0; i < nNodes; ++i) for (int c = 0; c < 4; ++c) yc[4 * agg[i] + c] += yf[4 * i + c];  // P^T A xf
+            for (auto& kv : Aref) zc[kv.first.first] += kv.second * xc[kv.first.second];                          // A_coarse xc
+            RealType dGal = 0; for (int i = 0; i < NDc; ++i) dGal = std::max(dGal, std::abs(yc[i] - zc[i]));
+
+            // GPU transfer kernels vs host (injection prolongation + sum restriction)
+            thrust::device_vector<RealType> d_xc(xc.begin(), xc.end()), d_xf(ND, RealType(0)), d_yc(NDc, RealType(0));
+            int nb = ((int)nNodes + blockSize - 1) / blockSize;
+            acmInjectKernel<RealType><<<nb, blockSize>>>(thrust::raw_pointer_cast(d_xc.data()),
+                thrust::raw_pointer_cast(d_xf.data()), thrust::raw_pointer_cast(d_agg.data()), (int)nNodes);
+            acmRestrictAddKernel<RealType><<<nb, blockSize>>>(thrust::raw_pointer_cast(d_xf.data()),
+                thrust::raw_pointer_cast(d_yc.data()), thrust::raw_pointer_cast(d_agg.data()), (int)nNodes);
+            cudaDeviceSynchronize();
+            std::vector<RealType> gxf(ND), gyc(NDc);
+            thrust::copy(d_xf.begin(), d_xf.end(), gxf.begin());
+            thrust::copy(d_yc.begin(), d_yc.end(), gyc.begin());
+            RealType dInj = 0, dRes = 0;
+            for (int i = 0; i < ND;  ++i) dInj = std::max(dInj, std::abs(gxf[i] - xf[i]));
+            for (int i = 0; i < NDc; ++i) dRes = std::max(dRes, std::abs(gyc[i] - rc[i]));
+
+            const RealType ctol = 1e-10;
+            auto pf2 = [&](bool ok) { return ok ? "PASS" : "FAIL"; };
+            std::cout << "[phase0][acm3] fine DOFs=" << ND << " -> coarse DOFs=" << NDc
+                      << " (aggregates=" << nCoarse << ", coarse nnz=" << ccnnz << ")\n";
+            std::cout << "[phase0][acm3] GPU coarse == host P^T A P : " << dRecipe << "  " << pf2(dRecipe < ctol) << "\n";
+            std::cout << "[phase0][acm3] Galerkin P^T A P x == Ac x : " << dGal    << "  " << pf2(dGal    < ctol) << "\n";
+            std::cout << "[phase0][acm3] GPU inject == host          : " << dInj    << "  " << pf2(dInj    < ctol) << "\n";
+            std::cout << "[phase0][acm3] GPU restrict == host        : " << dRes    << "  " << pf2(dRes    < ctol) << "\n";
+            std::cout << "[phase0][acm3] -> "
+                      << ((dRecipe < ctol && dGal < ctol && dInj < ctol && dRes < ctol) ? "ALL PASS" : "FAIL") << "\n";
+        }
 
         // ---- Phase 1, 1a: Hypre point-block BoomerAMG GMRES (iters vs mesh) vs cusolver reference ----
         if (doHypre)

--- a/examples/distributed/unstructured/mars_coupled_model_operator.cu
+++ b/examples/distributed/unstructured/mars_coupled_model_operator.cu
@@ -27,6 +27,8 @@ using namespace mars::amr;
 #include "backend/distributed/unstructured/fem/mars_fem_projection.hpp"
 #include "backend/distributed/unstructured/solvers/mars_acm_coarsen.hpp"  // ACM Stage 3 coarse-op + transfers
 #include "backend/distributed/unstructured/solvers/mars_acm_vcycle.hpp"   // ACM Stage 4a V-cycle
+#include "backend/distributed/unstructured/solvers/mars_gpu_acm_preconditioner.hpp"  // ACM Stage 4b precond
+#include "backend/distributed/unstructured/solvers/mars_gmres_solver.hpp"            // native (Flex)GMRES
 
 #include <thrust/device_vector.h>
 #include <thrust/inner_product.h>
@@ -168,6 +170,7 @@ int main(int argc, char** argv)
     bool doHypre    = false;     // --hypre: Phase-1 1a -- Hypre point-block BoomerAMG GMRES iters vs cusolver ref (implies --assemble)
     bool doAcm3     = false;      // --acm-stage3: GPU coarse-operator + transfers vs host P^T A P (implies --assemble)
     bool doAcm4     = false;      // --acm-stage4: GPU multilevel V-cycle vs host V-cycle replica (implies --assemble)
+    bool doAcm4b    = false;      // --acm-stage4b: ACM-preconditioned FlexGMRES iters vs 1a baseline + cusolver ref
     double beta     = 45.0;      // --beta: skew-cavity angle (deg), used only for the --solve BC geometry
     int    Re       = 100;       // --Re: Reynolds number for the lid-driven solve (3b)
     int    picard   = 30;        // --picard: max Picard outer iterations
@@ -183,6 +186,7 @@ int main(int argc, char** argv)
         else if (a == "--hypre")                  { doAssemble = true; doHypre  = true; }
         else if (a == "--acm-stage3")             { doAssemble = true; doAcm3   = true; }
         else if (a == "--acm-stage4")             { doAssemble = true; doAcm4   = true; }
+        else if (a == "--acm-stage4b")            { doAssemble = true; doAcm4b  = true; }
         else if (a.rfind("--beta=", 0) == 0)        beta       = std::stod(a.substr(7));
         else if (a.rfind("--Re=", 0) == 0)          Re         = std::stoi(a.substr(5));
         else if (a.rfind("--picard=", 0) == 0)      picard     = std::stoi(a.substr(9));
@@ -557,8 +561,9 @@ int main(int argc, char** argv)
             std::cout << "[phase0][acm4] -> " << (dRel < ctol ? "ALL PASS" : "FAIL") << "\n";
         }
 
-        // ---- Phase 1, 1a: Hypre point-block BoomerAMG GMRES (iters vs mesh) vs cusolver reference ----
-        if (doHypre)
+        // ---- Phase 1 1a (Hypre point-block) + ACM Stage 4b (FlexGMRES): shared BC-eliminated
+        //      Stokes operator + cusolverSp QR reference, then each solver's own benchmark ----
+        if (doHypre || doAcm4b)
         {
             const RealType nuS  = RealType(1) / static_cast<RealType>(Re);
             const RealType hpar = RealType(1) / std::sqrt(static_cast<RealType>(nNodes) * RealType(0.5));
@@ -602,11 +607,15 @@ int main(int argc, char** argv)
                   thrust::raw_pointer_cast(d_colInd.data()), thrust::raw_pointer_cast(d_rhs.data()),
                   1e-12, 1, thrust::raw_pointer_cast(d_xref.data()), &sg);
               cudaDeviceSynchronize(); cusparseDestroyMatDescr(de); cusolverSpDestroy(cs); }
-            // Hypre point-block BoomerAMG + GMRES (wrap CSR into a SparseMatrix)
+            // wrap the BC-eliminated CSR into a SparseMatrix (shared by the Hypre + ACM solves)
             SparseMatrix<int, RealType, cstone::GpuTag> Am; Am.allocate(ND, ND, nnz);
             thrust::copy(d_rowOff.begin(), d_rowOff.end(), thrust::device_pointer_cast(Am.rowOffsetsPtr()));
             thrust::copy(d_colInd.begin(), d_colInd.end(), thrust::device_pointer_cast(Am.colIndicesPtr()));
             thrust::copy(d_vals.begin(),   d_vals.end(),   thrust::device_pointer_cast(Am.valuesPtr()));
+
+            if (doHypre)
+            {
+            // Hypre point-block BoomerAMG + GMRES
             cstone::DeviceVector<RealType> bH, xH; bH.resize(ND); xH.resize(ND);
             thrust::copy(d_rhs.begin(), d_rhs.end(), thrust::device_pointer_cast(bH.data()));
             HypreGMRESSolver<RealType, int, cstone::GpuTag> hg(
@@ -637,6 +646,75 @@ int main(int argc, char** argv)
                       << " nnz=" << nnz << " |x_hypre-x_qr|rel=" << rel
                       << "  -> " << (hyOk ? "PASS (converged + matches reference)" : "CHECK") << "\n";
             assemblePass = assemblePass && hyOk;
+            }  // if (doHypre)
+
+            // ---- ACM Stage 4b: ACM-preconditioned native FlexGMRES vs the 1a baseline + cusolver ref ----
+            if (doAcm4b)
+            {
+                using Vec = cstone::DeviceVector<RealType>;
+                Vec bvec; bvec.resize(ND);
+                thrust::copy(d_rhs.begin(), d_rhs.end(), thrust::device_pointer_cast(bvec.data()));
+
+                // max|x_xref| for the relative-error denominator
+                thrust::device_vector<RealType> d_absref(ND);
+                thrust::transform(d_xref.begin(), d_xref.end(), d_absref.begin(),
+                    [] __device__ (RealType c) { return fabs(c); });
+                const RealType rmax = thrust::reduce(d_absref.begin(), d_absref.end(), RealType(0), thrust::maximum<RealType>());
+                auto relErr = [&](Vec& xv) -> RealType {
+                    thrust::device_vector<RealType> xt(ND);
+                    thrust::copy(thrust::device_pointer_cast(xv.data()),
+                                 thrust::device_pointer_cast(xv.data() + ND), xt.begin());
+                    thrust::transform(xt.begin(), xt.end(), d_xref.begin(), xt.begin(),
+                        [] __device__ (RealType a, RealType c) { return fabs(a - c); });
+                    RealType dmax = thrust::reduce(xt.begin(), xt.end(), RealType(0), thrust::maximum<RealType>());
+                    return dmax / (rmax > 0 ? rmax : RealType(1));
+                };
+
+                std::cout << std::scientific << std::setprecision(3);
+
+                // GATE 1 (Z-basis correctness): with an IDENTITY preconditioner, flexible GMRES must
+                // reduce EXACTLY to plain GMRES (Z_j=V_j, x=x0+Z y = x0+V y) -- a convergence-independent
+                // algebraic identity. A Z-basis reconstruction bug breaks this even if neither converges.
+                // (Jacobi is too weak to converge on this indefinite saddle operator, so it cannot be the
+                // oracle; identity can.)
+                Vec xp; xp.resize(ND);
+                GMRESSolver<RealType, int, cstone::GpuTag> gp(2000, 1e-8, 30);
+                gp.setVerbose(false); gp.solve(Am, bvec, xp, false);            // plain (unpreconditioned)
+                const int itP = gp.getLastIterations();
+                IdentityPreconditioner<RealType, int, cstone::GpuTag> id;
+                Vec xi; xi.resize(ND);
+                GMRESSolver<RealType, int, cstone::GpuTag> gi(2000, 1e-8, 30);
+                gi.setVerbose(false); gi.setPreconditioner(&id); gi.setFlexible(true);
+                gi.solve(Am, bvec, xi, true);                                   // flexible, M = I
+                const int itI = gi.getLastIterations();
+                thrust::device_vector<RealType> xpv(ND), xiv(ND);
+                thrust::copy(thrust::device_pointer_cast(xp.data()), thrust::device_pointer_cast(xp.data() + ND), xpv.begin());
+                thrust::copy(thrust::device_pointer_cast(xi.data()), thrust::device_pointer_cast(xi.data() + ND), xiv.begin());
+                thrust::transform(xpv.begin(), xpv.end(), xiv.begin(), xiv.begin(),
+                    [] __device__ (RealType a, RealType b) { return fabs(a - b); });
+                const RealType ddiff = thrust::reduce(xiv.begin(), xiv.end(), RealType(0), thrust::maximum<RealType>());
+                thrust::transform(xpv.begin(), xpv.end(), xpv.begin(), [] __device__ (RealType a) { return fabs(a); });
+                const RealType dpmax = thrust::reduce(xpv.begin(), xpv.end(), RealType(0), thrust::maximum<RealType>());
+                const RealType relZ = ddiff / (dpmax > 0 ? dpmax : RealType(1));
+                const bool gate1 = (itP == itI) && (relZ < 1e-10);
+                std::cout << "[phase0][acm4b][gate1] FGMRES(I)==plain GMRES (Z-basis): iters " << itP << "/" << itI
+                          << " rel=" << relZ << "  -> " << (gate1 ? "PASS" : "FAIL") << "\n";
+
+                // GATE 2 (ACM quality): ACM-preconditioned FlexGMRES converges to the reference.
+                GpuAcmPreconditioner<RealType, int, cstone::GpuTag> acm;
+                Vec xa; xa.resize(ND);
+                GMRESSolver<RealType, int, cstone::GpuTag> ga(2000, 1e-8, 30);
+                ga.setVerbose(false); ga.setPreconditioner(&acm); ga.setFlexible(true);
+                ga.solve(Am, bvec, xa, true);
+                const int itA = ga.getLastIterations();
+                const RealType relA = relErr(xa);
+                const bool gate2 = (itA > 0) && (itA < 1980) && (relA < 5e-2);   // converged (< maxIter) + correct
+                std::cout << "[phase0][acm4b] Re=" << Re << " ACM-FlexGMRES iters=" << itA
+                          << " (Hypre 1a baseline n16/32/64 = 13/19/39) levels=" << acm.numLevels()
+                          << " |x_acm-x_qr|rel=" << relA
+                          << "  -> " << (gate1 && gate2 ? "PASS" : "CHECK") << "\n";
+                assemblePass = assemblePass && gate1 && gate2;
+            }
         }
 
         // ---- 3b: Picard loop + cusolverSp QR direct reference solve + benchmark match ----

--- a/scripts/acm_smoother_study.py
+++ b/scripts/acm_smoother_study.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""ACM host-prototype (Phase 1c de-risk): can a GPU-friendly polynomial smoother give the
+mesh-INDEPENDENCE that l1-Jacobi cannot?
+
+1a showed Hypre point-block BoomerAMG converges but grows ~x3 with mesh, because the only
+GPU-viable Hypre smoother is weak l1-Jacobi (strong GS is a no-op on GPU). The GPU ACM's
+plan is unsmoothed agglomeration (sum-of-fine + injection, the darwish2008 form) + a
+GPU-friendly smoother. This tests, on the SAME coupled cavity operator, the ACM family
+(pyamg smooth=None = injection) under two smoothers:
+
+  ACM+Jacobi  : weighted Jacobi (mimics the GPU BoomerAMG l1-Jacobi ceiling) -> expect growth
+  ACM+Cheby   : Chebyshev polynomial (runs fine on GPU; matvec-only) -> expect flat
+
+If ACM+Cheby is flat where ACM+Jacobi grows, the GPU ACM's smoother choice is justified and
+it will beat the 1a baseline. (pyamg signal; definitive answer is the GPU ACM build.)
+Run: /tmp/p1env/bin/python scripts/acm_smoother_study.py
+"""
+import importlib.util
+import numpy as np
+import pyamg
+
+spec = importlib.util.spec_from_file_location("p1", "scripts/phase1_precond_study.py")
+p1 = importlib.util.module_from_spec(spec); spec.loader.exec_module(p1)   # reuses build()/gmres_iters()/_block_B()
+
+JAC  = ('jacobi',    {'iterations': 2, 'omega': 4.0 / 3.0})   # weak, ~ GPU l1-Jacobi
+CHEB = ('chebyshev', {'degree': 3, 'iterations': 1})          # polynomial, GPU-friendly
+
+
+def acm(A, smoother):
+    # smooth=None -> unsmoothed aggregation = injection prolongation + sum-of-fine coarse
+    # = additive-correction agglomeration MG (the darwish2008 ACM form), block near-null-space.
+    return pyamg.smoothed_aggregation_solver(
+        A, B=p1._block_B(A.shape[0]), smooth=None, max_coarse=50,
+        presmoother=smoother, postsmoother=smoother).aspreconditioner('V')
+
+
+def run():
+    ns = [16, 24, 32, 40]
+    mats = {n: p1.build(n) for n in ns}
+    print(f"{'precond':<14} " + "  ".join(f"n={n}" for n in ns))
+    rows = {}
+    for name, sm in [("ACM+Jacobi", JAC), ("ACM+Cheby", CHEB)]:
+        out = []
+        for n in ns:
+            A, b = mats[n]
+            try:
+                out.append(p1.gmres_iters(A, b, M=acm(A, sm)))
+            except Exception as e:
+                out.append(f"ERR:{type(e).__name__}")
+        rows[name] = out
+        print(f"{name:<14} " + "  ".join(f"{str(v):>5}" for v in out))
+
+    print()
+    for name in ["ACM+Jacobi", "ACM+Cheby"]:
+        v = rows[name]
+        if all(isinstance(x, int) and x > 0 for x in v):
+            g = v[-1] / max(1, v[0])
+            print(f"[verdict] {name}: {v} -> {'MESH-INDEPENDENT' if g < 1.6 else 'grows'} (x{g:.1f})")
+        else:
+            print(f"[verdict] {name}: {v} -> errored")
+    print("[note] If ACM+Cheby is flat where ACM+Jacobi grows, the GPU ACM's polynomial-smoother")
+    print("       choice recovers the mesh-independence stock GPU BoomerAMG (l1-Jacobi) cannot.")
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/acm_stage0_galerkin_gate.py
+++ b/scripts/acm_stage0_galerkin_gate.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""ACM Stage 0 (host, NO-REGRET): directional aggregation + Galerkin-equivalence gate.
+
+Proves the load-bearing algebra before any GPU code: that the paper's Eq.27-28 sum-of-fine
+coarse operator (which the GPU builds by segmented-reduce over fine nonzeros grouped by
+parent-aggregate) equals P^T A P bit-for-bit for a 0/1 block aggregate-membership P. If these
+disagree, the GPU coarse-operator design (Stage 3) is wrong.
+
+Builds the directional-P from the paper's criterion (Eqs 19-20, beta=0.5) with a GEOMETRIC
+node-dual face weight |S_ij| = sum over triangles sharing edge (i,j) of |centroid - edge_mid|
+(the median-dual SCS face length -- the legitimate node-centered analog of the paper's
+cell-centered |face normal|, honestly labeled; NOT a bare FEM-edge proxy).
+
+Reuses coupled_cavity_reference (skew_mesh) + phase1_precond_study (build = assembled coupled
+[u,v,p] Stokes operator). Run: /tmp/p1env/bin/python scripts/acm_stage0_galerkin_gate.py
+"""
+import importlib.util
+import numpy as np
+import scipy.sparse as sp
+
+spec = importlib.util.spec_from_file_location("p1", "scripts/phase1_precond_study.py")
+p1 = importlib.util.module_from_spec(spec); spec.loader.exec_module(p1)
+cav = p1.cav
+
+BETA = 0.5
+KMAX = 4         # paper fuses up to k_max-1 neighbors into a seed -> ~4 nodes/aggregate
+NDOF = 3         # cavity is [u,v,p]
+
+
+def dual_face_weights(P, tris):
+    """omega[(i,j)] = median-dual SCS face length between nodes i,j (node-dual |S| analog)."""
+    w = {}
+    for t in tris:
+        c = P[t].mean(axis=0)                      # triangle centroid
+        for a, b in ((t[0], t[1]), (t[1], t[2]), (t[2], t[0])):
+            mid = 0.5 * (P[a] + P[b])
+            seg = np.linalg.norm(c - mid)          # SCS dual-face contribution from this triangle
+            key = (min(a, b), max(a, b))
+            w[key] = w.get(key, 0.0) + seg
+    return w
+
+
+def adjacency(w, N):
+    nb = [[] for _ in range(N)]
+    for (i, j) in w:
+        nb[i].append(j); nb[j].append(i)
+    return nb
+
+
+def directional_aggregate(P, tris):
+    """Faithful seed-growth (Eqs 19-20, beta=0.5, k_max), node-granular. Returns agg[node]."""
+    N = len(P)
+    w = dual_face_weights(P, tris)
+    nb = adjacency(w, N)
+    wij = lambda i, j: w[(min(i, j), max(i, j))]
+    wmax = np.array([max((wij(i, j) for j in nb[i]), default=0.0) for i in range(N)])
+    strong = lambda i, j: (wij(i, j) > BETA * wmax[i]) and (wij(i, j) > BETA * wmax[j])
+
+    agg = np.full(N, -1, dtype=np.int64)
+    naggr = 0
+    for seed in range(N):
+        if agg[seed] != -1:
+            continue
+        agg[seed] = naggr
+        count = 1
+        # fuse strong, non-aggregated neighbors of the seed up to k_max-1
+        for j in nb[seed]:
+            if count >= KMAX:
+                break
+            if agg[j] == -1 and strong(seed, j):
+                agg[j] = naggr; count += 1
+        naggr += 1
+
+    # cleanup: leftover nodes join a neighboring aggregate (strong if possible, else any)
+    for i in range(N):
+        if agg[i] != -1:
+            continue
+        cand = [agg[j] for j in nb[i] if agg[j] != -1 and strong(i, j)]
+        if not cand:
+            cand = [agg[j] for j in nb[i] if agg[j] != -1]
+        agg[i] = cand[0] if cand else naggr
+        if not cand:
+            naggr += 1
+    return agg, naggr
+
+
+def block_P(agg, naggr, ndof=NDOF):
+    """0/1 block aggregate-membership: fine dof (ndof*node+c) -> coarse dof (ndof*I+c)."""
+    N = len(agg)
+    rows = np.arange(ndof * N)
+    cols = np.array([ndof * agg[r // ndof] + (r % ndof) for r in rows])
+    return sp.csr_matrix((np.ones(ndof * N), (rows, cols)), shape=(ndof * N, ndof * naggr))
+
+
+def sumfine_coarse(A, agg, naggr, ndof=NDOF):
+    """Eq.27-28 the GPU way: segmented reduce of fine nonzeros by (parent(row),parent(col))."""
+    Ac = A.tocoo()
+    dof2cdof = lambda d: ndof * agg[d // ndof] + (d % ndof)
+    cr = np.array([dof2cdof(r) for r in Ac.row])
+    cc = np.array([dof2cdof(c) for c in Ac.col])
+    nC = ndof * naggr
+    return sp.coo_matrix((Ac.data, (cr, cc)), shape=(nC, nC)).tocsr()
+
+
+def run():
+    for n in [16, 24, 32]:
+        Pc, tris = cav.skew_mesh(n, 45.0)
+        A, rhs = p1.build(n)                       # assembled coupled Stokes operator + RHS
+        agg, naggr = directional_aggregate(Pc, tris)
+
+        P = block_P(agg, naggr)
+        A_ptap = (P.T @ A @ P).tocsr()
+        A_sum = sumfine_coarse(A, agg, naggr)
+        d_A = abs((A_ptap - A_sum)).max()
+
+        r = rhs - A @ np.zeros(A.shape[0])         # residual at x=0 = rhs
+        B_ptap = P.T @ r
+        B_sum = np.zeros(NDOF * naggr)
+        np.add.at(B_sum, np.array([NDOF * agg[d // NDOF] + (d % NDOF) for d in range(len(r))]), r)
+        d_B = abs(B_ptap - B_sum).max()
+
+        ratio = len(Pc) / naggr
+        ok = (d_A < 1e-12) and (d_B < 1e-12)
+        print(f"n={n:<3} nodes={len(Pc):<5} aggregates={naggr:<5} coarsening={ratio:4.2f}x  "
+              f"|PtAP - sumfine|={d_A:.2e}  |Ptr - sumfine_r|={d_B:.2e}  -> {'PASS' if ok else 'FAIL'}")
+    print("[gate] sum-of-fine (Eq.27-28, the GPU segmented-reduce recipe) == P^T A P for 0/1 block P.")
+    print("[note] directional edge is NOT tested here (isotropic cavity) -- that is Stage 2 on a stretched mesh.")
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/acm_stage1_vcycle.py
+++ b/scripts/acm_stage1_vcycle.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""ACM Stage 1 (host): full paper V-cycle as a preconditioner; faithfulness check.
+
+Builds the multilevel hierarchy faithfully (directional aggregation -> sum-of-fine Galerkin
+coarse [proven == P^T A P in Stage 0] -> order-zero injection / sum transfers), smooths with a
+TRUE per-node block-Jacobi (the GPU-forced replacement for ILU(0)), and runs it as a GMRES
+preconditioner. (The fixed-smoother V-cycle is a stationary linear operator, so plain
+preconditioned GMRES is the correct host check; FlexGMRES is only needed on the GPU where the
+cycle becomes non-stationary.)
+
+GATE (this is a faithfulness check, NOT a win):
+  - block-Jacobi V-cycle must REPRODUCE the known isotropic unsmoothed growth (~x1.7-2.0) --
+    the replica is faithful, not magically flat;
+  - point-Jacobi must be much worse / diverge (confirms block-Jacobi is mandatory on the saddle
+    block where the pressure diagonal is ~0);
+  - coarse per-node diagonal blocks must be invertible (singular coarse blocks = a known
+    unsmoothed-aggregation failure mode).
+
+Reuses Stage 0 (aggregation, block_P) + phase1_precond_study (build). Levels >=1 use the paper's
+algebraic 'mutual coefficients' strength (block Frobenius norm) since no geometry survives.
+Run: /tmp/p1env/bin/python scripts/acm_stage1_vcycle.py
+"""
+import importlib.util
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+
+s0spec = importlib.util.spec_from_file_location("s0", "scripts/acm_stage0_galerkin_gate.py")
+s0 = importlib.util.module_from_spec(s0spec); s0spec.loader.exec_module(s0)
+p1, cav = s0.p1, s0.cav
+NDOF, BETA, KMAX = s0.NDOF, s0.BETA, s0.KMAX
+MAX_COARSE = 60          # direct solve below this many DOFs (Algorithm-A coarsest)
+
+
+def algebraic_weights(A, ndof):
+    """Level>=1 strength: omega_IJ = ||block_IJ||_F (paper's 'mutual coefficients' route)."""
+    Ac = A.tocoo()
+    nB = A.shape[0] // ndof
+    acc = {}
+    for r, c, v in zip(Ac.row, Ac.col, Ac.data):
+        I, J = r // ndof, c // ndof
+        if I == J:
+            continue
+        key = (min(I, J), max(I, J))
+        acc[key] = acc.get(key, 0.0) + v * v
+    return {k: np.sqrt(s) for k, s in acc.items()}
+
+
+def aggregate(weights, N):
+    """Faithful seed-growth on a generic strength graph (Eqs 19-20, beta=0.5, k_max)."""
+    nb = s0.adjacency(weights, N)
+    wij = lambda i, j: weights[(min(i, j), max(i, j))]
+    wmax = np.array([max((wij(i, j) for j in nb[i]), default=0.0) for i in range(N)])
+    strong = lambda i, j: (wij(i, j) > BETA * wmax[i]) and (wij(i, j) > BETA * wmax[j])
+    agg = np.full(N, -1, np.int64); k = 0
+    for seed in range(N):
+        if agg[seed] != -1:
+            continue
+        agg[seed] = k; cnt = 1
+        for j in nb[seed]:
+            if cnt >= KMAX:
+                break
+            if agg[j] == -1 and strong(seed, j):
+                agg[j] = k; cnt += 1
+        k += 1
+    for i in range(N):
+        if agg[i] != -1:
+            continue
+        cand = [agg[j] for j in nb[i] if agg[j] != -1 and strong(i, j)] or \
+               [agg[j] for j in nb[i] if agg[j] != -1]
+        agg[i] = cand[0] if cand else k
+        if not cand:
+            k += 1
+    return agg, k
+
+
+def build_hierarchy(A0, Pcoord, tris):
+    levels = [A0]; Ps = []
+    A = A0; lvl = 0
+    while A.shape[0] > MAX_COARSE:
+        if lvl == 0:
+            agg, na = s0.directional_aggregate(Pcoord, tris)
+        else:
+            N = A.shape[0] // NDOF
+            w = algebraic_weights(A, NDOF)
+            if not w:
+                break
+            agg, na = aggregate(w, N)
+        if na <= 1 or na * NDOF >= A.shape[0]:      # no real coarsening -> stop
+            break
+        P = s0.block_P(agg, na, NDOF)
+        A = (P.T @ A @ P).tocsr()
+        Ps.append(P); levels.append(A); lvl += 1
+    return levels, Ps
+
+
+def block_dinv(A, ndof, reg=1e-10):
+    """Per-node ndof x ndof diagonal-block inverse (regularized for the ~0 pressure diagonal)."""
+    n = A.shape[0] // ndof
+    D = A.toarray() if A.shape[0] < 4000 else None
+    blocks = np.empty((n, ndof, ndof))
+    Ad = A.tocsr()
+    worst = np.inf
+    for i in range(n):
+        sl = slice(ndof * i, ndof * i + ndof)
+        B = (D[sl, sl] if D is not None else Ad[sl, sl].toarray())
+        worst = min(worst, abs(np.linalg.det(B)))
+        blocks[i] = np.linalg.inv(B + reg * np.eye(ndof))
+    return blocks, worst
+
+
+def smooth_block(A, b, x, Dinv, ndof, sweeps, omega=0.7):
+    n = A.shape[0] // ndof
+    for _ in range(sweeps):
+        r = (b - A @ x).reshape(n, ndof)
+        x = x + omega * np.einsum('nij,nj->ni', Dinv, r).reshape(-1)
+    return x
+
+
+def smooth_point(A, b, x, dinv, sweeps, omega=0.7):
+    for _ in range(sweeps):
+        x = x + omega * dinv * (b - A @ x)
+    return x
+
+
+def make_vcycle(levels, Ps, mode):
+    facs = {}                                       # cached coarsest LU + smoother data
+    Acoarse = levels[-1]
+    facs['lu'] = spla.splu(Acoarse.tocsc())
+    sm = []
+    worst_det = np.inf
+    for A in levels[:-1]:
+        if mode == 'block':
+            Dinv, wd = block_dinv(A, NDOF); worst_det = min(worst_det, wd)
+            sm.append(('block', Dinv))
+        else:
+            d = A.diagonal(); d[np.abs(d) < 1e-30] = 1e-30
+            sm.append(('point', 1.0 / d))
+    def vcycle(lvl, b):
+        if lvl == len(levels) - 1:
+            return facs['lu'].solve(b)
+        A = levels[lvl]; kind, data = sm[lvl]
+        sweep = (smooth_block if kind == 'block' else smooth_point)
+        args = (data, NDOF) if kind == 'block' else (data,)
+        x = sweep(A, b, np.zeros_like(b), *args, 2)         # 2 pre-sweeps (paper)
+        r = b - A @ x
+        ec = vcycle(lvl + 1, Ps[lvl].T @ r)                 # restrict (sum) -> recurse
+        x = x + Ps[lvl] @ ec                                # prolong (injection) correct
+        x = sweep(A, b, x, *args, 1)                        # 1 post-sweep (paper)
+        return x
+    M = spla.LinearOperator(levels[0].shape, matvec=lambda b: vcycle(0, b))
+    return M, worst_det
+
+
+def run():
+    print(f"{'n':<4}{'DOFs':<7}{'lvls':<6}{'blockJac':<10}{'pointJac':<10}{'worst|det|':<12}")
+    for n in [16, 24, 32]:
+        Pc, tris = cav.skew_mesh(n, 45.0)
+        A, b = p1.build(n)
+        levels, Ps = build_hierarchy(A, Pc, tris)
+        Mb, wd = make_vcycle(levels, Ps, 'block')
+        Mp, _ = make_vcycle(levels, Ps, 'point')
+        itb = p1.gmres_iters(A, b, M=Mb)
+        itp = p1.gmres_iters(A, b, M=Mp)
+        print(f"{n:<4}{A.shape[0]:<7}{len(levels):<6}{itb:<10}{itp:<10}{wd:<12.2e}")
+    print(f"[gate] block-Jacobi V-cycle should converge + reproduce unsmoothed growth (~x1.7-2.0,")
+    print(f"       faithful, NOT magically flat); point-Jacobi should be much worse (saddle block);")
+    print(f"       worst|det| > 0 confirms coarse diagonal blocks are invertible. vs 1a: 13/19/39.")
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/acm_stage2_stretched.py
+++ b/scripts/acm_stage2_stretched.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""ACM Stage 2 (host): the DECISIVE stretched-mesh GO/NO-GO. De-rigged per review.
+
+The whole justification for building the paper's faithful (unsmoothed/injection) ACM. The host
+studies showed it grows x1.7-2.0 on ISOTROPIC meshes while smoothed-SA is flat (x1.4), so the
+paper's form is only worth building if its DIRECTIONAL (Mavriplis) agglomeration beats smoothed-SA
+on a STRETCHED/anisotropic (boundary-layer) mesh. We test three hierarchies in the SAME V-cycle
+with the SAME point-Jacobi smoother (so the ONLY variable is aggregation + prolongation):
+
+  dir_inj : directional aggregation + order-zero injection P   (THE PAPER)
+  iso_inj : isotropic distance-1 aggregation + injection P     (strawman)
+  iso_sa  : isotropic aggregation + SMOOTHED P                 (THE REAL COMPETITOR)
+
+GO  = paper (dir_inj) growth g<1.6 AND it beats iso_sa on the stretched mesh -> build faithful ACM.
+NO-GO = paper not flat, OR smoothed-SA matches/beats it -> smoothed-SA is the 'something better';
+        escalate to the user (do NOT silently switch -- 'paper form first' was the instruction).
+
+Also tracks aggregate ANISOTROPY (do directional aggregates elongate along the stretch direction,
+as Mavriplis intends). Run: /tmp/p1env/bin/python scripts/acm_stage2_stretched.py
+"""
+import importlib.util
+import numpy as np
+import scipy.sparse as sp
+
+s1spec = importlib.util.spec_from_file_location("s1", "scripts/acm_stage1_vcycle.py")
+s1 = importlib.util.module_from_spec(s1spec); s1spec.loader.exec_module(s1)
+s0, p1, cav = s1.s0, s1.p1, s1.cav
+NDOF, KMAX = s1.NDOF, s1.KMAX
+
+
+def stretched_mesh(n, p):
+    """structured (n+1)^2, uniform x, POWER-graded y=(j/n)^p clustered at y=0 (wall aspect=n^(p-1))."""
+    P = np.zeros(((n + 1) ** 2, 2))
+    for j in range(n + 1):
+        y = (j / n) ** p
+        for i in range(n + 1):
+            P[j * (n + 1) + i] = [i / n, y]
+    tris = []
+    for j in range(n):
+        for i in range(n):
+            a = j * (n + 1) + i; b = a + 1; c = a + (n + 1) + 1; d = a + (n + 1)
+            tris.append([a, b, c]); tris.append([a, c, d])
+    dy_min = P[(n + 1)][1] - P[0][1]                   # first cell height at the wall
+    return P, np.array(tris), (1.0 / n) / dy_min       # aspect ratio dx/dy_min
+
+
+def p_for_aspect(n, aspect):
+    return 1.0 + np.log(aspect) / np.log(n)            # aspect = n^(p-1)
+
+
+def build_stretched(n, p, Re=100.0):
+    P, tris, ar = stretched_mesh(n, p)
+    N = len(P); nu = 1.0 / Re; h = 1.0 / n; tau = h * h / (4.0 * nu)
+    A, rhs = cav.assemble(P, tris, nu, tau, np.zeros((N, 2)))
+    A, rhs = cav.apply_bcs(A, rhs, P, n, ulid=1.0)
+    return sp.csr_matrix(A), rhs.copy(), P, tris, ar
+
+
+def block_adjacency(A, ndof):
+    Ac = A.tocoo(); N = A.shape[0] // ndof
+    nb = [set() for _ in range(N)]
+    for r, c in zip(Ac.row, Ac.col):
+        I, J = r // ndof, c // ndof
+        if I != J:
+            nb[I].add(J)
+    return [list(x) for x in nb]
+
+
+def isotropic_aggregate(nb, N):
+    """distance-1 greedy (no strength test) -- the isotropic baseline aggregation."""
+    agg = np.full(N, -1, np.int64); k = 0
+    for seed in range(N):
+        if agg[seed] != -1:
+            continue
+        agg[seed] = k; cnt = 1
+        for j in nb[seed]:
+            if cnt >= KMAX:
+                break
+            if agg[j] == -1:
+                agg[j] = k; cnt += 1
+        k += 1
+    for i in range(N):
+        if agg[i] != -1:
+            continue
+        cand = [agg[j] for j in nb[i] if agg[j] != -1]
+        agg[i] = cand[0] if cand else k
+        if not cand:
+            k += 1
+    return agg, k
+
+
+def smooth_prolongation(A, Pt, ndof, niter=10):
+    """smoothed-aggregation P = (I - omega D^-1 A) P_tent, omega = 4/(3 rho(D^-1 A))."""
+    d = A.diagonal().copy(); d[np.abs(d) < 1e-30] = 1e-30
+    Dinv = sp.diags(1.0 / d); DA = (Dinv @ A).tocsr()
+    x = np.random.RandomState(0).randn(A.shape[0])
+    for _ in range(niter):
+        x = DA @ x; x /= np.linalg.norm(x)
+    rho = np.linalg.norm(DA @ x)
+    return (Pt - (4.0 / (3.0 * rho)) * (DA @ Pt)).tocsr()
+
+
+def build_hierarchy(A0, Pcoord, tris, mode):
+    directional = mode.startswith('dir'); sa = mode.endswith('sa')
+    levels = [A0]; Ps = []; A = A0; lvl = 0
+    while A.shape[0] > s1.MAX_COARSE:
+        N = A.shape[0] // NDOF
+        if directional:
+            if lvl == 0:
+                agg, na = s0.directional_aggregate(Pcoord, tris)
+            else:
+                w = s1.algebraic_weights(A, NDOF)
+                if not w:
+                    break
+                agg, na = s1.aggregate(w, N)
+        else:
+            agg, na = isotropic_aggregate(block_adjacency(A, NDOF), N)
+        if na <= 1 or na * NDOF >= A.shape[0]:
+            break
+        Pt = s0.block_P(agg, na, NDOF)
+        P = smooth_prolongation(A, Pt, NDOF) if sa else Pt
+        A = (P.T @ A @ P).tocsr()
+        Ps.append(P); levels.append(A); lvl += 1
+        if lvl == 0:
+            pass
+    return levels, Ps
+
+
+def aggregate_stats(agg, Pcoord):
+    """mean nodes/aggregate and mean bbox aspect (y-extent/x-extent, capped) -- do aggregates align with the stretch?"""
+    sizes, bbox = [], []
+    for I in range(int(agg.max()) + 1):
+        pts = Pcoord[agg == I]
+        if len(pts) < 2:
+            sizes.append(len(pts)); continue
+        sizes.append(len(pts))
+        dx = np.ptp(pts[:, 0]); dy = np.ptp(pts[:, 1])
+        bbox.append(min((dy + 1e-12) / (dx + 1e-12), 100.0))   # >1 = elongated along stretch (y)
+    return float(np.mean(sizes)), float(np.mean(bbox)) if bbox else 1.0
+
+
+MODES = [('dir_inj', 'directional+inj (PAPER)'),
+         ('iso_inj', 'isotropic+inj  (strawman)'),
+         ('iso_sa',  'isotropic+SA   (COMPETITOR)')]
+
+
+def solve_iters(A, b, Pc, tris, mode):
+    levels, Ps = build_hierarchy(A, Pc, tris, mode)
+    return p1.gmres_iters(A, b, M=s1.make_vcycle(levels, Ps, 'point')[0])
+
+
+def run():
+    # ---- Sweep 1: fixed n, INCREASING aspect -- does smoothed-SA blow up as cells stretch? ----
+    n = 32
+    print(f"[sweep 1] fixed n={n}, increasing wall aspect ratio (iters; lower=better):")
+    print(f"  {'aspect':<9}{'dir_inj(PAPER)':<16}{'iso_inj':<10}{'iso_sa(SA)':<12}")
+    for aspect in [1, 10, 100, 1000]:
+        p = p_for_aspect(n, aspect)
+        A, b, Pc, tris, ar = build_stretched(n, p)
+        its = {m: solve_iters(A, b, Pc, tris, m) for m, _ in MODES}
+        print(f"  {ar:<9.0f}{its['dir_inj']:<16}{its['iso_inj']:<10}{its['iso_sa']:<12}")
+
+    # ---- Sweep 2: fixed high aspect ~200, INCREASING n -- mesh-independence (flatness) ----
+    print(f"\n[sweep 2] fixed wall aspect ~=200, increasing n (growth = flatness):")
+    iters = {m: [] for m, _ in MODES}
+    for nn in [16, 24, 32, 40]:
+        p = p_for_aspect(nn, 200.0)
+        A, b, Pc, tris, ar = build_stretched(nn, p)
+        line = f"  n={nn:<3} DOFs={A.shape[0]:<5} aspect={ar:6.0f}  "
+        for m, _ in MODES:
+            it = solve_iters(A, b, Pc, tris, m); iters[m].append(it)
+            line += f"{m.split('_')[0]}+{m.split('_')[1]}={it:<5}"
+        agg_d, _ = s0.directional_aggregate(Pc, tris)
+        agg_i, _ = isotropic_aggregate(block_adjacency(A, NDOF), len(Pc))
+        sd, bd = aggregate_stats(agg_d, Pc); si, bi = aggregate_stats(agg_i, Pc)
+        line += f" | aggsize dir={sd:.1f}/iso={si:.1f} bbox-aspect dir={bd:.1f}/iso={bi:.1f}"
+        print(line)
+
+    print(f"\n  {'method':<28}{'iters':<22}{'growth'}")
+    g = {}
+    for m, name in MODES:
+        v = iters[m]; ok = all(isinstance(x, int) and x > 0 for x in v)
+        g[m] = (v[-1] / v[0]) if ok else float('inf')
+        print(f"  {name:<28}{str(v):<22}{'x%.2f' % g[m] if ok else 'DIVERGED'}")
+
+    # ---- honest multi-signal verdict (compare at the FINEST mesh + growth, not the n=16 tie) ----
+    paper, iso, sa = iters['dir_inj'], iters['iso_inj'], iters['iso_sa']
+    flat = g['dir_inj'] < 1.6
+    beats_sa = isinstance(paper[-1], int) and isinstance(sa[-1], int) and paper[-1] < 0.9 * sa[-1]
+    beats_iso = isinstance(paper[-1], int) and isinstance(iso[-1], int) and paper[-1] < 0.9 * iso[-1]
+    print()
+    print(f"[signals @ finest mesh] paper flat: {flat} (g={g['dir_inj']:.2f}) | "
+          f"paper beats smoothed-SA: {beats_sa} ({paper[-1]} vs {sa[-1]}) | "
+          f"directional beats isotropic-inj: {beats_iso} ({paper[-1]} vs {iso[-1]})")
+    if flat and beats_sa and beats_iso:
+        print("[VERDICT] GO -- the paper's DIRECTIONAL ACM is flat AND beats both smoothed-SA and")
+        print("          isotropic injection on the stretched mesh -> build the faithful ACM (Stages 3-6).")
+    elif beats_sa and not beats_iso:
+        print("[VERDICT] PARTIAL -- the UNSMOOTHED (injection) approach beats smoothed-SA on stretching")
+        print("          (so smoothed-SA is NOT the better choice), but directional aggregation does not")
+        print("          yet separate from plain isotropic injection. Escalate: build unsmoothed ACM, but")
+        print("          the directional-vs-isotropic value needs a sharper test (3D/tet, real |S|).")
+    else:
+        why = []
+        if not flat: why.append(f"paper not flat (g={g['dir_inj']:.2f})")
+        if not beats_sa: why.append("smoothed-SA matches/beats the paper")
+        print(f"[VERDICT] NO-GO -- {'; '.join(why)}. Escalate (settled-tradeoff: 'paper form first').")
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/phase1_precond_study.py
+++ b/scripts/phase1_precond_study.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Phase-1 preconditioner study (host signal, NOT the definitive Hypre answer).
+
+The existential question for the coupled solver: does ANY AMG-class preconditioner give
+near mesh-INDEPENDENT GMRES iteration counts on the coupled collocated saddle operator?
+Built on the same coupled cavity operator the host replica validated (Stokes, PSPG-
+stabilized [u,v,p], lid-driven BCs). Tests at several mesh sizes:
+
+  - none      : GMRES, no preconditioner (baseline; iters should grow ~1/h)
+  - ILU       : scipy spilu
+  - AMG-RS    : pyamg classical Ruge-Stuben (scalar)
+  - AMG-sys   : pyamg smoothed-aggregation with the 3-DOF block near-null-space
+                (the closest host analog to Hypre point-block / nodal-systems AMG)
+
+CAVEAT: pyamg != Hypre point-block BoomerAMG; this is a SIGNAL to decide whether 1a
+(Hypre point-block) is worth building or we go straight to 1c (agglomeration ACM).
+Run with the throwaway venv that has scipy+pyamg:  /tmp/p1env/bin/python scripts/phase1_precond_study.py
+"""
+import sys, importlib.util
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+import pyamg
+
+spec = importlib.util.spec_from_file_location("cav", "scripts/coupled_cavity_reference.py")
+cav = importlib.util.module_from_spec(spec); spec.loader.exec_module(cav)
+
+
+def build(n, Re=100.0):
+    P, tris = cav.skew_mesh(n, 45.0)
+    N = len(P)
+    nu = 1.0 / Re
+    h = 1.0 / n
+    tau = h * h / (4.0 * nu)
+    A, rhs = cav.assemble(P, tris, nu, tau, np.zeros((N, 2)))   # Stokes (advection off)
+    A, rhs = cav.apply_bcs(A, rhs, P, n, ulid=1.0)
+    return sp.csr_matrix(A), rhs.copy()
+
+
+def gmres_iters(A, b, M=None, rtol=1e-8, restart=300, maxiter=3000):
+    cnt = [0]
+    def cb(_): cnt[0] += 1
+    x, info = spla.gmres(A, b, M=M, rtol=rtol, atol=0.0, restart=restart,
+                         maxiter=maxiter, callback=cb, callback_type='pr_norm')
+    return (cnt[0] if info == 0 else -1)   # -1 = did not converge
+
+
+def _block_B(ND):
+    B = np.zeros((ND, 3))                     # component-constant near-null-space (u,v,p blocks)
+    for c in range(3):
+        B[c::3, c] = 1.0
+    return B
+
+
+def systems_amg(A, smooth='default'):
+    # smooth=None -> UNSMOOTHED aggregation = injection prolongation + sum-of-fine
+    # coarse operator (R A R^T) = the additive-correction agglomeration MG (ACM analog).
+    kw = dict(B=_block_B(A.shape[0]), max_coarse=50)
+    if smooth is None:
+        kw['smooth'] = None
+    return pyamg.smoothed_aggregation_solver(A, **kw).aspreconditioner('V')
+
+
+def run():
+    ns = [16, 24, 32]
+    print(f"{'precond':<10} " + "  ".join(f"n={n}(DOFs={3*(n+1)**2})" for n in ns))
+    rows = {}
+    mats = {n: build(n) for n in ns}
+    for name in ["none", "ILU", "AMG-RS", "AMG-sys", "ACM-agg"]:
+        out = []
+        for n in ns:
+            A, b = mats[n]
+            try:
+                if name == "none":
+                    M = None
+                elif name == "ILU":
+                    M = spla.LinearOperator(A.shape, spla.spilu(A.tocsc()).solve)
+                elif name == "AMG-RS":
+                    M = pyamg.ruge_stuben_solver(A, max_coarse=50).aspreconditioner('V')
+                elif name == "AMG-sys":
+                    M = systems_amg(A)                       # smoothed aggregation (systems)
+                else:
+                    M = systems_amg(A, smooth=None)          # ACM analog: unsmoothed agglomeration
+                it = gmres_iters(A, b, M=M)
+            except Exception as e:
+                it = f"ERR:{type(e).__name__}"
+            out.append(it)
+        rows[name] = out
+        print(f"{name:<10} " + "  ".join(f"{str(v):>12}" for v in out))
+
+    # verdict: an AMG-class row that stays ~flat (mesh-independent) answers the question YES
+    print()
+    for name in ["AMG-RS", "AMG-sys", "ACM-agg"]:
+        v = rows[name]
+        if all(isinstance(x, int) and x > 0 for x in v):
+            growth = v[-1] / max(1, v[0])
+            verdict = "MESH-INDEPENDENT (AMG works)" if growth < 2.0 else "iters GROW with mesh"
+            print(f"[verdict] {name}: iters {v} -> {verdict} (x{growth:.1f})")
+        else:
+            print(f"[verdict] {name}: {v} -> did NOT converge / errored")
+    print("[note] pyamg signal only; definitive answer is Hypre point-block BoomerAMG on GPU (1a).")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
- **fix(pump): revive the pressure outlet (the REAL through-flow fix). outletU was set unconditionally -> always velocity-Dirichlet outlet -> both-ends-Dirichlet admits a flat-pressure tank-recirculation div=0 solution -> NO flow through the passage (confirmed: 1e-10 pressure solve gave identical flat-p, so it's structural not convergence -- AMG would NOT help). Gate outletU on !outletDoNothing so do-nothing (default) leaves outletU<=0 -> solver masks the WHOLE outlet face p=0 + frees outlet velocity (singlePin=false, solver:4080) -> inlet flux against fixed-p outlet FORCES the outlet->suction gradient -> through-flow. The dead --outlet flag now actually works**
- **fix(pump): default outlet back to MASS-CONSERVING (the correct design). Root cause found: the divergence operator only loops interior faces (sum(div)==0 always), so the pressure solve is NEVER told mass enters at the inlet -> a velocity-inlet + free pressure-outlet is UNPROJECTABLE -> no through-flow (flow dies at inlet, pressure parks in body). The code's own comment (solver:2295) flags this. My prior do-nothing default was backwards: the mass-conserving outlet (vel outflow removes Q + single pin) BALANCES the flux so the projection builds the inlet->outlet gradient that drives flow through the passage. The dead-flag gate stays so do-nothing is still selectable (needs a boundary-flux source term to be correct -- separate work)**
- **pump through-flow: (1) default to do-nothing outlet = whole-face p=0 + FREE outlet velocity (the channel-proven pairing that builds the inlet->outlet pressure head; both-ends-velocity-Dirichlet + single pin gave a flat-pressure dead-passage solution). (2) --inlet-flux-source (GUARDED, off): add the prescribed inlet flux as a boundary divergence source -- the exterior opening flux is in no interior SCS so it's never integrated (verified not a double-count); A/B it. (3) [through-flow] Q_in/Q_out/ratio diagnostic each step so we MEASURE through-flow (ratio->1) instead of eyeballing uMax. mass-conserving still selectable. cavity/channel/TGV unaffected**
- **pump: REMOVE the broken --inlet-flux-source (double-counted the inlet flux already registered via interior SCS scatter; full-opening-area x rho/dt -> instant blowup, ratio=garbage) and revert default to MASS-CONSERVING outlet. Verified high-confidence: the inlet flux is already in the divergence for a velocity-Dirichlet inlet, so the only correct inlet boundary source is ZERO. do-nothing (whole-face p=0 + free outlet) does NOT self-drive a small interior outlet -> ratio=0 (no through-flow); the prior do-nothing-default + comments were disproven by the A/B. mass-conserving (U_out=Uin*Ain/Aout + single pin) forces Q_out=Q_in by construction. Kept the [through-flow] Q diagnostic (correct + useful)**
- **pump through-flow REWORK (verified root cause): the reference flows through the pump with ANY scheme (bj/upwind) so the dead passage is OUR bug, not Re/scheme. TWO real defects fixed: FIX1 --opening-flux-source (GUARDED off): inlet/outlet OPENING faces are exterior, in no interior SCS, so the prescribed opening flux never reaches the pressure RHS -> pressure flat -> no through-flow. Add it as a COMPATIBLE surface integral (u.n)*A_share, SAME scale as interior scatter, NOT x rho/dt (RHS does it), net~0 -- verified NOT a double-count (telescoping interior pairs never touch the opening face). FIX2 --dirichlet-lift (default ON): velocity-diffusion col-zero had no Dirichlet lift -> inlet momentum never diffused inward -> jet died at inlet. Add b-=K[row,bdry]*uTarget. FIX3: replace TAUTOLOGICAL Q_out (relocked to prescribed outletU) with an INTERIOR cut-plane flux probe at 25/50/75% -- measures SOLVED through-flow, can't be faked. old line relabeled [bc-sanity]**
- **pump FIX B: pressure-drop drive via --pump-dp=VALUE (gated, off by default -> existing pump byte-identical). Root cause: the divergence operator integrates only INTERIOR SCS faces, so a VELOCITY prescribed on the interior inlet opening is invisible to the pressure solver (exterior opening face never integrated) + the corrector freezes velocity-Dirichlet nodes -> no through-flow (proven: interior-flux mid-cut=0). FIX B masks BOTH openings as pressure-Dirichlet (p=dP inlet, p=0 outlet), frees both velocities, seeds the dP head in d_p -> flow EMERGES from the interior gradient (SCS-captured, VISIBLE). Startup-safe: two Dirichlet faces make the matrix NONSINGULAR -> no compatibility condition -> no FIX-1 source-blowup. inlet velocity becomes an OUTPUT (tune dP to hit ~0.5 m/s). Keeps interior-flux probe to verify mid-cut goes nonzero**
- **pump FIX B phi-lift (the piece that makes dP actually drive flow). Bug: FIX B seeded a one-node dP spike + pinned the phi increment to 0 at both faces -> interior never relaxed into the inlet->outlet gradient -> dP didn't drive flow (identical tiny flow at dP=1000 vs 30000). FIX: pin the SOLVED pressure to the target via rhs=target-p^n at masked DOFs (clamp to constant, NOT additive -> steady+bounded), so the Poisson solve imposes dP->0 Dirichlet data + relaxes the spanning gradient; the already-live predictor grad(p^n) then drives through-flow. LOAD-BEARING: pump runs DDT matrix-free, so the lift goes in solvePressureDDT's boundary-pin lambda (not the K-path). All gated pumpDp>0; pumpDp<=0 byte-identical (cavity/channel/TGV untouched)**
- **pump THROUGH-FLOW fix: prescribed-balanced opening-flux source (default ON). The verified root cause: a velocity-inlet's opening flux is invisible to the pressure solver (divergence integrates interior SCS only) -> flat passage -> dead passage (proven: interior-flux cut@50%=0). FIX: inject the opening flux into divAccNode so the projection SEES the inflow and builds the inlet->outlet gradient that drives the passage. KEY over the broken FIX 1: use PRESCRIBED GLOBAL-direction velocities (Uinf*inletDir, outletU*outletDir) not the solved u** -> inlet sums to -Q_in, outlet to +Q_in (outletU=Uin*Ain/Aout) -> total=0 EXACTLY every step incl step0 -> single-pin Neumann stays compatible -> CANNOT blow up like FIX 1 (which used u**=0 at the step0 outlet -> one-sided -> phi=1e36). Config: mass-conserving velocity inlet+outlet (sustains the jet) + this source (makes it visible). No removeMean (pin handles it). FIX B (pumpDp) abandoned, gated off**
- **pump: default opening-flux-source back OFF -- the prescribed-balanced source STILL blows up at step0 (phi=1e7->inf, CG residual grows = incompatible, same FLT_MAX as FIX 1). The 'sum=0 by construction' startup-safety proof was WRONG: the discrete per-node area shares evidently do not sum to exactly Q, so sum!=0, x rho/dt=1e6 -> explodes even at step0. Revert to the STABLE mass-conserving default (no through-flow, but runs). The opening-flux-source remains a flag for debugging but is NOT a working fix. Through-flow is UNRESOLVED -- see scratch/pump_throughflow_HANDOFF.md**
- **pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B**
- **Revert "pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B"**
- **debug: MARS_OFS_DBG -- print divAccNode |max| before/after the opening-flux source + the global net source sum, to SEE if the source is a giant localized spike (divAcc max jumps) and whether net is actually ~0. Instrumentation only, gated on env. Investigating the repeated step0 phi=1e7 blowup**
- **debug: print Qin_raw/Qout_raw separately -- the [ofs-dbg] net=-Q_in (one-sided) proves the OUTLET source contributes ZERO. Need to see Qin_raw vs Qout_raw to find why the outlet half does not fire (area-vec sign? outletDir?)**
- **pump: adjustPhi rescale FOUND THE BUG via debug -- the discrete inlet/outlet fluxes differ ~1.5% (Qin_raw=-5.975e-3, Qout_raw=+5.884e-3), NOT roundoff: the per-node area-vectors sum to a different value than the analytic areaIn/areaOut used for outletU. That 9e-5 residual x rho/dt=1e6 -> incompatible RHS -> phi=1e7 blowup. FIX: oScale=-Qin_raw/Qout_raw, rescale the outlet source so it EXACTLY cancels the inlet (net->0). The reductions now always run (not just debug). [ofs-dbg2] prints the net to confirm it goes to ~0**
- **pump: removeMean for the opening-flux source -- THE ACTUAL FIX. Debug PROVED the blowup is NOT flux imbalance: with the adjustPhi rescale the net source is bit-exactly 0 (8.67e-19) and it STILL blew up to phi=1e7 identically. Real cause (the code's own comments flag it: lines 897/2209/3333/5145): the single p=0 pin weakly controls the DDT constant null space; a boundary source excites that mode and Jacobi-PCG loses pAp>0 (residual GROWS 0.98->1.46 then garbage phi=1e7). FIX: removeMean the RHS + phi (project the null-space component out) when opening-flux is on -- the same cure the periodic path uses. Gated on useOpeningFluxSource**
- **debug: removeMean did NOT fix the blowup (phi=1e7 identical) -> null-space theory also wrong. KEY realization: the CG CONVERGES (3e-8), so phi=1e7 is the TRUE solution -- the operator+RHS are fine, the answer is legitimately huge. Add [ofs-dbg3] b|max and [ofs-dbg4] phi|max split by OPENING vs INTERIOR nodes, to decide: is phi huge only at the opening nodes (tiny DDT boundary-layer diagonal, b/diag=1e6*1e-4/1e-5=1e7 LOCAL) or everywhere (global)? That picks the final fix**
- **pump: --source-ramp-steps=N gentle startup for the opening-flux source. ROOT CAUSE (measured): the source WORKS (real through-flow, step1 cut@50% nonzero) but starting from rest at full strength dumps the whole inlet->outlet pressure head onto a near-singular interior node (sliver cell, DDT diag=1e-5, 600x below bulk) -> phi spikes to 6e6 there -> grad(phi) spike -> corrector velocity spike -> advection 950x/step -> blowup. NOT fixable by clip (preconditioner-only, phi is the true solution), CFL (structural per-step amplification), or balance/removeMean (all already correct). FIX: ramp Uinf 0->full over N steps so the head + phi + grad stay small while flow develops gently. Scales the inlet velocity target (from a base snapshot) AND the opening-flux source (reads Uinf live) -> balance preserved at every ramp level**
- **pump: allow dt to shrink up to 2x/step (was 5%/step). With the ramp, the flow develops stably for ~16 steps (phi=1e4, u_max bounded+growing, cut@50% nonzero) then a CFL violation at u~100 ran away because the 5%/step shrink cap could not drop dt fast enough to catch it. Fast shrink catches the violation in one step; growth stays gentle (5%/step) so BDF2's constant-dt assumption holds at steady state**
- **pump: targeted operator-diagonal floor on the matrix-free DDT (the sliver-node fix). MEASURED: the ramp fixes startup (steps 1-16 stable, flow developing, cut@50% nonzero) but one sliver interior node (tiny SCS face areas -> DDT diag=1e-5, 600x below bulk) makes phi spike there -> corrector velocity spike -> diffusion CG breaks (pAp<0, u**>>u*) -> blowup, even at dt=5e-8 (so NOT CFL). Jacobi clip is preconditioner-only (no-op on phi). FIX: raise ONLY the degenerate rows to epsFloor=0.05*max_diag in the TRUE matrix-free operator via per-node shift out[i]+=shift_i*phi[i]; 0 on the healthy bulk -> byte-identical there -> cavity/channel/cube16 untouched. Caps phi at b/3.3e-4 (~31x smaller) -> below blowup threshold. Pure positive diagonal add -> keeps SPD. Preconditioner diag floored to match. Velocity diffusion needs NO floor (M/dt keeps it conditioned; its divergence was downstream of the phi spike). Env MARS_DDT_OP_FLOOR_FRAC**
- **debug: MARS_CHECKER -- per-element mean-free pressure RMS diagnostic (the checkerboard mode an inf-sup stabilizer penalizes). Lets us SEE the checkerboard grow + SEE a stabilizer kill it in a few steps, instead of inferring from a full-run blowup. Confirms/quantifies the LBB decoupling diagnosis. Env-gated, tet-only, rank0, free in production. NOTE: adjudication confirmed BD-on-DDT is WRONG (breaks div=0 identity, accumulating divergence); the identity-safe path is VMS/RC on the divergence SOURCE (needs a phi-vs-d_p fix). Checkerboard fix != through-flow fix (separate defects)**
- **fix: checker diagnostic compile error -- a pair-returning __device__ lambda in transform_reduce needs its return type proclaimed in host context. Split into two scalar (double) reductions (mean-free energy + total) -- avoids the trait error, same result**
- **pump: replace the div-BREAKING operator-diagonal floor with an identity-safe MASS floor. The operator floor (out[i]+=shift*phi in applyDDTPerNode) only the OPERATOR saw, not the corrector -> solving (A+S)phi=b left div(u^{n+1})=(dt/rho)*S*phi un-projected -> accumulating residual -> smooth |p| 1e3->1e34 blowup (the SAME div=0-breaking class the code warns against for BD-on-DDT, lines 5602-5610). FIX: floor the lumped mass d_massNode instead -- A=D M^-1 D^T and the corrector ALSO applies M^-1 from the same d_massNode, so flooring mass changes operator AND corrector consistently -> div=0 PRESERVED. Removed d_shiftDDTNode + its apply + the operator-floor build. Env MARS_MASS_FLOOR_FRAC (default 1e-3*max_mass)**
- **pump: implicit PSPG pressure stabilization (--pspg) -- the CORRECT equal-order checkerboard fix. VERIFIED root cause of the checkerboard blowup: the existing VMS adds tau*(-lap p^n) to the RHS = an EXPLICIT forward-Euler Laplacian-of-p update -> unconditionally amplifies the high-freq mode at ANY tau (why 1e-6/1e-5/1e-3 all blew up). FIX: add tau*L*phi IMPLICITLY inside applyDDTPerNode so CG solves (A+tau*L)phi=b. L=sum_e V_e G^T G is symmetric PSD, shares A's constant null mode (removed by the pin) -> SPD, damps checkerboard at ALL tau>0. Acts on phi (the correction, ->0) so it self-extinguishes; post-corrector div relaxes to ~tau*lap(phi)=O(h^2), a CONSISTENT residual that vanishes under refinement -- the textbook PSPG, NOT the inconsistent div-breaking BD/floor. tau=h^2/24 (a LENGTH^2, not dt/rho). Confirm via MARS_CHECKER: frac must shrink. New kernel applyPSPGLaplacianTetKernel; gated --pspg, tau auto or --pspg-tau**
- **pump PSPG: FIX THE SIGN. The DDT operator outAcc = D M^-1 D^T phi ~ -lap(phi) (SPD-positive; A=-lap, matches b=-coef*div). My PSPG scattered +div(grad phi)=+lap(phi) = OPPOSITE sign -> SUBTRACTED definiteness (made conditioning worse, no damping). Flip: scatter -s to iL / +s to iR so it adds +tau*(-lap)phi = positive energy, same orientation as A. This is why the first PSPG run showed frac still growing + cg_p=-2 (wrong-sign term de-conditioned the operator). NOTE: that run ALSO lost the Jacobi clip (diag=6.5e-12) -- must pass MARS_DDT_JACOBI_CLIP_FRAC for the sliver**
- **pump PSPG: add tau*L diagonal to the Jacobi preconditioner (the REAL bug). Numerically verified (host dense-matrix replica): my PSPG sign was CORRECT (-s/+s -> L=+Vol*G^T*G, same sign as A=-lap, A+tau*L more SPD). The cg_p=-2 failure was the PRECONDITIONER mismatch: operator ran A+tau*L but d_diagDDT was built from A only -> worst on the sliver rows (tiny A-diag, large tau*L-diag) -> CG stalls. FIX: computeTetPSPGDiagonalKernel scatters tau*Vol*|dNdx_i|^2 into d_diagAccNode (before halo/gather) so the preconditioner matches the stabilized operator. Gated usePSPG, tet-only. Sign left unchanged (verified correct)**
- **pump: pin the degenerate sliver DOF(s) -- the identity-safe fix for the unsolvable pressure (cg_p=-2). A near-zero-volume tet gives a DDT diagonal ~9 OOM below bulk (1e-12 vs 6e-3); Jacobi-PCG cannot solve it. FIX: mask any owned DOF with diag < MARS_SLIVER_PIN_FRAC*max_diag (default 1e-6) into d_isPressureBdryDof -> the operator forces out=phi (identity row) AND the RHS forces b=0, exactly like the outflow/pin DOFs (verified both paths check maskPtr). One removed equation, div-safe. Makes the pressure solvable so the real physics + PSPG become readable. The mass floor was the wrong lever (sliver diag is AREA-driven, not mass); this pins the node directly**
- **poiseuille validation example: channel-fork NS solver with balanced opening-flux source; parabola matches analytic profile within reference tolerance (RMS 5.8e-3 < 6e-3, interior flux ratio ~1). Plus tutorial.**
- **pump: assembled tet DDT operator + FlexGMRES (toward Hypre AMG pressure solve). (1) ASSEMBLE the matrix-free D M^-1 D^T into CSR for tet (buildDDTSparsityTet + assembleDDTPerNodeKernelTet, node-driven so the per-node M^-1 cross-element face pairs are captured; tet nodeFaces[4][3]={{0,2,3},{0,1,4},{1,2,5},{3,4,5}} derived from d_tetLRSCV). Same operator as matrix-free (verify bit-identical via MARS_DDT_PROBE_DIFF, PSPG off) -> corrector stays div=0-exact. GPU-resident; only host touch is the rank0 setup [DDT-health] print. Matrix-free path UNTOUCHED (gated, additive -- can return to it). (2) FlexGMRES in the Hypre wrapper (default for BoomerAMG, the right Krylov for a varying AMG preconditioner; env MARS_HYPRE_FLEXGMRES). NOT YET COMPILED (no nvcc locally)**
- **pump: assemble PSPG tau*L into the DDT CSR (assemblePSPGStiffnessTetKernel). Element-driven 4x4 tet stiffness tau*Vol*(dNdx_i.dNdx_j) scattered via atomicAddSparseEntry into the existing DDT two-hop sparsity (subset, no new entries). Same tau*L the matrix-free path adds -> assembled A+tau*L == matrix-free A+tau*L. Iterates halo elements (elementCount includes halo) so owned boundary rows get cross-rank stiffness; writes owned rows only. Gated usePSPG. This (a) keeps PSPG on the assembled/Hypre path and (b) regularizes the Gram-form DDT toward diagonal dominance so Jacobi/BoomerAMG can precondition the 9-OOM operator. GPU-resident**
- **pump: activate the assembled DDT pressure solve on --solver=hypre. Re-gate the assembled-DDT block (was MARS_DDT_USE_ASSEMBLED_CG && CG only) to ALSO fire on solverKind==Hypre && nnzDDT>0 -> the SAME operator (D M^-1 D^T + assembled PSPG tau*L) is solved by Hypre FlexGMRES+BoomerAMG instead of matrix-free Jacobi-CG. Matrix-free path UNTOUCHED as the default (no --solver=hypre -> byte-identical). The wrapIntoSparseMatrix(s.AddT) now fires for tet automatically (nnzDDT>0). Global-DOF numbering + MPI partitioning already built at setup for the Hypre path. End-to-end: --solver=hypre -> assembled gate -> solveOneComponent(GMRES) -> FlexGMRES+AMG. Validate via MARS_DDT_PROBE_DIFF (PSPG off) first**
- **fix(pump): remove duplicate template clause before assembleDDTPerNodeKernelTet (my PSPG-kernel insert left an orphan template<> -> 'multiple template clauses' compile error)**
- **pump driver: parse --solver=hypre (was hardcoded SolverKind::CG -> the assembled Hypre path could never activate; explains why --solver=hypre runs were silently matrix-free CG). Sets SolverKind::Hypre -> the assembled DDT + FlexGMRES+BoomerAMG gate fires. --solver=cg restores default. Banner prints the active pressure path**
- **fix(pump hypre): skip the sliver-pin on the Hypre/assembled path. The pin reads the matrix-free d_diagDDT (tiny entries floored to 1 -> globalMax=1 -> 1e-6 threshold pinned ~220k DOFs), and enforcePressureBcRhsKernel then ZEROED b at all those rows -> RHS~0 -> phi=0 every step (no flow: u stuck at 0, div never projected). BoomerAMG handles the conditioning without pinning, so gate the pin on solverKind!=Hypre. This was why --solver=hypre ran stable but produced phi=0**
- **fix(pump hypre): force the VELOCITY solve onto in-house CG even under --solver=hypre. Root cause of the dead u=0 run: solverKind==Hypre routed the velocity matrix (M/dt + nu*K, mass-dominated / near-diagonal) through BoomerAMG-PCG, which is the wrong tool for a non-elliptic mass matrix -> exits ~1 iter returning x~0 -> u**=0 -> div(u**) RHS=0 -> phi=0 -> nothing develops. FIX: add forceCG param to solveOneComponent; velocity solves pass forceCG=true so they use the in-house CG (~14 iters, works) regardless of solverKind. Hypre/AMG stays reserved for the ill-conditioned DDT PRESSURE operator -- the only thing that needs it. (Also: pres_r0=0 under hypre is a stale-diagnostic artifact, lastPressR0 only written in the matrix-free path)**
- **poiseuille: --check regression mode + ctest entry, velocity-fit G closure (100.8% of exact), single-station profile CSV + plot script, u-field render script; fix wall-eps node pinning; document the incremental-p artifact (visualize u, not umag/p)**
- **debug(pump hypre): add MARS_SOLVE_TRACE -- prints converged/iters/|xVec|max right after the Hypre solve, to pin down whether phi=0 is (a) converged=false so xVec never scattered to qOut, or (b) xVec~0 itself. The verbose run showed BoomerAMG sets up + runs (b nonzero, L2=15) but only ~2 cycles at conv factor 0.43 -> likely final_res>tol -> converged=false -> no scatter -> phi=0**
- **poiseuille render: pump-style 3-panel validation layout (field + animated profile-vs-exact + centerline development), PIL composite + header**
- **fix(pump hypre): enforce the single pin into the ASSEMBLED DDT matrix (d_valuesDDT), not just the K-path d_valuesPre. ROOT CAUSE of phi=0: the pin row was only applied to d_valuesPre (K-path), so the assembled DDT operator s.AddT stayed SINGULAR (pure-Neumann pump pressure has a constant null mode). BoomerAMG/FlexGMRES on a singular operator returned the null-space solution = 0 -> 'converged in 2 iters', x=0, phi=0 (proven by MARS_SOLVE_TRACE: pressure solve converged=1 iters=2 |xVec|max=0 while velocity solves gave real nonzero x). FIX: enforcePinRowKeepDiagKernel on d_rowPtrDDT/d_colIndDDT/d_valuesDDT too (keepDiag = AMG-friendly). Single pin is the correct null-space removal for the pure-Neumann pump (matches the reference's 'single pressure reference')**
- **fix(pump hypre): accept a best-effort pressure solve (rel-res < MARS_HYPRE_ACCEPT_RES, default 1e-2) instead of requiring final_res<1e-8. Diagnosis via MARS_SOLVE_TRACE+Jacobi: FlexGMRES+Jacobi runs full 2000 iters and produces a NONZERO xVec (1930, growing) but stalls at res~7e-3 -> the strict converged gate rejected it -> not scattered -> phi=0 -> dead. A projection step does not need machine-precision phi; a partial solve removes most divergence. Now accept it. (AMG still falsely converges at x=0 on this near-singular op -- separate, retune next; Jacobi is the working floor)**
- **poiseuille tutorial: starter-level Part 2 (equations, parabola derivation, CVFEM discretization, projection, solvers) + output-files table**
- **pump hypre: make BoomerAMG actually converge (fix the x=0 false convergence). Root cause: (1) the pump single-pin set the pinned DDT row diagonal to 1.0 (10-25x the native ~0.04-0.14), a documented PMIS-coarsening killer -> AMG V-cycle collapses onto the constant null mode -> FlexGMRES exits at 2 iters with x=0; (2) weak AMG settings (l1-Jacobi relax, strong=0.5, aggressive coarsening) for a 3D near-singular Poisson. FIXES: symmetric pin in the assembled DDT (zero row AND column, restore NATIVE diagonal via read/setRowDiagonalKernel -> no spike); AMG retune relax 18->8 (l1 hybrid SSOR), strong 0.5->0.25 (3D), agg 1->0, all env-overridable (MARS_AMG_*); GMRES min-iter floor + optional abstol; null-mode guard (reject converged-but-x=0). Best-effort acceptance now rejects null x**
- **pump hypre: harden the acceptance against the 1e7-phi blowup (multi-agent verification confirmed: cause = convergence/conditioning + loose accept gate admitting under-resolved huge phi; sign correct, removeMean NOT needed/refuted). (BUG2) upper-bound x reject in the Hypre wrapper: reject converged-but-|x|>>|b| (MARS_HYPRE_MAXX_RATIO default 1e6) -- the null-guard only caught x~0, not the observed x=huge. (accept) tighten default MARS_HYPRE_ACCEPT_RES 1e-2 -> 1e-6 so a res~2e-4 partial solve is rejected (phi stays warm-started) instead of scattering garbage. (BUG3) fix misleading 'opening-flux on by default' comments (it is OFF). Path to bounded solve: --pspg (AMG-friendly operator) + retuned BoomerAMG + these guards**
- **fix(pump hypre): BoomerAMG RelaxType 8 -> 18 (l1-Jacobi) -- the cause of AMG returning x=0 with a garbage 1.1e-315 residual. The retune to RelaxType=8 (l1-hybrid-SSOR, GS-family) is NOT GPU-functional: the cuda Hypre build does not implement GS-family smoothers as a real sweep (they no-op / go non-symmetric on GPU), so the V-cycle does nothing -> x=0 on the first cycle. The WORKING PCG wrapper (mars_hypre_pcg_solver.hpp:362-373) uses 18 for exactly this reason ('default GS becomes non-symmetric on GPU'), not merely PCG symmetry -- the GMRES comment misread that. l1-Jacobi-AMG-FlexGMRES is the standard GPU pressure solver. Verified pin/PSPG order is correct (pin enforced after PSPG). Testable via MARS_AMG_RELAX=18 (now the default)**
- **pump hypre: complete the AMG fix -- (1) NumSweeps 1->2 (l1-Jacobi is weaker than SSOR; 2 sweeps restore the smoothing strength). (2) Route the --pspg DDT pressure solve to Hypre PCG instead of GMRES: PSPG's tau*L makes A = D M^-1 D^T + tau*L SPD and the symmetric pin removes the null mode, so CG+AMG (the textbook pressure-Poisson solver, what deal.II/MFEM/Nalu use) is valid and more stable than FlexGMRES. Gated on s.usePSPG -> PCG; pure-DDT SPSD stays GMRES (Hypre PCG rejects SPSD with error 1). The PCG wrapper already uses GPU-safe RelaxType=18. MARS_HYPRE_KRYLOV still overrides for debug. Combined with the RelaxType 8->18 fix, this should give a converging bounded AMG pressure solve**
- **TGV: MARS_PRED_PERSLOT_GRADP toggle -- match predictor grad(p) seam reduction to corrector (Fable wdxg6s3ce: predictor folds, corrector per-slot -> dt-independent feedback gain 1.17)**
- **revert(pump hypre): route pressure back to FlexGMRES (not PCG). Routing --pspg to PCG was a regression: the PCG wrapper has NEITHER the null-mode guard NOR the upper-bound-x reject (only the GMRES wrapper does), so a converged-but-huge phi (PCG 'converged' in 14 iters at |phi|=1e123 on the still-ill-conditioned operator) was scattered -> corrector blew up -> inf predictor -> velocity Hypre-PCG errors downstream. GMRES carries the guards that keep it bounded. The RelaxType=18 fix (AMG now functional) stays. PCG can return once its wrapper has the same guards**
- **TGV: MARS_TGV_NONINCREMENTAL toggle (Fable fallback #3 -- p=phi non-incremental, severs pressure-accumulation feedback, loop gain exactly 0)**
- **pump hypre: PCG+AMG is the working --pspg path (port the guards). EMPIRICAL: on our GPU, PCG+BoomerAMG CONVERGES (16 iters, flow develops steps 1-3, div drops) while GMRES+AMG no-ops to x=0 (separate GMRES-wrapper GPU bug, debug later). PSPG makes the operator SPD + the pin removes the null mode, so CG+AMG is valid + textbook. Ported the null-mode + upper-bound-x guards (+ getEnvDouble, lastSolutionMax_, nullSolutionReturned_, accessors) from the GMRES wrapper to the PCG wrapper so a huge/near-null phi is rejected not scattered. Re-route --pspg pressure to PCG (PSPG off stays GMRES for SPSD). solveOneComponent picks up the guard via the solve() return**
- **pump hypre: GMRES+AMG is the pressure path (per the reference: GMRES + AMG-preconditioner). (1) Route --pspg pressure to GMRES, not PCG: GMRES tolerates the assembled DDT+tau*L operator's near-indefiniteness (tiny passage-cell diagonals) where PCG breaks down (pAp<0, HYPRE error 256). (2) Default to PLAIN GMRES (HYPRE_GMRESSetPrecond), not FlexGMRES: a 1-V-cycle AMG is a FIXED linear op so plain GMRES is valid AND is the battle-tested GPU path; FlexGMRES's precond-apply appeared to no-op on our GPU build (x=0, denormal residual). MARS_HYPRE_FLEXGMRES=1 / MARS_HYPRE_KRYLOV=pcg still available. All prior work kept (assembled DDT, PSPG-CSR, guards on both wrappers, symmetric pin, velocity-on-CG, RelaxType=18)**
- **TGV: MARS_TGV_USTART_BCAST toggle -- force start-of-step u broadcast on reduced path so skew advection mdot is seam-consistent (secondary loop is advective: --skew=0 bounds it, --skew=1 doesn't)**
- **pump hypre: pin tiny-diagonal rows of the ASSEMBLED DDT operator (the REAL fix for the 1e6 phi). DIAGNOSIS via plain GMRES+AMG: AMG now CONVERGES tight (40 iters, final_res=8e-9) -- FlexGMRES was the no-op -- but the CONVERGED solution is |phi|~1e6*|b| because the degenerate passage/sliver cells give the operator near-zero diagonals -> near-zero eigenvalues -> A^-1 amplifies ~1e6 -> physically-huge phi -> blowup feedback (b grows with div). FIX: pinTinyDiagonalRowsKernel makes every owned row with diag < MARS_DDT_ASM_PIN_FRAC*max_diag (default 1e-4) an identity row + marks it in d_isPressureBdryDof (RHS zeroed there) -> removes the near-zero eigenvalues so phi is physical. Runs on the assembled matrix before the s.AddT wrap, Hypre-path only. This is the assembled analogue of the matrix-free sliver-pin, reading the ACTUAL assembled diagonal**
- **docs: TGV breakthrough -- primary feedback loop (predictor/corrector grad(p) seam mismatch) FIXED via MARS_PRED_PERSLOT_GRADP; secondary loop localized to skew advection mdot at periodic seam. Baseline step-40 blowup -> step-160. Flags stay opt-in until secondary loop fixed.**
- **TGV: MARS_PRED_PERSLOT_ADV toggle -- make predictor advN per-slot to match per-slot grad(p) (predictor RHS seam-consistency; secondary loop is the advN-folded/gradP-perslot mismatch)**
- **pump hypre: use the GALERKIN LAPLACIAN K (s.Apre), not the Gram form D M^-1 D^T (s.AddT), for the assembled pressure solve -- THE STRUCTURAL FIX. Verified (agent + scaling argument): the DDT diagonal 0.25*|sum sigma_g A_g|^2/V is a square of a CANCELLING signed area-vector sum -> near-zero on GOOD cells (a real sliver gives a HUGE diagonal here, not tiny) -> near-zero eigenvalues -> 1e6 phi amplification -> blowup. Collaborator was RIGHT: no bad mesh cells; it's our Gram construction. The Galerkin K_ij=integral grad N_i.grad N_j has diagonal ~h (sum of squares, no cancellation) -> well-conditioned, AMG-friendly, no near-zero eigenvalue -- and is what the reference assembles. K is SPD so default to PCG+AMG (textbook pressure solver, now valid). MARS_HYPRE_USE_DDT=1 reverts to DDT+GMRES for comparison. Corrector stays M^-1 D^T (div relaxes, acceptable). All prior infra kept**
- **pump hypre: use GMRES (not PCG) for the Galerkin K pressure solve too. K (Apre) is SPD in principle but PCG broke down (pAp<0, HYPRE error 256, ~3 iters) -- BoomerAMG-as-preconditioner is non-symmetric on GPU (GS-family relax) + the pin-row diag=1 spike disturbs coarsening, so the preconditioned operator isn't SPD for CG. GMRES tolerates it (the proven-converging path). RESULT of the K switch: |phi| dropped from 1e6 to ~6000-30000 -- the Galerkin operator IS far better conditioned than DDT (no near-zero eigenvalue), confirming the artifact diagnosis. MARS_HYPRE_KRYLOV=pcg to force CG**
- **TGV: per-slot grad(p) divides by per-slot half-CV mass (d_massNodePerSlot), not merged (workflow w7bapvkdt: per-slot numerator/merged mass = half gradient = the residual factor-of-2 keeping feedback gain >1)**
- **Revert "TGV: per-slot grad(p) divides by per-slot half-CV mass (d_massNodePerSlot), not merged (workflow w7bapvkdt: per-slot numerator/merged mass = half gradient = the residual factor-of-2 keeping feedback gain >1)"**
- **pump: --pressure-k flag = the reference collocated Galerkin setup (the K-path fix). Solves the well-conditioned Galerkin stiffness K (s.Apre, AMG-able, physical phi) AND corrects with the CONJUGATE SCS Green-Gauss gradient (useLegacyGradient=true -> useDivT=false) -- the pairing that makes the K projection consistent. The old 'nearly orthogonal' K-failure was K solved but corrected with D^T (the gradient conjugate to DDT, not K). Pair with --vms-stab (divergence-side checkerboard stabilization, keeps K clean) + --solver=hypre -> the trifecta: well-conditioned + checkerboard-stable + projection-consistent, exactly what the reference does. DDT stays the default (no flag = byte-identical). Workflow-verified high-confidence**
- **fix(pump K-path): use GMRES for the Hypre K pressure solve. The PressureSolveKind::K branch called solveOneComponent with the default KrylovHint (PCG); under --solver=hypre that routes to Hypre PCG, which false-converges in ~2 iters (cg_p=2) on this operator (BoomerAMG non-symmetric on GPU + pin spike) -> garbage phi -> the (now conjugate) corrector amplifies it -> blowup. Pass KrylovHint::GMRES when solverKind==Hypre, matching the DDT branch (cg_p=33-60, converges). This was why --pressure-k --vms-stab blew up despite all 3 fixes being active: the K solve never actually solved**
- **pump: FEM-consistent weak div/grad projection (--pressure-k v2). The SCS divergence/gradient pair has cancellation null modes (the verified artifact), so part of the divergence is INVISIBLE to the correction -> accumulates ~1.2x/step -> blowup ~step 15 regardless of solver (falsified pairings: DDT+D^T exact but 1e6 phi; K+D^T leaks; K+SCS-grad 44x/step). FIX: standard P1 weak-form pair, matched to K -- divergence b_i=-(V/4)dNdx_i.sum(u_j) per element (boundary term = existing opening-flux source), corrector gradient = mass-normalized (V/4)-weighted element-gradient average (the exact adjoint). D_fem M^-1 D_fem^T is a no-cancellation Gram form spectrally equivalent to K -> per-step divergence removal is a contraction on ALL modes. Numerically verified (host replica): exact weak integrals, +grad sign, adjointness. Predictor grad(p^n) switched too. K+Hypre GMRES solve unchanged. New mars_fem_projection.hpp; gated useFemProjection; no flag = byte-identical**
- **pump: consistent P1 face-quadrature opening flux for the FEM projection (the destabilizer fix). DISCRIMINATOR: source OFF -> first STABLE run (phi 219->51 decaying, u bounded, div falling); source ON -> geometric blowup from step 1. The weak form requires oint(N_i u.n) as a consistent face integral; the lumped per-node source (u_i.areaVec_i, global dir) mismatches it node-by-node (rim + per-node-normal curvature) -> fixed-location spurious mass source -> hot spot. FIX: host-side setup weights w_i = (1/12)(2u_i+u_j+u_k).A_f over the side-set triangles using the velocity the BC ACTUALLY imposes per node, uploaded once (d_femFluxWin/Wout); per step divAcc += ramp*w_in + oScale*w_out (net=0 machine-exact, same ramp/oScale algebra). Gated useFemProjection; lumped path untouched otherwise. Verified: exact integral, signs, balance, uniform-velocity == lumped**
- **poiseuille multirank: fix DDT pressure solve across the streamwise rank seam. Three matrix-free fixes (column-zero for SPD, per-iter ghost exchange of p, Jacobi diagonal built matrix-free with reverse-halo fold) + route inlet BCs through the pump path (built inside setup, rank-consistent). 4-rank pressure CG now converges (was non-SPD/diverging). Single-rank byte-identical.**
- **pump: PISO inner pressure corrections (--correctors=N, FEM-projection path). Measured defect: one K-solve contracts the weak divergence only ~0.5-0.6x (K vs the D_fem M^-1 D_fem^T Gram spectral gap), so the un-removed residual + the re-presented boundary flux compound ~1.2-1.3x/step -> blowup ~step 12. FIX: iterate div->solve->correct on the CURRENT velocity iterate within the step; the interior divergence progressively cancels the (constant) boundary source so the SUM shrinks ~0.5x/pass (2-3 passes -> ~10-25% leftover -> contraction). runPressureSolveStep takes optional velocity-iterate ptrs (default u**); computeGradPhi/runCorrector extracted to lambdas, phiTotal accumulated + published so p+=phi and predictor grad(p^n) see the full increment. Honest [fem-div k=..] residual print (the SCS [CORR] div_max mismeasures the FEM path). N=1 byte-identical. gated useFemProjection+TetTag. NOT YET COMPILED**
- **pump: assemble the FEM-Gram pressure operator A_fem = D_fem M^-1 D_fem^T (the EXACT conjugate of the FEM div/grad corrector). Root cause of the un-removable divergence (flat PISO): K != D_fem M^-1 D_fem^T, so solving K leaves a residual the FEM corrector cannot project out. A_fem is the operator the projection identity requires: solve A_fem phi = (rho/dt) D_fem u**, correct u^{n+1}=u**-(dt/rho)M^-1 D_fem^T phi -> D_fem u^{n+1}=0 EXACTLY in one pass (host replica: div 0.173 -> 2.4e-16). Built from the FEM stencil a_i=-(V/4)dNdx_i (NOT SCS area-vectors -> NO cancellation, healthy SPD diagonal ~K/valence, AMG-friendly -- unlike the abandoned SCS DDT). Node-driven assembly factored as sum_i (1/M_i)(S_a.S_b), reuses buildDDTSparsityTet (same two-hop pattern), symmetric pin, wrapped s.AFemGram, solved with Hypre GMRES instead of s.Apre when useFemProjection. [FemGram-health] diag print. Gated; no flag byte-identical. NOT YET COMPILED**
- **pump --pressure-k: solve K + SCS Green-Gauss corrector + rely on --vms-stab (the reference collocated method). PROVEN this session: exact projection is impossible with a well-conditioned operator -- ANY conjugate D M^-1 D^T Gram form (SCS or FEM-Gram) has near-zero interior diagonals because sum_e grad N_a = 0 on a closed 1-ring (divergence theorem); FEM-Gram failed identically to SCS (diag 0.00, |x|=2.3e6, guard-rejected; host 2-tet replica missed it -- no closed-ring node). The reference does NOT drive div=0; it solves the well-conditioned K and stabilizes the residual divergence (--vms-stab). So --pressure-k now = K + useLegacyGradient=true (SCS corrector, K-consistent) + useFemProjection=false (FEM-Gram off). Pair with --vms-stab + --solver=hypre. FEM-Gram/projection kernels kept in tree (gated off) but no longer used by --pressure-k**
- **pump: scale-aware [FemGram-health] diagnostic. The old print flagged diag range [0.00, 0.02] as a fault, but A_fem = D_gal M^-1 D_gal^T is a Gram-Laplacian that correctly scales O(h) in 3D -- 0.02 IS healthy on a fine mesh, not near-zero. Host replica (closed-ring interior node, octahedron) verified: the kernel computes the correct operator to machine precision (brute-force D M^-1 D^T == factored form, diff 0); A_fem[0][0]=h exactly; one correction drops weak div 1e-1 -> 3e-17. The self-term (j==a) IS the cancelling closed-ring sum (~0) but the off-intermediate neighbor terms keep the diagonal positive O(h). New invariants: minDiag/sum|offdiag| (~1 healthy, <<1 = SCS collapse) + max|rowsum|/diag (~0 = constant null mode). Route A (FEM-Gram, --pressure-k) is structurally CORRECT; the earlier blowup was NOT the operator**
- **fix(pump): --pressure-k = Route A (FEM-Gram), the VERIFIED-correct config -- not the proven-bad K+SCS. Host replica proved A_fem = D_gal M^-1 D_gal^T is the correct SPD operator (assembly==brute-force diff 0; one correction drops div 1e-1->3e-17; the [0.00] diagonal was a MISREAD of the healthy O(h) scale). K+SCS gradient AMPLIFIES divergence 100x (25.9->2637, measured) -- that mix is what blew up. Now --pressure-k sets useFemProjection=true -> solver routes to s.AFemGram (GMRES+AMG) + FEM corrector gradient. Consistent weak-Galerkin family throughout**
- **fix(pump): silent neighbor-cap overflow made A_fem near-singular on the real mesh (the actual bug -- NOT the mesh). On the production tet mesh, high-valence interior nodes (40-70+, tets are high-valence) exceeded the hardcoded 48-neighbor caps in buildDDTSparsityTet + assembleFemGramPerNodeKernelTet, which SILENTLY DROPPED couplings -> A_fem rows lost off-diagonals -> near-singular (minDiag/sum|offdiag|=0.02) -> Hypre converges to |x|=2.3e6 for |b|=1.7 (eigenvalue ~1e-6) -> guard-rejects -> phi=0 -> blowup. Host replica (small clean patches, low valence) never hit it. FIX: (1) restructured assembleFemGramPerNodeKernelTet to scatter-direct into the CSR via atomicAddSparseEntry (element-pair double sum, math bit-identical to the verified Sum_i(1/M_i)S_a.S_b) -- NO partner buffer, cannot overflow at any valence, no register pressure; setup-only so the O(m^2) atomics cost nothing. (2) sparsity cap 48->96 (shared macro MARS_DDT_TET_MAX_OTHERS, single source of truth) + overflow COUNTER that prints [FemGram-assembly] N nodes exceeded cap (max valence) -- never silent again. Expect minDiag/sum|offdiag|~1, physical phi, div_max drops**
- **poiseuille: strip failed fork-local multirank seam attempts (ghost-row fold, promoted-ownership assembly, debug probes); keep the working pressure-solve seam fixes + --bdf1. Velocity multirank seam needs element-halo widening in domain.cu (proven: off-rank stiffness lives in elements this rank lacks; not foldable).**
- **pump: symmetric Jacobi scaling of A_fem so AMG solves it on the BIG mesh. A/B PROVED the method works (small mesh: minDiag/sum|offdiag|=0.07, phi physical 74, div_max contracts 9->5, flow develops) but the BIG mesh is near-singular (minDiag=0.02, |x|=2.3e6 for |b|=1.7, accepting it -> div 7->22->161->29869 blowup). The near-zero eigenvalue is from the lumped mass M^-1 spanning a wider range on the bigger non-uniform (but VALID, production-run) mesh -- pure operator conditioning. FIX (textbook for variable-mass B M^-1 B^T): solve A_hat y = b_hat, A_hat = D^-1/2 A_fem D^-1/2 (unit diagonal), recover x = D^-1/2 y (solution identical, just AMG-conditionable). Scale CSR in place at setup (col factor via dofToNode + halo for ghosts), scale b / unscale x per solve, gated useFemGramSolve, MARS_FEMGRAM_NOSCALE for A/B. Expect big-mesh minDiag~1, physical phi, div_max contracts like small. NOT YET COMPILED**
- **docs: confirm secondary loop = skew advection KE injection at non-solenoidal seam (hand-derived energy identity mdot*(qR^2-qL^2))**
- **TGV: MARS_TGV_EMAC -- energy-stable advection correction (advN -= q*div(u)) for non-solenoidal periodic seam; cancels the skew KE-injection (hand-derived residual mdot*(qR^2-qL^2)) without touching u or mass**
- **TGV EMAC: tunable coefficient MARS_TGV_EMAC_C (default -1) to sweep the q*div correction sign/magnitude empirically**
- **pump: --pressure-k default = K-solve + FEM weak gradient (drop the AMG-hostile Gram operator)**
- **docs: node-EMAC negative result; real fix is per-face mdot reconcile at periodic seam (skew is per-element energy-conserving; leak is cross-element mdot mismatch at the shared periodic face)**
- **TGV: MARS_TGV_SEAM_UPWIND -- seam-localized upwind dissipation for the periodic advective loop. PROVEN: per-face energy-zero impossible for conservative flux (production F*(qR-qL)); skew needs div u=0 to telescope; reduced projection leaves per-slot seam div by design -> must dissipate. Surgical upwind blend at seam faces only (derived coeff 0.5a|mdot|(qL-qR), production -0.5a|mdot|(qL-qR)^2<=0). --skew=0 (result 9) proves it bounds; this localizes it.**
- **docs: CORE WALL identified -- reduced periodic projection leaves per-slot seam divergence by design (proven: upwind delays but cannot cure -> continuous div source). NOT advection/corrector/feedback. Same 'boundary-complete divergence' open item as wing/pump. Feedback loops fixed (step40->190). Next = projection completeness, not more correction terms.**
- **docs: final handoff -- most promising untested fix is fold+broadcast CORRECTOR gradPhi (single-rank does this and is clean; differs from result-7 u-broadcast). Plus DOF over-collapse + per-slot residual r_M=-r_S leads. Core wall = projection leaves per-slot seam div.**
- **pump: AMG-on-K preconditioned solve of the Gram operator A_fem (Schur fix)**
- **pump: scale K by A_fem's D^-1/2 for the Schur preconditioner (the consistent fix)**
- **pump: stabilized-K pressure path -- add PSPG tau*L into K (the production method)**
- **pump: GMRES for both Hypre pressure paths (fixes cg_p=3 PCG false-convergence)**
- **pump: ramp the FIX-B pressure head (--pump-dp) with --source-ramp-steps**
- **pump: open-face momentum closure for FIX-B (fixes the advection detonation)**
- **multirank velocity solve: force Jacobi preconditioner diagonal positive (|diag|) so rho=(r,z)>0 -- seam DOFs had negative assembled diagonal, breaking CG conjugacy. Plus domain.hpp halo-factor knob (MARS_HALO_FACTOR, default 1.0) and MARS_NS_DEBUG_STEPS/MARS_CG_TRACE diagnostics. Channel multirank velocity operator still asymmetric at seam (pAp<0) -- next.**
- **pump: cap dt by the pressure-gradient kick too (fixes the head-ramp blowup)**
- **pump: MARS_NS_DEBUG_STEPS env to extend the [ns-dbg] window (watch late-step transitions)**
- **pump: clamp open-face grad(p)/grad(phi) in the predictor+corrector (closes the head-runaway)**
- **render: --side-set-io marks inlet/outlet from the side_set_id field (reliable, not the flow auto-detect)**
- **pump: FIX-B #3 open-face normal-velocity projection (--open-normal-proj)**
- **pump: FIX-B #2 dynamic-head inlet target (--total-pressure, totalPressure BC)**
- **pump: FIX-B #1 flux-consistent pressure BC (--flux-pressure-bc, closes the high-head div-creep)**
- **pump: exempt --flux-pressure-bc from the do-nothing-outlet source guard (the bug that no-op'd #1)**
- **docs: update pump tutorial to the implemented solver + add private deep-dive**
- **docs: privatize pump tutorial (move to gitignored internal-notes/ + correct stale DDT->K+tauL pressure path)**
- **docs: remove pump_cfd_tutorial nav entry + inbound links (NDA hazard + broken publish)**
- **docs: fix fabricated APIs, stale clone URLs, kernel list, multi-rank honesty**
- **channel: add [vel-pap-probe] single consistent-p pAp=(u,Au) diagnostic**
- **docs: use 'summation by parts' for the SCS flux-cancellation property**
- **coupled solver Phase 0: GPU model operator + thin-3D mesh gen, validated vs Erturk-Dursun**
- **coupled solver Phase 1: opt-in point-block BoomerAMG + GPU iter study (existential YES, smoother ceiling)**
- **ACM host Stages 0-2: Galerkin gate + V-cycle faithfulness + decisive stretched-mesh GO (directional beats smoothed-SA on anisotropic meshes)**
- **ACM Stage 3: GPU coarse-operator (sum-of-fine == P^T A P) + injection/restrict transfers, validated on H100 (4 gates exact, n16/32/64)**
- **ACM Stage 4a: GPU multilevel V-cycle (SpMV + point-Jacobi + sum-of-fine hierarchy), validated vs host replica to round-off (n16/32/64)**
- **ACM Stage 4b: native FlexGMRES (Z-basis) + pluggable Preconditioner + GpuAcmPreconditioner; single-rank ACM solver converges coupled saddle system on H100 (Z-basis exact, ACM-FlexGMRES 54/106/97 matches QR ref)**
