### PR TITLE
cstone

### DIFF
--- a/backend/distributed/unstructured/domain.hpp
+++ b/backend/distributed/unstructured/domain.hpp
@@ -1928,8 +1928,9 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
     auto t2 = clk::now();
     bboxTimeMs = std::chrono::duration<float, std::milli>(t2 - t1).count();
 
-    std::cout << "Rank " << rank_ << ": Created bounding box: [" << box_.xmin() << "," << box_.xmax() << "] ["
-              << box_.ymin() << "," << box_.ymax() << "] [" << box_.zmin() << "," << box_.zmax() << "]" << std::endl;
+    if (!std::getenv("MARS_QUIET_MESH"))
+        std::cout << "Rank " << rank_ << ": Created bounding box: [" << box_.xmin() << "," << box_.xmax() << "] ["
+                  << box_.ymin() << "," << box_.ymax() << "] [" << box_.zmin() << "," << box_.zmax() << "]" << std::endl;
 
     // Test SFC precision for this domain (debug only)
     testSfcPrecision<KeyType, RealType>(box_, rank_);
@@ -1960,8 +1961,9 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
     auto t6 = clk::now();
     syncTimeMs = std::chrono::duration<float, std::milli>(t6 - t5).count();
 
-    std::cout << "Rank " << rank_ << " initialized " << ElementTag::Name << " domain with " << nodeCount_
-              << " nodes and " << elementCount_ << " elements." << std::endl;
+    if (!std::getenv("MARS_QUIET_MESH"))
+        std::cout << "Rank " << rank_ << " initialized " << ElementTag::Name << " domain with " << nodeCount_
+                  << " nodes and " << elementCount_ << " elements." << std::endl;
 }
 
 // Constructor from mesh data (for MFEM or other formats) - automatically computes bounding box
@@ -2015,8 +2017,9 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
     sync(d_conn_, d_coords_);
     logGpuMemAroundSync(rank_, "post-sync");
 
-    std::cout << "Rank " << rank_ << " initialized " << ElementTag::Name << " domain with " << nodeCount_
-              << " nodes and " << elementCount_ << " elements." << std::endl;
+    if (!std::getenv("MARS_QUIET_MESH"))
+        std::cout << "Rank " << rank_ << " initialized " << ElementTag::Name << " domain with " << nodeCount_
+                  << " nodes and " << elementCount_ << " elements." << std::endl;
 }
 
 // Constructor from mesh data with boundary info - automatically computes bounding box
@@ -2069,8 +2072,9 @@ ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::ElementDomain(cons
     sync(d_conn_, d_coords_);
     logGpuMemAroundSync(rank_, "post-sync");
 
-    std::cout << "Rank " << rank_ << " initialized " << ElementTag::Name << " domain with " << nodeCount_
-              << " nodes and " << elementCount_ << " elements." << std::endl;
+    if (!std::getenv("MARS_QUIET_MESH"))
+        std::cout << "Rank " << rank_ << " initialized " << ElementTag::Name << " domain with " << nodeCount_
+                  << " nodes and " << elementCount_ << " elements." << std::endl;
 }
 
 // Device-data constructor: no host round-trip
@@ -2169,7 +2173,8 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::readMeshDataS
 {
     int rank = rank_;
     int numRanks = numRanks_;
-    std::cout << "Reading mesh data from " << meshFile << " on rank " << rank << std::endl;
+    if (!std::getenv("MARS_QUIET_MESH"))
+        std::cout << "Reading mesh data from " << meshFile << " on rank " << rank << std::endl;
     try
     {
         // Helper to handle coordinate conversion based on type
@@ -2529,8 +2534,9 @@ void ElementDomain<ElementTag, RealType, KeyType, AcceleratorTag>::sync(const De
             thrust::raw_pointer_cast(d_elemH.data()), elementCount_);
         cudaCheckError();
 
-        std::cout << "Rank " << rank_ << " syncing " << ElementTag::Name << " domain with " << elementCount_
-                  << " elements." << std::endl;
+        if (!std::getenv("MARS_QUIET_MESH"))
+            std::cout << "Rank " << rank_ << " syncing " << ElementTag::Name << " domain with " << elementCount_
+                      << " elements." << std::endl;
 
         // Check if we need to sync with original coordinates (compile-time check for hex8)
         if constexpr (std::is_same_v<ElementTag, HexTag>) {
@@ -3182,7 +3188,8 @@ CoordinateCache<ElementTag, RealType, KeyType, AcceleratorTag>::CoordinateCache(
             thrust::raw_pointer_cast(d_node_z_.data()), nodeCount, domain.getBoundingBox());
         cudaCheckError();
 
-        std::cout << "Rank " << domain.rank() << " cached " << nodeCount << " node coordinates." << std::endl;
+        if (!std::getenv("MARS_QUIET_MESH"))
+            std::cout << "Rank " << domain.rank() << " cached " << nodeCount << " node coordinates." << std::endl;
     }
 }
 

--- a/backend/distributed/unstructured/solvers/mars_acm_vcycle.hpp
+++ b/backend/distributed/unstructured/solvers/mars_acm_vcycle.hpp
@@ -18,8 +18,13 @@
 #include "backend/distributed/unstructured/solvers/mars_acm_coarsen.hpp"
 #include <thrust/device_vector.h>
 #include <thrust/fill.h>
+#include <cusolverSp.h>
+#include <cusparse.h>
 #include <vector>
 #include <set>
+#include <unordered_map>
+#include <algorithm>
+#include <type_traits>
 #include <cmath>
 
 namespace mars {
@@ -75,22 +80,66 @@ struct AcmLevel {
     thrust::device_vector<RealType> bvec, xvec, rtmp, xtmp;    // per-level cycle work vectors
 };
 
-// host-once greedy aggregation on the block graph of a coupled (4*node+comp) CSR
-inline void acmHostAggregate(const std::vector<int>& rowOff, const std::vector<int>& colInd,
-                             int nNodes, int kmax, std::vector<int>& agg, int& nCoarse)
+// host-once DIRECTIONAL aggregation (Mavriplis-style, paper Eqs 19-20) on the block graph of a coupled
+// (4*node+comp) CSR. Strength S_IJ = ||A_IJ block||_F symmetrized -- the paper's algebraic "mutual
+// coefficients" route: on a stretched mesh the strong couplings run across the thin cell direction, so
+// aggregates elongate along the anisotropy. Two-sided strong test with factor beta (paper uses 0.5),
+// strongest-first greedy seed-growth, then a cleanup pass that ABSORBS leftover nodes into the strongest
+// neighboring aggregate (this is what keeps the coarsening ratio healthy -- avoids the singleton spray
+// that made the isotropic greedy stall at ~1.3x on unstructured meshes). beta=0 -> isotropic.
+template<typename RealType>
+inline void acmDirectionalAggregate(const std::vector<int>& rowOff, const std::vector<int>& colInd,
+                                    const std::vector<RealType>& vals, int nNodes, int kmax,
+                                    RealType beta, std::vector<int>& agg, int& nCoarse)
 {
     const int ND = 4 * nNodes;
-    std::vector<std::set<int>> nb(nNodes);
+    // block-Frobenius^2 per ordered block-pair (I,J), I!=J
+    std::unordered_map<long long, RealType> sq;
+    sq.reserve(static_cast<size_t>(colInd.size()));
     for (int r = 0; r < ND; ++r) {
-        int I = r >> 2;
-        for (int k = rowOff[r]; k < rowOff[r + 1]; ++k) nb[I].insert(colInd[k] >> 2);
+        long long I = r >> 2;
+        for (int k = rowOff[r]; k < rowOff[r + 1]; ++k) {
+            long long J = colInd[k] >> 2;
+            if (I != J) sq[I * static_cast<long long>(nNodes) + J] += vals[k] * vals[k];
+        }
     }
+    // symmetric strength S_IJ = sqrt(sq_IJ + sq_JI), each undirected edge emitted once into both lists
+    std::vector<std::vector<std::pair<int, RealType>>> nb(nNodes);
+    for (const auto& kv : sq) {
+        int I = static_cast<int>(kv.first / nNodes), J = static_cast<int>(kv.first % nNodes);
+        if (I < J) {
+            auto it = sq.find(J * static_cast<long long>(nNodes) + I);
+            RealType s = std::sqrt(kv.second + (it != sq.end() ? it->second : RealType(0)));
+            nb[I].push_back({J, s}); nb[J].push_back({I, s});
+        }
+    }
+    std::vector<RealType> wmax(nNodes, 0);
+    for (int i = 0; i < nNodes; ++i) {
+        for (auto& e : nb[i]) wmax[i] = std::max(wmax[i], e.second);
+        std::sort(nb[i].begin(), nb[i].end(), [](auto& a, auto& b) { return a.second > b.second; });  // strongest first
+    }
+    auto strong = [&](int i, int j, RealType s) { return s > beta * wmax[i] && s > beta * wmax[j]; };
+
     agg.assign(nNodes, -1); nCoarse = 0;
+    // Pass 1: seed only where a strong unaggregated neighbor exists (no singleton-seeding), fuse strongest-first
+    for (int seed = 0; seed < nNodes; ++seed) {
+        if (agg[seed] != -1) continue;
+        bool canSeed = false;
+        for (auto& e : nb[seed]) if (agg[e.first] == -1 && strong(seed, e.first, e.second)) { canSeed = true; break; }
+        if (!canSeed) continue;
+        agg[seed] = nCoarse; int cnt = 1;
+        for (auto& e : nb[seed]) {
+            if (cnt >= kmax) break;
+            if (agg[e.first] == -1 && strong(seed, e.first, e.second)) { agg[e.first] = nCoarse; ++cnt; }
+        }
+        ++nCoarse;
+    }
+    // Pass 2: absorb every leftover node into its strongest neighboring aggregate (true isolates -> own)
     for (int i = 0; i < nNodes; ++i) {
         if (agg[i] != -1) continue;
-        agg[i] = nCoarse; int cnt = 1;
-        for (int j : nb[i]) { if (cnt >= kmax) break; if (j != i && agg[j] == -1) { agg[j] = nCoarse; ++cnt; } }
-        ++nCoarse;
+        int best = -1;
+        for (auto& e : nb[i]) if (agg[e.first] != -1) { best = agg[e.first]; break; }   // nb sorted by strength
+        agg[i] = (best >= 0) ? best : nCoarse++;
     }
 }
 
@@ -98,7 +147,8 @@ template<typename RealType>
 void acmBuildHierarchy(const thrust::device_vector<int>& rowOff0,
                        const thrust::device_vector<int>& colInd0,
                        const thrust::device_vector<RealType>& vals0, int nNodes0,
-                       int kmax, int maxCoarseND, std::vector<AcmLevel<RealType>>& levels)
+                       int kmax, int maxCoarseND, std::vector<AcmLevel<RealType>>& levels,
+                       RealType beta = RealType(0.5))
 {
     levels.clear();
     {
@@ -117,10 +167,12 @@ void acmBuildHierarchy(const thrust::device_vector<int>& rowOff0,
         if (levels[idx].ND <= maxCoarseND) break;
 
         std::vector<int> hro(levels[idx].rowOff.size()), hci(levels[idx].colInd.size());
+        std::vector<RealType> hva(levels[idx].vals.size());
         thrust::copy(levels[idx].rowOff.begin(), levels[idx].rowOff.end(), hro.begin());
         thrust::copy(levels[idx].colInd.begin(), levels[idx].colInd.end(), hci.begin());
+        thrust::copy(levels[idx].vals.begin(), levels[idx].vals.end(), hva.begin());
         std::vector<int> agg; int nCoarse;
-        acmHostAggregate(hro, hci, levels[idx].nNodes, kmax, agg, nCoarse);
+        acmDirectionalAggregate<RealType>(hro, hci, hva, levels[idx].nNodes, kmax, beta, agg, nCoarse);
         if (nCoarse >= levels[idx].nNodes) break;            // no coarsening progress
 
         levels[idx].agg.assign(agg.begin(), agg.end());
@@ -144,14 +196,40 @@ inline void acmSmoothGpu(AcmLevel<RealType>& L, int sweeps, RealType omega)
     }
 }
 
+// coarsest direct solve (Algorithm A): A_c x = b via cusolverSp QR. Replaces the non-contractive Jacobi
+// sweeps that poison a deep hierarchy. The coarse op is indefinite -> QR (not LU). cs==nullptr keeps the
+// Jacobi-sweep coarsest (so the Stage-4a host-vs-GPU V-cycle match still holds bit-for-bit).
+template<typename RealType>
+inline void acmCoarseSolve(AcmLevel<RealType>& L, int coarse, RealType omega,
+                           cusolverSpHandle_t cs, cusparseMatDescr_t descr)
+{
+    if (!(cs && descr)) { acmSmoothGpu(L, coarse, omega); return; }
+    int singularity = -1;                                  // <0 = full rank; >=0 = first deficient pivot
+    const int nnzc = static_cast<int>(L.vals.size());
+    if constexpr (std::is_same_v<RealType, double>)
+        cusolverSpDcsrlsvqr(cs, L.ND, nnzc, descr, acmRaw(L.vals), acmRaw(L.rowOff), acmRaw(L.colInd),
+                            acmRaw(L.bvec), 1e-12, 1, acmRaw(L.xvec), &singularity);   // reorder=1 (match ref, stabilize)
+    else
+        cusolverSpScsrlsvqr(cs, L.ND, nnzc, descr, acmRaw(L.vals), acmRaw(L.rowOff), acmRaw(L.colInd),
+                            acmRaw(L.bvec), 1e-6f, 1, acmRaw(L.xvec), &singularity);
+    cudaDeviceSynchronize();
+    // a rank-deficient coarse saddle block (near-null pressure mode) makes the QR least-squares solve
+    // unreliable -> don't inject garbage into the cycle; reset and fall back to smoothing.
+    if (singularity >= 0) {
+        thrust::fill(L.xvec.begin(), L.xvec.end(), RealType(0));
+        acmSmoothGpu(L, coarse, omega);
+    }
+}
+
 // one V-cycle on levels[Lidx], operating on its bvec (in) / xvec (in-out)
 template<typename RealType>
 void acmVcycleGpu(std::vector<AcmLevel<RealType>>& levels, int Lidx,
-                  int pre, int post, int coarse, RealType omega)
+                  int pre, int post, int coarse, RealType omega,
+                  cusolverSpHandle_t cs = nullptr, cusparseMatDescr_t descr = nullptr)
 {
     AcmLevel<RealType>& L = levels[Lidx];
     const int blk = 256, grd = (L.ND + blk - 1) / blk;
-    if (Lidx == (int)levels.size() - 1) { acmSmoothGpu(L, coarse, omega); return; }
+    if (Lidx == (int)levels.size() - 1) { acmCoarseSolve(L, coarse, omega, cs, descr); return; }
 
     acmSmoothGpu(L, pre, omega);
     acmSpmvKernel<RealType><<<grd, blk>>>(acmRaw(L.rowOff), acmRaw(L.colInd), acmRaw(L.vals),
@@ -164,7 +242,7 @@ void acmVcycleGpu(std::vector<AcmLevel<RealType>>& levels, int Lidx,
     const int gN = (L.nNodes + blk - 1) / blk;
     acmRestrictAddKernel<RealType><<<gN, blk>>>(acmRaw(L.rtmp), acmRaw(C.bvec), acmRaw(L.agg), L.nNodes);
 
-    acmVcycleGpu(levels, Lidx + 1, pre, post, coarse, omega);
+    acmVcycleGpu(levels, Lidx + 1, pre, post, coarse, omega, cs, descr);
 
     acmInjectKernel<RealType><<<gN, blk>>>(acmRaw(C.xvec), acmRaw(L.xtmp), acmRaw(L.agg), L.nNodes);
     acmAddKernel<RealType><<<grd, blk>>>(acmRaw(L.xvec), acmRaw(L.xtmp), L.ND);

--- a/backend/distributed/unstructured/solvers/mars_acm_vcycle.hpp
+++ b/backend/distributed/unstructured/solvers/mars_acm_vcycle.hpp
@@ -63,6 +63,68 @@ __global__ void acmJacobiKernel(const int* rowOff, const int* colInd, const Real
     xout[r] = xin[r] + omega * dinv[r] * (b[r] - s);
 }
 
+// ---- COUPLED (block) smoother: invert the per-node 4x4 [u,v,w,p] block so each relaxation captures
+// the local pressure-velocity coupling (point-Jacobi is segregated -- it never sees the G/D coupling).
+// 4x4 Gauss-Jordan inverse with partial pivoting + tiny-pivot regularization (host+device).
+template<typename T>
+__host__ __device__ inline void acmInvert4x4(const T* A, T* Ai)
+{
+    T m[4][8];
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) m[i][j] = A[4 * i + j];
+        for (int j = 0; j < 4; ++j) m[i][4 + j] = (i == j) ? T(1) : T(0);
+    }
+    for (int col = 0; col < 4; ++col) {
+        int piv = col; T best = fabs((double)m[col][col]);
+        for (int r = col + 1; r < 4; ++r) { double v = fabs((double)m[r][col]); if (v > best) { best = v; piv = r; } }
+        if (piv != col) for (int j = 0; j < 8; ++j) { T t = m[col][j]; m[col][j] = m[piv][j]; m[piv][j] = t; }
+        T d = m[col][col];
+        if (fabs((double)d) < 1e-30) d = (d >= T(0)) ? T(1e-30) : T(-1e-30);   // regularize singular block
+        for (int j = 0; j < 8; ++j) m[col][j] /= d;
+        for (int r = 0; r < 4; ++r) if (r != col) { T f = m[r][col]; for (int j = 0; j < 8; ++j) m[r][j] -= f * m[col][j]; }
+    }
+    for (int i = 0; i < 4; ++i) for (int j = 0; j < 4; ++j) Ai[4 * i + j] = m[i][4 + j];
+}
+
+// per node: extract the 4x4 diagonal [u,v,w,p] block from the CSR and store its inverse (16/node)
+template<typename RealType>
+__global__ void acmBlockInvKernel(const int* rowOff, const int* colInd, const RealType* vals,
+                                  RealType* binv, int nNodes)
+{
+    int node = blockIdx.x * blockDim.x + threadIdx.x; if (node >= nNodes) return;
+    RealType B[16];
+    for (int t = 0; t < 16; ++t) B[t] = RealType(0);
+    for (int a = 0; a < 4; ++a) {
+        int r = 4 * node + a;
+        for (int k = rowOff[r]; k < rowOff[r + 1]; ++k) {
+            int c = colInd[k];
+            if (c >= 4 * node && c < 4 * node + 4) B[4 * a + (c - 4 * node)] = vals[k];
+        }
+    }
+    acmInvert4x4(B, binv + 16 * node);
+}
+
+// one damped BLOCK-Jacobi sweep: per node x_blk += omega * Binv * (b - A xin)_blk  (couples u,v,w,p)
+template<typename RealType>
+__global__ void acmBlockJacobiKernel(const int* rowOff, const int* colInd, const RealType* vals,
+                                     const RealType* binv, const RealType* b,
+                                     const RealType* xin, RealType* xout, RealType omega, int nNodes)
+{
+    int node = blockIdx.x * blockDim.x + threadIdx.x; if (node >= nNodes) return;
+    RealType res[4];
+    for (int a = 0; a < 4; ++a) {
+        int r = 4 * node + a; RealType s = 0;
+        for (int k = rowOff[r]; k < rowOff[r + 1]; ++k) s += vals[k] * xin[colInd[k]];
+        res[a] = b[r] - s;
+    }
+    const RealType* Bi = binv + 16 * node;
+    for (int a = 0; a < 4; ++a) {
+        RealType dx = 0;
+        for (int c = 0; c < 4; ++c) dx += Bi[4 * a + c] * res[c];
+        xout[4 * node + a] = xin[4 * node + a] + omega * dx;
+    }
+}
+
 template<typename RealType>
 __global__ void acmSubKernel(const RealType* a, const RealType* b, RealType* y, int ND)
 { int r = blockIdx.x * blockDim.x + threadIdx.x; if (r < ND) y[r] = a[r] - b[r]; }
@@ -75,7 +137,7 @@ template<typename RealType>
 struct AcmLevel {
     int nNodes = 0, ND = 0, nCoarse = 0;
     thrust::device_vector<int> rowOff, colInd;
-    thrust::device_vector<RealType> vals, dinv;
+    thrust::device_vector<RealType> vals, dinv, binv;          // dinv: point-Jacobi; binv: 4x4 block-Jacobi
     thrust::device_vector<int> agg;                            // nNodes -> parent (empty on coarsest)
     thrust::device_vector<RealType> bvec, xvec, rtmp, xtmp;    // per-level cycle work vectors
 };
@@ -162,6 +224,10 @@ void acmBuildHierarchy(const thrust::device_vector<int>& rowOff0,
         levels[idx].dinv.resize(levels[idx].ND);
         acmDinvKernel<RealType><<<grd, blk>>>(acmRaw(levels[idx].rowOff), acmRaw(levels[idx].colInd),
                                               acmRaw(levels[idx].vals), acmRaw(levels[idx].dinv), levels[idx].ND);
+        levels[idx].binv.resize(16 * levels[idx].nNodes);     // per-node 4x4 inverse (coupled block smoother)
+        { const int gN = (levels[idx].nNodes + blk - 1) / blk;
+          acmBlockInvKernel<RealType><<<gN, blk>>>(acmRaw(levels[idx].rowOff), acmRaw(levels[idx].colInd),
+              acmRaw(levels[idx].vals), acmRaw(levels[idx].binv), levels[idx].nNodes); }
         levels[idx].bvec.assign(levels[idx].ND, 0); levels[idx].xvec.assign(levels[idx].ND, 0);
         levels[idx].rtmp.assign(levels[idx].ND, 0); levels[idx].xtmp.assign(levels[idx].ND, 0);
         if (levels[idx].ND <= maxCoarseND) break;
@@ -185,13 +251,19 @@ void acmBuildHierarchy(const thrust::device_vector<int>& rowOff0,
     }
 }
 
+// useBlock=true -> coupled per-node 4x4 block-Jacobi (captures the local [u,v,w,p] coupling);
+// false -> segregated point-Jacobi (kept for the Stage-4a host-match gate).
 template<typename RealType>
-inline void acmSmoothGpu(AcmLevel<RealType>& L, int sweeps, RealType omega)
+inline void acmSmoothGpu(AcmLevel<RealType>& L, int sweeps, RealType omega, bool useBlock)
 {
-    const int blk = 256, grd = (L.ND + blk - 1) / blk;
+    const int blk = 256, grd = (L.ND + blk - 1) / blk, gN = (L.nNodes + blk - 1) / blk;
     for (int s = 0; s < sweeps; ++s) {
-        acmJacobiKernel<RealType><<<grd, blk>>>(acmRaw(L.rowOff), acmRaw(L.colInd), acmRaw(L.vals),
-            acmRaw(L.dinv), acmRaw(L.bvec), acmRaw(L.xvec), acmRaw(L.xtmp), omega, L.ND);
+        if (useBlock)
+            acmBlockJacobiKernel<RealType><<<gN, blk>>>(acmRaw(L.rowOff), acmRaw(L.colInd), acmRaw(L.vals),
+                acmRaw(L.binv), acmRaw(L.bvec), acmRaw(L.xvec), acmRaw(L.xtmp), omega, L.nNodes);
+        else
+            acmJacobiKernel<RealType><<<grd, blk>>>(acmRaw(L.rowOff), acmRaw(L.colInd), acmRaw(L.vals),
+                acmRaw(L.dinv), acmRaw(L.bvec), acmRaw(L.xvec), acmRaw(L.xtmp), omega, L.ND);
         L.xvec.swap(L.xtmp);                                 // O(1) pointer swap; xvec holds the new iterate
     }
 }
@@ -200,10 +272,10 @@ inline void acmSmoothGpu(AcmLevel<RealType>& L, int sweeps, RealType omega)
 // sweeps that poison a deep hierarchy. The coarse op is indefinite -> QR (not LU). cs==nullptr keeps the
 // Jacobi-sweep coarsest (so the Stage-4a host-vs-GPU V-cycle match still holds bit-for-bit).
 template<typename RealType>
-inline void acmCoarseSolve(AcmLevel<RealType>& L, int coarse, RealType omega,
+inline void acmCoarseSolve(AcmLevel<RealType>& L, int coarse, RealType omega, bool useBlock,
                            cusolverSpHandle_t cs, cusparseMatDescr_t descr)
 {
-    if (!(cs && descr)) { acmSmoothGpu(L, coarse, omega); return; }
+    if (!(cs && descr)) { acmSmoothGpu(L, coarse, omega, useBlock); return; }
     int singularity = -1;                                  // <0 = full rank; >=0 = first deficient pivot
     const int nnzc = static_cast<int>(L.vals.size());
     if constexpr (std::is_same_v<RealType, double>)
@@ -217,21 +289,21 @@ inline void acmCoarseSolve(AcmLevel<RealType>& L, int coarse, RealType omega,
     // unreliable -> don't inject garbage into the cycle; reset and fall back to smoothing.
     if (singularity >= 0) {
         thrust::fill(L.xvec.begin(), L.xvec.end(), RealType(0));
-        acmSmoothGpu(L, coarse, omega);
+        acmSmoothGpu(L, coarse, omega, useBlock);
     }
 }
 
-// one V-cycle on levels[Lidx], operating on its bvec (in) / xvec (in-out)
+// one V-cycle on levels[Lidx], operating on its bvec (in) / xvec (in-out). useBlock -> coupled block-Jacobi.
 template<typename RealType>
 void acmVcycleGpu(std::vector<AcmLevel<RealType>>& levels, int Lidx,
-                  int pre, int post, int coarse, RealType omega,
+                  int pre, int post, int coarse, RealType omega, bool useBlock = false,
                   cusolverSpHandle_t cs = nullptr, cusparseMatDescr_t descr = nullptr)
 {
     AcmLevel<RealType>& L = levels[Lidx];
     const int blk = 256, grd = (L.ND + blk - 1) / blk;
-    if (Lidx == (int)levels.size() - 1) { acmCoarseSolve(L, coarse, omega, cs, descr); return; }
+    if (Lidx == (int)levels.size() - 1) { acmCoarseSolve(L, coarse, omega, useBlock, cs, descr); return; }
 
-    acmSmoothGpu(L, pre, omega);
+    acmSmoothGpu(L, pre, omega, useBlock);
     acmSpmvKernel<RealType><<<grd, blk>>>(acmRaw(L.rowOff), acmRaw(L.colInd), acmRaw(L.vals),
                                           acmRaw(L.xvec), acmRaw(L.rtmp), L.ND);
     acmSubKernel<RealType><<<grd, blk>>>(acmRaw(L.bvec), acmRaw(L.rtmp), acmRaw(L.rtmp), L.ND);
@@ -242,11 +314,11 @@ void acmVcycleGpu(std::vector<AcmLevel<RealType>>& levels, int Lidx,
     const int gN = (L.nNodes + blk - 1) / blk;
     acmRestrictAddKernel<RealType><<<gN, blk>>>(acmRaw(L.rtmp), acmRaw(C.bvec), acmRaw(L.agg), L.nNodes);
 
-    acmVcycleGpu(levels, Lidx + 1, pre, post, coarse, omega, cs, descr);
+    acmVcycleGpu(levels, Lidx + 1, pre, post, coarse, omega, useBlock, cs, descr);
 
     acmInjectKernel<RealType><<<gN, blk>>>(acmRaw(C.xvec), acmRaw(L.xtmp), acmRaw(L.agg), L.nNodes);
     acmAddKernel<RealType><<<grd, blk>>>(acmRaw(L.xvec), acmRaw(L.xtmp), L.ND);
-    acmSmoothGpu(L, post, omega);
+    acmSmoothGpu(L, post, omega, useBlock);
 }
 
 // ---- host replica (validation oracle): same hierarchy, same arithmetic, on the CPU ----

--- a/backend/distributed/unstructured/solvers/mars_gpu_acm_preconditioner.hpp
+++ b/backend/distributed/unstructured/solvers/mars_gpu_acm_preconditioner.hpp
@@ -78,7 +78,7 @@ public:
         thrust::copy(thrust::device_pointer_cast(r.data()),
                      thrust::device_pointer_cast(r.data() + nd_), levels_[0].bvec.begin());
         thrust::fill(levels_[0].xvec.begin(), levels_[0].xvec.end(), RealType(0));
-        mars::acmVcycleGpu<RealType>(levels_, 0, pre_, post_, coarse_, omega_, cs_, descr_);
+        mars::acmVcycleGpu<RealType>(levels_, 0, pre_, post_, coarse_, omega_, /*useBlock=*/true, cs_, descr_);
         thrust::copy(levels_[0].xvec.begin(), levels_[0].xvec.end(),
                      thrust::device_pointer_cast(z.data()));
     }

--- a/backend/distributed/unstructured/solvers/mars_gpu_acm_preconditioner.hpp
+++ b/backend/distributed/unstructured/solvers/mars_gpu_acm_preconditioner.hpp
@@ -15,6 +15,7 @@
 #include <thrust/copy.h>
 #include <thrust/fill.h>
 #include <vector>
+#include <cstdlib>
 
 namespace mars
 {
@@ -28,9 +29,29 @@ public:
     using Matrix = SparseMatrix<IndexType, RealType, AcceleratorTag>;
     using Vector = typename mars::VectorSelector<RealType, AcceleratorTag>::type;
 
-    GpuAcmPreconditioner(int kmax = 4, int maxCoarseND = 64,
+    // maxCoarseND=256: directional aggregation coarsens fast, so a moderate coarsest is reached in few
+    // levels and is solved directly by QR. beta defaults to 0.5 (the paper's directional factor); env
+    // MARS_ACM_BETA overrides it (set 0 for isotropic, to A/B against directional in one binary).
+    GpuAcmPreconditioner(int kmax = 4, int maxCoarseND = 256,
                          int pre = 2, int post = 1, int coarse = 10, RealType omega = RealType(0.7))
-        : kmax_(kmax), maxCoarseND_(maxCoarseND), pre_(pre), post_(post), coarse_(coarse), omega_(omega) {}
+        : kmax_(kmax), maxCoarseND_(maxCoarseND), pre_(pre), post_(post), coarse_(coarse),
+          omega_(omega), beta_(RealType(0.5))
+    {
+        if (const char* e = std::getenv("MARS_ACM_BETA")) beta_ = static_cast<RealType>(std::atof(e));
+        cusolverSpCreate(&cs_);
+        cusparseCreateMatDescr(&descr_);
+        cusparseSetMatType(descr_, CUSPARSE_MATRIX_TYPE_GENERAL);
+        cusparseSetMatIndexBase(descr_, CUSPARSE_INDEX_BASE_ZERO);
+    }
+
+    ~GpuAcmPreconditioner()
+    {
+        if (descr_) cusparseDestroyMatDescr(descr_);
+        if (cs_) cusolverSpDestroy(cs_);
+    }
+
+    GpuAcmPreconditioner(const GpuAcmPreconditioner&) = delete;             // owns a cusolver handle
+    GpuAcmPreconditioner& operator=(const GpuAcmPreconditioner&) = delete;
 
     // build the multilevel hierarchy once from the finest coupled CSR (interleaved 4*node+comp)
     void setup(const Matrix& A) override
@@ -46,28 +67,31 @@ public:
         thrust::copy(thrust::device_pointer_cast(A.valuesPtr()),
                      thrust::device_pointer_cast(A.valuesPtr() + nz), va.begin());
         // acmBuildHierarchy wants int CSR; IndexType is int in this driver's instantiation.
-        mars::acmBuildHierarchy<RealType>(ro, ci, va, ND / 4, kmax_, maxCoarseND_, levels_);
+        mars::acmBuildHierarchy<RealType>(ro, ci, va, ND / 4, kmax_, maxCoarseND_, levels_, beta_);
         nd_ = ND;
     }
 
-    // z = M^-1 r  (one V-cycle, fresh zero initial guess)
+    // z = M^-1 r  (one V-cycle, fresh zero initial guess; direct QR at the coarsest)
     void apply(const Vector& r, Vector& z) override
     {
         if (static_cast<int>(z.size()) != nd_) z.resize(nd_);
         thrust::copy(thrust::device_pointer_cast(r.data()),
                      thrust::device_pointer_cast(r.data() + nd_), levels_[0].bvec.begin());
         thrust::fill(levels_[0].xvec.begin(), levels_[0].xvec.end(), RealType(0));
-        mars::acmVcycleGpu<RealType>(levels_, 0, pre_, post_, coarse_, omega_);
+        mars::acmVcycleGpu<RealType>(levels_, 0, pre_, post_, coarse_, omega_, cs_, descr_);
         thrust::copy(levels_[0].xvec.begin(), levels_[0].xvec.end(),
                      thrust::device_pointer_cast(z.data()));
     }
 
     int numLevels() const { return static_cast<int>(levels_.size()); }
+    RealType beta() const { return beta_; }
 
 private:
     int kmax_, maxCoarseND_, pre_, post_, coarse_, nd_ = 0;
-    RealType omega_;
+    RealType omega_, beta_;
     std::vector<mars::AcmLevel<RealType>> levels_;
+    cusolverSpHandle_t cs_ = nullptr;
+    cusparseMatDescr_t descr_ = nullptr;
 };
 
 }  // namespace fem

--- a/backend/distributed/unstructured/utils/mars_read_exodus_mesh.hpp
+++ b/backend/distributed/unstructured/utils/mars_read_exodus_mesh.hpp
@@ -8,6 +8,7 @@
 #include <tuple>
 #include <algorithm>
 #include <cstring>
+#include <cstdlib>
 #include <map>
 #include <array>
 #include <unordered_set>
@@ -104,7 +105,8 @@ inline auto readExodusMeshWithElementPartitioning(const std::string& meshFile, i
     }
 
     if (rank == 0) {
-        std::cout << "Exodus mesh: " << total_nodes << " nodes, " << total_elements << " elements" << std::endl;
+        if (!std::getenv("MARS_QUIET_MESH"))
+            std::cout << "Exodus mesh: " << total_nodes << " nodes, " << total_elements << " elements" << std::endl;
     }
 
     // Read all coordinates (we need global coordinates for proper partitioning)
@@ -226,7 +228,8 @@ inline auto readExodusMeshWithElementPartitioning(const std::string& meshFile, i
     std::vector<uint8_t> boundaryNodes(nodeCount, 0);
 
     if (rank == 0) {
-        std::cout << "Rank 0: " << elementCount << " elements, " << nodeCount << " nodes (from Exodus)" << std::endl;
+        if (!std::getenv("MARS_QUIET_MESH"))
+            std::cout << "Rank 0: " << elementCount << " elements, " << nodeCount << " nodes (from Exodus)" << std::endl;
     }
 
     return std::make_tuple(nodeCount, elementCount,

--- a/examples/distributed/unstructured/mars_coupled_model_operator.cu
+++ b/examples/distributed/unstructured/mars_coupled_model_operator.cu
@@ -1107,14 +1107,22 @@ int main(int argc, char** argv)
             int it = 0, singularity = -2; RealType du = 0;
             cusolverStatus_t st = CUSOLVER_STATUS_SUCCESS;
             for (it = 0; it < picard; ++it) {
-                // re-assemble with the frozen (previous-iterate) velocity, proper nu/tau
+                // re-assemble with the frozen (previous-iterate) velocity. doRhieChow -> collocated RC
+                // operator (no tau); else PSPG. The cavity benchmark (vs Erturk-Dursun) validates RC accuracy.
                 thrust::fill(d_vals.begin(), d_vals.end(), RealType(0));
-                assembleCoupledStokesKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
-                    c0, c1, c2, c3, nx, ny, nz,
-                    thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
-                    thrust::raw_pointer_cast(d_vals.data()), nuS, tauS,
-                    thrust::raw_pointer_cast(d_avx.data()), thrust::raw_pointer_cast(d_avy.data()),
-                    thrust::raw_pointer_cast(d_avz.data()), startEl, numLocal);
+                if (doRhieChow)
+                    assembleRhieChowGpu<KeyType, RealType>(c0, c1, c2, c3, nx, ny, nz,
+                        thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
+                        thrust::raw_pointer_cast(d_vals.data()), nuS,
+                        thrust::raw_pointer_cast(d_avx.data()), thrust::raw_pointer_cast(d_avy.data()),
+                        thrust::raw_pointer_cast(d_avz.data()), startEl, numLocal, (int)nNodes, blockSize);
+                else
+                    assembleCoupledStokesKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+                        c0, c1, c2, c3, nx, ny, nz,
+                        thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
+                        thrust::raw_pointer_cast(d_vals.data()), nuS, tauS,
+                        thrust::raw_pointer_cast(d_avx.data()), thrust::raw_pointer_cast(d_avy.data()),
+                        thrust::raw_pointer_cast(d_avz.data()), startEl, numLocal);
                 cudaDeviceSynchronize();
                 thrust::fill(d_rhs.begin(), d_rhs.end(), RealType(0));
                 applyBCKernel<RealType><<<dblk, blockSize>>>(

--- a/examples/distributed/unstructured/mars_coupled_model_operator.cu
+++ b/examples/distributed/unstructured/mars_coupled_model_operator.cu
@@ -263,6 +263,41 @@ __global__ void assembleRhieChowDivGradKernel(
     }
 }
 
+// Assemble the full collocated Rhie-Chow coupled operator into a pre-zeroed CSR (caller fills d_vals=0):
+// a^uu(nu*K) + FV a^pu/a^up=-(a^pu)^T + RC a^pp d_f-Laplacian (d_f from the momentum diagonal, no tau).
+template<typename KeyType, typename RealType>
+void assembleRhieChowGpu(const KeyType* c0, const KeyType* c1, const KeyType* c2, const KeyType* c3,
+                         const RealType* nx, const RealType* ny, const RealType* nz,
+                         const int* d_rowOff, const int* d_colInd, RealType* d_vals, RealType nu,
+                         const RealType* avxp, const RealType* avyp, const RealType* avzp,
+                         size_t startElem, size_t numLocal, int nNodes, int blockSize)
+{
+    const int eBlocks = (int)((numLocal + blockSize - 1) / blockSize);
+    thrust::device_vector<RealType> avX(6 * numLocal), avY(6 * numLocal), avZ(6 * numLocal);
+    precomputeTetAreaVectorsGpu<KeyType, RealType>(c0, c1, c2, c3, numLocal, nx, ny, nz,
+        thrust::raw_pointer_cast(avX.data()), thrust::raw_pointer_cast(avY.data()), thrust::raw_pointer_cast(avZ.data()));
+    cudaDeviceSynchronize();
+    assembleMomentumKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+        c0, c1, c2, c3, nx, ny, nz, d_rowOff, d_colInd, d_vals, nu, avxp, avyp, avzp, startElem, numLocal);
+    cudaDeviceSynchronize();
+    thrust::device_vector<RealType> Vp(nNodes, RealType(0)), invApV(nNodes, RealType(0));
+    computeNodeVolumeKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+        c0, c1, c2, c3, nx, ny, nz, thrust::raw_pointer_cast(Vp.data()), startElem, numLocal);
+    cudaDeviceSynchronize();
+    const int nblkN = (nNodes + blockSize - 1) / blockSize;
+    computeInvApVKernel<RealType><<<nblkN, blockSize>>>(d_rowOff, d_colInd, d_vals,
+        thrust::raw_pointer_cast(Vp.data()), thrust::raw_pointer_cast(invApV.data()), nNodes);
+    cudaDeviceSynchronize();
+    assembleRhieChowDivGradKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+        c0, c1, c2, c3, thrust::raw_pointer_cast(avX.data()), thrust::raw_pointer_cast(avY.data()),
+        thrust::raw_pointer_cast(avZ.data()), d_rowOff, d_colInd, d_vals, startElem, numLocal);
+    assembleRhieChowAppKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+        c0, c1, c2, c3, nx, ny, nz, thrust::raw_pointer_cast(avX.data()), thrust::raw_pointer_cast(avY.data()),
+        thrust::raw_pointer_cast(avZ.data()), thrust::raw_pointer_cast(invApV.data()),
+        d_rowOff, d_colInd, d_vals, startElem, numLocal);
+    cudaDeviceSynchronize();
+}
+
 // ---- Increment 3a: Dirichlet BC elimination + direct reference solve ----
 // Identity-row BC: for a Dirichlet dof, zero its CSR row, set its diagonal to 1,
 // rhs = prescribed value. Correct for a DIRECT solve (the interior rows still see
@@ -523,38 +558,10 @@ int main(int argc, char** argv)
         }
 
         if (doRhieChow) {
-            // collocated Rhie-Chow coupled operator: a^uu(nu*K) + FV a^pu/a^up + RC a^pp(d_f-Laplacian).
-            // a^pp coupling is harvested from the momentum diagonal (no tau). Host-validated in
-            // scripts/rhie_chow_replica.py (G1 a^pu=-(a^up)^T, G2 a^pp M-matrix).
-            thrust::device_vector<RealType> d_avX(6*numLocal), d_avY(6*numLocal), d_avZ(6*numLocal);
-            precomputeTetAreaVectorsGpu<KeyType, RealType>(c0, c1, c2, c3, numLocal, nx, ny, nz,
-                thrust::raw_pointer_cast(d_avX.data()), thrust::raw_pointer_cast(d_avY.data()),
-                thrust::raw_pointer_cast(d_avZ.data()));
-            cudaDeviceSynchronize();
-            assembleMomentumKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
-                c0, c1, c2, c3, nx, ny, nz, thrust::raw_pointer_cast(d_rowOff.data()),
-                thrust::raw_pointer_cast(d_colInd.data()), thrust::raw_pointer_cast(d_vals.data()),
-                nu, avxp, avyp, avzp, startEl, numLocal);
-            cudaDeviceSynchronize();
-            thrust::device_vector<RealType> d_Vp(nNodes, RealType(0)), d_invApV(nNodes, RealType(0));
-            computeNodeVolumeKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
-                c0, c1, c2, c3, nx, ny, nz, thrust::raw_pointer_cast(d_Vp.data()), startEl, numLocal);
-            cudaDeviceSynchronize();
-            const int nblkN = ((int)nNodes + blockSize - 1) / blockSize;
-            computeInvApVKernel<RealType><<<nblkN, blockSize>>>(
+            assembleRhieChowGpu<KeyType, RealType>(c0, c1, c2, c3, nx, ny, nz,
                 thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
-                thrust::raw_pointer_cast(d_vals.data()), thrust::raw_pointer_cast(d_Vp.data()),
-                thrust::raw_pointer_cast(d_invApV.data()), (int)nNodes);
-            cudaDeviceSynchronize();
-            assembleRhieChowDivGradKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
-                c0, c1, c2, c3, thrust::raw_pointer_cast(d_avX.data()), thrust::raw_pointer_cast(d_avY.data()),
-                thrust::raw_pointer_cast(d_avZ.data()), thrust::raw_pointer_cast(d_rowOff.data()),
-                thrust::raw_pointer_cast(d_colInd.data()), thrust::raw_pointer_cast(d_vals.data()), startEl, numLocal);
-            assembleRhieChowAppKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
-                c0, c1, c2, c3, nx, ny, nz, thrust::raw_pointer_cast(d_avX.data()),
-                thrust::raw_pointer_cast(d_avY.data()), thrust::raw_pointer_cast(d_avZ.data()),
-                thrust::raw_pointer_cast(d_invApV.data()), thrust::raw_pointer_cast(d_rowOff.data()),
-                thrust::raw_pointer_cast(d_colInd.data()), thrust::raw_pointer_cast(d_vals.data()), startEl, numLocal);
+                thrust::raw_pointer_cast(d_vals.data()), nu, avxp, avyp, avzp,
+                startEl, numLocal, (int)nNodes, blockSize);
         } else {
             assembleCoupledStokesKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
                 c0, c1, c2, c3, nx, ny, nz,
@@ -922,11 +929,17 @@ int main(int argc, char** argv)
             const RealType hpar = RealType(1) / std::sqrt(static_cast<RealType>(nNodes) * RealType(0.5));
             const RealType tauS = hpar * hpar / (RealType(4) * nuS);
             thrust::fill(d_vals.begin(), d_vals.end(), RealType(0));
-            assembleCoupledStokesKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
-                c0, c1, c2, c3, nx, ny, nz,
-                thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
-                thrust::raw_pointer_cast(d_vals.data()), nuS, tauS, nullptr, nullptr, nullptr,
-                startEl, numLocal);
+            if (doRhieChow)   // collocated Rhie-Chow operator (no tau, intrinsic checkerboard suppression)
+                assembleRhieChowGpu<KeyType, RealType>(c0, c1, c2, c3, nx, ny, nz,
+                    thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
+                    thrust::raw_pointer_cast(d_vals.data()), nuS, nullptr, nullptr, nullptr,
+                    startEl, numLocal, (int)nNodes, blockSize);
+            else
+                assembleCoupledStokesKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+                    c0, c1, c2, c3, nx, ny, nz,
+                    thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
+                    thrust::raw_pointer_cast(d_vals.data()), nuS, tauS, nullptr, nullptr, nullptr,
+                    startEl, numLocal);
             cudaDeviceSynchronize();
 
             // boundary nodes: a tet face shared by exactly one element is a surface face (host sort+count)

--- a/examples/distributed/unstructured/mars_coupled_model_operator.cu
+++ b/examples/distributed/unstructured/mars_coupled_model_operator.cu
@@ -47,9 +47,12 @@ using namespace mars::amr;
 #include <vector>
 #include <set>
 #include <map>
+#include <array>
+#include <algorithm>
 #include <utility>
 #include <cmath>
 #include <cstdlib>
+#include <thrust/inner_product.h>
 
 // ---- Increment 2a: coupled Stokes block assembly (advection OFF) ----
 // Assembles the interleaved (dof = 4*node + comp) CSR with the coefficients
@@ -171,6 +174,7 @@ int main(int argc, char** argv)
     bool doAcm3     = false;      // --acm-stage3: GPU coarse-operator + transfers vs host P^T A P (implies --assemble)
     bool doAcm4     = false;      // --acm-stage4: GPU multilevel V-cycle vs host V-cycle replica (implies --assemble)
     bool doAcm4b    = false;      // --acm-stage4b: ACM-preconditioned FlexGMRES iters vs 1a baseline + cusolver ref
+    bool doAcmPump  = false;      // --acm-pump: mesh-agnostic ACM-FlexGMRES vs BoomerAMG on ANY tet mesh (residual-based)
     double beta     = 45.0;      // --beta: skew-cavity angle (deg), used only for the --solve BC geometry
     int    Re       = 100;       // --Re: Reynolds number for the lid-driven solve (3b)
     int    picard   = 30;        // --picard: max Picard outer iterations
@@ -187,6 +191,7 @@ int main(int argc, char** argv)
         else if (a == "--acm-stage3")             { doAssemble = true; doAcm3   = true; }
         else if (a == "--acm-stage4")             { doAssemble = true; doAcm4   = true; }
         else if (a == "--acm-stage4b")            { doAssemble = true; doAcm4b  = true; }
+        else if (a == "--acm-pump")               { doAssemble = true; doAcmPump = true; }
         else if (a.rfind("--beta=", 0) == 0)        beta       = std::stod(a.substr(7));
         else if (a.rfind("--Re=", 0) == 0)          Re         = std::stoi(a.substr(5));
         else if (a.rfind("--picard=", 0) == 0)      picard     = std::stoi(a.substr(9));
@@ -225,8 +230,9 @@ int main(int argc, char** argv)
     const size_t startEl  = domain.startIndex();
     const size_t numLocal = domain.localElementCount();
     if (rank == 0)
-        std::cout << "[phase0] mesh: elements=" << domain.getElementCount()
-                  << " nodes=" << nNodes << " localElems=" << numLocal << "\n";
+        if (!std::getenv("MARS_QUIET_MESH"))
+            std::cout << "[phase0] mesh: elements=" << domain.getElementCount()
+                      << " nodes=" << nNodes << " localElems=" << numLocal << "\n";
 
     const auto& conn = domain.getElementToNodeConnectivity();
     const KeyType* c0 = std::get<0>(conn).data();
@@ -420,8 +426,11 @@ int main(int argc, char** argv)
         const RealType atol = 1e-12;
         auto pf = [&](bool ok) { return ok ? "PASS" : "FAIL"; };
         std::cout << std::scientific << std::setprecision(3);
-        std::cout << "[phase0][assemble] DOFs=" << ND << " nnz=" << nnz
-                  << (doAdvect ? "  (advection ON)" : "  (Stokes)") << "\n";
+        if (std::getenv("MARS_QUIET_MESH"))
+            std::cout << "[phase0][assemble]" << (doAdvect ? "  (advection ON)" : "  (Stokes)") << "\n";
+        else
+            std::cout << "[phase0][assemble] DOFs=" << ND << " nnz=" << nnz
+                      << (doAdvect ? "  (advection ON)" : "  (Stokes)") << "\n";
         std::cout << "[phase0][assemble] a_pu==-a_up^T : " << e1 << "  " << pf(e1 < atol) << "\n";
         std::cout << "[phase0][assemble] a_pp.1==0     : " << e2 << "  " << pf(e2 < atol) << "\n";
         std::cout << "[phase0][assemble] sum(D.const)  : " << e3 << "  " << pf(e3 < atol) << "\n";
@@ -715,6 +724,120 @@ int main(int argc, char** argv)
                           << "  -> " << (gate1 && gate2 ? "PASS" : "CHECK") << "\n";
                 assemblePass = assemblePass && gate1 && gate2;
             }
+        }
+
+        // ---- ACM on a real mesh: mesh-agnostic ACM-FlexGMRES vs Hypre BoomerAMG (residual-based,
+        //      no direct reference -> scales to large meshes). Closed-domain Stokes: u=v=w=0 on the
+        //      surface, pressure pinned, smooth body force drives the flow. ----
+        if (doAcmPump)
+        {
+            const RealType nuS  = RealType(1) / static_cast<RealType>(Re);
+            const RealType hpar = RealType(1) / std::sqrt(static_cast<RealType>(nNodes) * RealType(0.5));
+            const RealType tauS = hpar * hpar / (RealType(4) * nuS);
+            thrust::fill(d_vals.begin(), d_vals.end(), RealType(0));
+            assembleCoupledStokesKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+                c0, c1, c2, c3, nx, ny, nz,
+                thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
+                thrust::raw_pointer_cast(d_vals.data()), nuS, tauS, nullptr, nullptr, nullptr,
+                startEl, numLocal);
+            cudaDeviceSynchronize();
+
+            // boundary nodes: a tet face shared by exactly one element is a surface face (host sort+count)
+            std::vector<std::array<int, 3>> faces; faces.reserve(4 * numLocal);
+            auto pushFace = [&](int a, int b, int c) {
+                int t[3] = {a, b, c}; std::sort(t, t + 3); faces.push_back({t[0], t[1], t[2]});
+            };
+            for (size_t e = 0; e < numLocal; ++e) {
+                int n0 = (int)h0[e], n1 = (int)h1[e], n2 = (int)h2[e], n3 = (int)h3[e];
+                pushFace(n0, n1, n2); pushFace(n0, n1, n3); pushFace(n0, n2, n3); pushFace(n1, n2, n3);
+            }
+            std::sort(faces.begin(), faces.end());
+            std::vector<uint8_t> isBnd(nNodes, 0);
+            for (size_t i = 0; i < faces.size(); ) {
+                size_t j = i + 1; while (j < faces.size() && faces[j] == faces[i]) ++j;
+                if (j - i == 1) for (int v : faces[i]) isBnd[v] = 1;   // single-occurrence face -> surface
+                i = j;
+            }
+            size_t nBnd = 0; for (size_t i = 0; i < nNodes; ++i) nBnd += isBnd[i];
+
+            std::vector<uint8_t> bcF(ND, 0);
+            std::vector<RealType> hrhs(ND, RealType(0));
+            for (size_t i = 0; i < nNodes; ++i) {
+                if (isBnd[i]) { bcF[4 * i + 0] = bcF[4 * i + 1] = bcF[4 * i + 2] = 1; }
+                hrhs[4 * i + 0] = std::sin(RealType(3) * hx[i] + RealType(1));      // smooth body force
+                hrhs[4 * i + 1] = std::sin(RealType(3) * hy[i] + RealType(2));
+                hrhs[4 * i + 2] = std::sin(RealType(3) * hz[i] + RealType(0.5));
+            }
+            bcF[3] = 1;   // pin pressure at node 0
+            thrust::device_vector<uint8_t>  d_bcF(bcF.begin(), bcF.end());
+            thrust::device_vector<RealType> d_bcV(ND, RealType(0));
+            thrust::device_vector<RealType> d_rhs(hrhs.begin(), hrhs.end());
+            const int dblk = (ND + blockSize - 1) / blockSize;
+            applyBCKernel<RealType><<<dblk, blockSize>>>(
+                thrust::raw_pointer_cast(d_bcF.data()), thrust::raw_pointer_cast(d_bcV.data()),
+                thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
+                thrust::raw_pointer_cast(d_vals.data()), thrust::raw_pointer_cast(d_rhs.data()), ND);
+            cudaDeviceSynchronize();
+
+            SparseMatrix<int, RealType, cstone::GpuTag> Am; Am.allocate(ND, ND, nnz);
+            thrust::copy(d_rowOff.begin(), d_rowOff.end(), thrust::device_pointer_cast(Am.rowOffsetsPtr()));
+            thrust::copy(d_colInd.begin(), d_colInd.end(), thrust::device_pointer_cast(Am.colIndicesPtr()));
+            thrust::copy(d_vals.begin(),   d_vals.end(),   thrust::device_pointer_cast(Am.valuesPtr()));
+            using Vec = cstone::DeviceVector<RealType>;
+            Vec b; b.resize(ND);
+            thrust::copy(d_rhs.begin(), d_rhs.end(), thrust::device_pointer_cast(b.data()));
+            const RealType bnorm = std::sqrt(thrust::inner_product(
+                thrust::device_pointer_cast(b.data()), thrust::device_pointer_cast(b.data() + ND),
+                thrust::device_pointer_cast(b.data()), RealType(0)));
+
+            // ||b - A x|| / ||b|| using the BC-eliminated CSR (acmSpmvKernel); no direct reference needed
+            thrust::device_vector<RealType> d_Ax(ND), d_diff(ND);
+            auto resid = [&](Vec& xv) -> RealType {
+                acmSpmvKernel<RealType><<<dblk, blockSize>>>(
+                    thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
+                    thrust::raw_pointer_cast(d_vals.data()), xv.data(), thrust::raw_pointer_cast(d_Ax.data()), ND);
+                cudaDeviceSynchronize();
+                thrust::transform(thrust::device_pointer_cast(b.data()), thrust::device_pointer_cast(b.data() + ND),
+                    d_Ax.begin(), d_diff.begin(), thrust::minus<RealType>());
+                RealType rn = std::sqrt(thrust::inner_product(d_diff.begin(), d_diff.end(), d_diff.begin(), RealType(0)));
+                return rn / (bnorm > 0 ? bnorm : RealType(1));
+            };
+
+            std::cout << std::scientific << std::setprecision(3);
+            if (!std::getenv("MARS_QUIET_MESH"))
+                std::cout << "[phase0][acm-pump] DOFs=" << ND << " nnz=" << nnz
+                          << " surface nodes=" << nBnd << "/" << nNodes << " nu=" << nuS << " tau=" << tauS << "\n";
+
+            GpuAcmPreconditioner<RealType, int, cstone::GpuTag> acm;
+            Vec xa; xa.resize(ND);
+            GMRESSolver<RealType, int, cstone::GpuTag> ga(2000, 1e-8, 30);
+            ga.setVerbose(false); ga.setPreconditioner(&acm); ga.setFlexible(true);
+            ga.solve(Am, b, xa, true);
+            const int itA = ga.getLastIterations(); const RealType rA = resid(xa);
+
+            Vec bh, xh; bh.resize(ND); xh.resize(ND);
+            thrust::copy(d_rhs.begin(), d_rhs.end(), thrust::device_pointer_cast(bh.data()));
+            HypreGMRESSolver<RealType, int, cstone::GpuTag> hg(
+                MPI_COMM_WORLD, 2000, 1e-8, HypreGMRESSolver<RealType, int, cstone::GpuTag>::BOOMERAMG, 50);
+            hg.setVerbose(false); hg.setPointBlock(4);
+            hg.solve(Am, bh, xh, 0, ND, 0, ND, std::vector<int>{});
+            const int itH = hg.getLastIterations(); const RealType rH = resid(xh);
+
+            thrust::device_vector<RealType> d_xa(ND), d_xh(ND);
+            thrust::copy(thrust::device_pointer_cast(xa.data()), thrust::device_pointer_cast(xa.data() + ND), d_xa.begin());
+            thrust::copy(thrust::device_pointer_cast(xh.data()), thrust::device_pointer_cast(xh.data() + ND), d_xh.begin());
+            thrust::transform(d_xa.begin(), d_xa.end(), d_xh.begin(), d_diff.begin(),
+                [] __device__ (RealType a, RealType c) { return fabs(a - c); });
+            const RealType dmax = thrust::reduce(d_diff.begin(), d_diff.end(), RealType(0), thrust::maximum<RealType>());
+            thrust::transform(d_xa.begin(), d_xa.end(), d_diff.begin(), [] __device__ (RealType a) { return fabs(a); });
+            const RealType amax = thrust::reduce(d_diff.begin(), d_diff.end(), RealType(0), thrust::maximum<RealType>());
+            const RealType agree = dmax / (amax > 0 ? amax : RealType(1));
+
+            std::cout << "[phase0][acm-pump] ACM-FlexGMRES  iters=" << itA << " levels=" << acm.numLevels()
+                      << " beta=" << acm.beta() << " (MARS_ACM_BETA, 0=isotropic) res=" << rA << "\n";
+            std::cout << "[phase0][acm-pump] BoomerAMG-GMRES iters=" << itH << " res=" << rH << "\n";
+            std::cout << "[phase0][acm-pump] solvers agree |x_acm-x_amg|rel=" << agree
+                      << "  -> " << ((rA < 1e-6 && rH < 1e-6 && agree < 1e-2) ? "PASS" : "CHECK") << "\n";
         }
 
         // ---- 3b: Picard loop + cusolverSp QR direct reference solve + benchmark match ----

--- a/examples/distributed/unstructured/mars_coupled_model_operator.cu
+++ b/examples/distributed/unstructured/mars_coupled_model_operator.cu
@@ -29,6 +29,7 @@ using namespace mars::amr;
 #include "backend/distributed/unstructured/solvers/mars_acm_vcycle.hpp"   // ACM Stage 4a V-cycle
 #include "backend/distributed/unstructured/solvers/mars_gpu_acm_preconditioner.hpp"  // ACM Stage 4b precond
 #include "backend/distributed/unstructured/solvers/mars_gmres_solver.hpp"            // native (Flex)GMRES
+#include "backend/distributed/unstructured/fem/mars_cvfem_tet_area.hpp"              // SCS area vectors (Rhie-Chow)
 
 #include <thrust/device_vector.h>
 #include <thrust/inner_product.h>
@@ -124,6 +125,144 @@ __global__ void assembleCoupledStokesKernel(
     }
 }
 
+// ---- Rhie-Chow coupled pressure block (replaces PSPG a^pp = tau*K) ----
+// The collocated inf-sup remedy (darwish2008a / Nalu-Wind / OpenFOAM): the SCS-face mass flux carries a
+// compact pressure term  -d_f*(p_R - p_L),  d_f = (V_P/a_P^u)_f * |A|^2/(A.dx)  -- the momentum-interpolation
+// coefficient, NOT a stabilization parameter. Continuity (sum of face fluxes) then yields a^pp as the
+// d_f-weighted graph Laplacian: row-sum zero, +d_f on the diagonal, -d_f off -- which suppresses
+// checkerboard intrinsically. d_f>0 since A is oriented L->R so A.dx>0 and V/a_P^u>0.
+
+// per-node median-dual control-volume V_P = sum over incident tets of V/4
+template<typename KeyType, typename RealType>
+__global__ void computeNodeVolumeKernel(const KeyType* c0, const KeyType* c1, const KeyType* c2,
+                                        const KeyType* c3, const RealType* nx, const RealType* ny,
+                                        const RealType* nz, RealType* Vp, size_t startElem, size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x; if (k >= numLocal) return;
+    size_t e = startElem + k;
+    const KeyType* cc[4] = {c0, c1, c2, c3};
+    int n[4]; RealType coords[4][3];
+    for (int i = 0; i < 4; ++i) { n[i] = (int)cc[i][e]; coords[i][0]=nx[n[i]]; coords[i][1]=ny[n[i]]; coords[i][2]=nz[n[i]]; }
+    RealType det, dNdx[4][3];
+    Tet4CVFEM::jacobian_and_dNdx<RealType>(coords, det, dNdx);
+    RealType V = det / RealType(6);
+    if (!(V > RealType(0))) return;
+    for (int i = 0; i < 4; ++i) atomicAdd(&Vp[n[i]], V * RealType(0.25));
+}
+
+// invApV[i] = V_P[i] / a_P^u[i], a_P^u = velocity-block diagonal (dof 4i+0) of the assembled momentum block
+template<typename RealType>
+__global__ void computeInvApVKernel(const int* rowOff, const int* colInd, const RealType* vals,
+                                    const RealType* Vp, RealType* invApV, int nNodes)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x; if (i >= nNodes) return;
+    int r = 4 * i; RealType aP = 0;
+    for (int kk = rowOff[r]; kk < rowOff[r + 1]; ++kk) if (colInd[kk] == r) { aP = vals[kk]; break; }
+    invApV[i] = (fabs((double)aP) > 1e-30) ? Vp[i] / aP : RealType(0);
+}
+
+// scatter the Rhie-Chow d_f-Laplacian into a^pp over the 6 tet SCS faces (ip order matches d_areaVec)
+template<typename KeyType, typename RealType>
+__global__ void assembleRhieChowAppKernel(const KeyType* c0, const KeyType* c1, const KeyType* c2,
+                                          const KeyType* c3, const RealType* nx, const RealType* ny,
+                                          const RealType* nz, const RealType* avX, const RealType* avY,
+                                          const RealType* avZ, const RealType* invApV,
+                                          const int* rowOff, const int* colInd, RealType* vals,
+                                          size_t startElem, size_t numLocal)
+{
+    size_t k = blockIdx.x * blockDim.x + threadIdx.x; if (k >= numLocal) return;
+    size_t e = startElem + k;
+    const KeyType* cc[4] = {c0, c1, c2, c3};
+    int n[4]; RealType X[4], Y[4], Z[4];
+    for (int i = 0; i < 4; ++i) { n[i] = (int)cc[i][e]; X[i]=nx[n[i]]; Y[i]=ny[n[i]]; Z[i]=nz[n[i]]; }
+    const int LR[6][2] = {{0,1},{1,2},{0,2},{0,3},{1,3},{2,3}};   // matches precomputeTetAreaVectorsKernel
+    for (int ip = 0; ip < 6; ++ip) {
+        int L = LR[ip][0], R = LR[ip][1], gL = n[L], gR = n[R];
+        size_t off = e * 6 + ip;
+        RealType Ax = avX[off], Ay = avY[off], Az = avZ[off];
+        RealType dx = X[R]-X[L], dy = Y[R]-Y[L], dz = Z[R]-Z[L];
+        RealType axdx = Ax*dx + Ay*dy + Az*dz;
+        if (fabs((double)axdx) < 1e-30) continue;
+        RealType asq = Ax*Ax + Ay*Ay + Az*Az;
+        RealType df = RealType(0.5) * (invApV[gL] + invApV[gR]) * asq / axdx;   // > 0
+        int rL = 4*gL+3, rsL = rowOff[rL], reL = rowOff[rL+1];
+        int rR = 4*gR+3, rsR = rowOff[rR], reR = rowOff[rR+1];
+        csrAdd<RealType>(vals, colInd, rsL, reL, 4*gL+3,  df);
+        csrAdd<RealType>(vals, colInd, rsL, reL, 4*gR+3, -df);
+        csrAdd<RealType>(vals, colInd, rsR, reR, 4*gR+3,  df);
+        csrAdd<RealType>(vals, colInd, rsR, reR, 4*gL+3, -df);
+    }
+}
+
+// momentum block only: a^uu = nu*K (+ frozen convection C_ij) -- component-diagonal, no pressure coupling.
+// Used by the Rhie-Chow path (the pressure coupling comes from the FV div/grad + RC a^pp, not Galerkin).
+template<typename KeyType, typename RealType>
+__global__ void assembleMomentumKernel(
+    const KeyType* c0, const KeyType* c1, const KeyType* c2, const KeyType* c3,
+    const RealType* nodeX, const RealType* nodeY, const RealType* nodeZ,
+    const int* rowOff, const int* colInd, RealType* vals, RealType nu,
+    const RealType* avx, const RealType* avy, const RealType* avz, size_t startElem, size_t numLocal)
+{
+    size_t kk = blockIdx.x * blockDim.x + threadIdx.x; if (kk >= numLocal) return;
+    size_t e = startElem + kk;
+    const KeyType* cc[4] = {c0, c1, c2, c3};
+    int n[4]; RealType coords[4][3];
+    for (int i = 0; i < 4; ++i) { n[i]=(int)cc[i][e]; coords[i][0]=nodeX[n[i]]; coords[i][1]=nodeY[n[i]]; coords[i][2]=nodeZ[n[i]]; }
+    RealType det, dNdx[4][3];
+    Tet4CVFEM::jacobian_and_dNdx<RealType>(coords, det, dNdx);
+    RealType V = det / RealType(6); if (!(V > RealType(0))) return;
+    RealType qV = V * RealType(0.25);
+    RealType ax = 0, ay = 0, az = 0;
+    if (avx) { for (int i=0;i<4;++i){ ax+=avx[n[i]]; ay+=avy[n[i]]; az+=avz[n[i]]; } ax*=RealType(0.25); ay*=RealType(0.25); az*=RealType(0.25); }
+    for (int a = 0; a < 4; ++a)
+        for (int b = 0; b < 4; ++b) {
+            RealType Kab = V * (dNdx[a][0]*dNdx[b][0] + dNdx[a][1]*dNdx[b][1] + dNdx[a][2]*dNdx[b][2]);
+            RealType Cab = avx ? qV * (ax*dNdx[b][0] + ay*dNdx[b][1] + az*dNdx[b][2]) : RealType(0);
+            for (int d = 0; d < 3; ++d) {
+                int rad = 4*n[a]+d, rs = rowOff[rad], re = rowOff[rad+1];
+                csrAdd<RealType>(vals, colInd, rs, re, 4*n[b]+d, nu*Kab + Cab);   // a^uu only
+            }
+        }
+}
+
+// Rhie-Chow FV pressure-velocity coupling, per SCS face (rho=1): a^pu = divergence of the averaged face
+// velocity (+-0.5*S_f), and a^up = -(a^pu)^T (the consistent discrete gradient, host-validated). This is
+// the collocated div/grad whose checkerboard the RC a^pp damps -- replaces the Galerkin qV*dNdx forms.
+template<typename KeyType, typename RealType>
+__global__ void assembleRhieChowDivGradKernel(
+    const KeyType* c0, const KeyType* c1, const KeyType* c2, const KeyType* c3,
+    const RealType* avX, const RealType* avY, const RealType* avZ,
+    const int* rowOff, const int* colInd, RealType* vals, size_t startElem, size_t numLocal)
+{
+    size_t kk = blockIdx.x * blockDim.x + threadIdx.x; if (kk >= numLocal) return;
+    size_t e = startElem + kk;
+    const KeyType* cc[4] = {c0, c1, c2, c3};
+    int n[4]; for (int i=0;i<4;++i) n[i]=(int)cc[i][e];
+    const int LR[6][2] = {{0,1},{1,2},{0,2},{0,3},{1,3},{2,3}};
+    for (int ip = 0; ip < 6; ++ip) {
+        int gL = n[LR[ip][0]], gR = n[LR[ip][1]];
+        size_t off = e*6 + ip;
+        RealType S[3] = {avX[off], avY[off], avZ[off]};
+        int cpL = 4*gL+3, cpLs = rowOff[cpL], cpLe = rowOff[cpL+1];   // continuity rows (a^pu)
+        int cpR = 4*gR+3, cpRs = rowOff[cpR], cpRe = rowOff[cpR+1];
+        for (int d = 0; d < 3; ++d) {
+            RealType h = RealType(0.5) * S[d];
+            // a^pu: div of avg face velocity (S out of L => +, out of R => -)
+            csrAdd<RealType>(vals, colInd, cpLs, cpLe, 4*gL+d,  h);
+            csrAdd<RealType>(vals, colInd, cpLs, cpLe, 4*gR+d,  h);
+            csrAdd<RealType>(vals, colInd, cpRs, cpRe, 4*gL+d, -h);
+            csrAdd<RealType>(vals, colInd, cpRs, cpRe, 4*gR+d, -h);
+            // a^up = -(a^pu)^T  (momentum rows, pressure cols)
+            int mL = 4*gL+d, mLs = rowOff[mL], mLe = rowOff[mL+1];
+            int mR = 4*gR+d, mRs = rowOff[mR], mRe = rowOff[mR+1];
+            csrAdd<RealType>(vals, colInd, mLs, mLe, 4*gL+3, -h);
+            csrAdd<RealType>(vals, colInd, mLs, mLe, 4*gR+3,  h);
+            csrAdd<RealType>(vals, colInd, mRs, mRe, 4*gL+3, -h);
+            csrAdd<RealType>(vals, colInd, mRs, mRe, 4*gR+3,  h);
+        }
+    }
+}
+
 // ---- Increment 3a: Dirichlet BC elimination + direct reference solve ----
 // Identity-row BC: for a Dirichlet dof, zero its CSR row, set its diagonal to 1,
 // rhs = prescribed value. Correct for a DIRECT solve (the interior rows still see
@@ -175,6 +314,7 @@ int main(int argc, char** argv)
     bool doAcm4     = false;      // --acm-stage4: GPU multilevel V-cycle vs host V-cycle replica (implies --assemble)
     bool doAcm4b    = false;      // --acm-stage4b: ACM-preconditioned FlexGMRES iters vs 1a baseline + cusolver ref
     bool doAcmPump  = false;      // --acm-pump: mesh-agnostic ACM-FlexGMRES vs BoomerAMG on ANY tet mesh (residual-based)
+    bool doRhieChow = false;      // --rhie-chow: assemble the collocated Rhie-Chow coupled operator (vs PSPG); implies --assemble
     double beta     = 45.0;      // --beta: skew-cavity angle (deg), used only for the --solve BC geometry
     int    Re       = 100;       // --Re: Reynolds number for the lid-driven solve (3b)
     int    picard   = 30;        // --picard: max Picard outer iterations
@@ -192,6 +332,7 @@ int main(int argc, char** argv)
         else if (a == "--acm-stage4")             { doAssemble = true; doAcm4   = true; }
         else if (a == "--acm-stage4b")            { doAssemble = true; doAcm4b  = true; }
         else if (a == "--acm-pump")               { doAssemble = true; doAcmPump = true; }
+        else if (a == "--rhie-chow")              { doAssemble = true; doRhieChow = true; }
         else if (a.rfind("--beta=", 0) == 0)        beta       = std::stod(a.substr(7));
         else if (a.rfind("--Re=", 0) == 0)          Re         = std::stoi(a.substr(5));
         else if (a.rfind("--picard=", 0) == 0)      picard     = std::stoi(a.substr(9));
@@ -381,12 +522,47 @@ int main(int argc, char** argv)
             avzp = thrust::raw_pointer_cast(d_avz.data());
         }
 
-        assembleCoupledStokesKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
-            c0, c1, c2, c3, nx, ny, nz,
-            thrust::raw_pointer_cast(d_rowOff.data()),
-            thrust::raw_pointer_cast(d_colInd.data()),
-            thrust::raw_pointer_cast(d_vals.data()),
-            nu, tau, avxp, avyp, avzp, startEl, numLocal);
+        if (doRhieChow) {
+            // collocated Rhie-Chow coupled operator: a^uu(nu*K) + FV a^pu/a^up + RC a^pp(d_f-Laplacian).
+            // a^pp coupling is harvested from the momentum diagonal (no tau). Host-validated in
+            // scripts/rhie_chow_replica.py (G1 a^pu=-(a^up)^T, G2 a^pp M-matrix).
+            thrust::device_vector<RealType> d_avX(6*numLocal), d_avY(6*numLocal), d_avZ(6*numLocal);
+            precomputeTetAreaVectorsGpu<KeyType, RealType>(c0, c1, c2, c3, numLocal, nx, ny, nz,
+                thrust::raw_pointer_cast(d_avX.data()), thrust::raw_pointer_cast(d_avY.data()),
+                thrust::raw_pointer_cast(d_avZ.data()));
+            cudaDeviceSynchronize();
+            assembleMomentumKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+                c0, c1, c2, c3, nx, ny, nz, thrust::raw_pointer_cast(d_rowOff.data()),
+                thrust::raw_pointer_cast(d_colInd.data()), thrust::raw_pointer_cast(d_vals.data()),
+                nu, avxp, avyp, avzp, startEl, numLocal);
+            cudaDeviceSynchronize();
+            thrust::device_vector<RealType> d_Vp(nNodes, RealType(0)), d_invApV(nNodes, RealType(0));
+            computeNodeVolumeKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+                c0, c1, c2, c3, nx, ny, nz, thrust::raw_pointer_cast(d_Vp.data()), startEl, numLocal);
+            cudaDeviceSynchronize();
+            const int nblkN = ((int)nNodes + blockSize - 1) / blockSize;
+            computeInvApVKernel<RealType><<<nblkN, blockSize>>>(
+                thrust::raw_pointer_cast(d_rowOff.data()), thrust::raw_pointer_cast(d_colInd.data()),
+                thrust::raw_pointer_cast(d_vals.data()), thrust::raw_pointer_cast(d_Vp.data()),
+                thrust::raw_pointer_cast(d_invApV.data()), (int)nNodes);
+            cudaDeviceSynchronize();
+            assembleRhieChowDivGradKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+                c0, c1, c2, c3, thrust::raw_pointer_cast(d_avX.data()), thrust::raw_pointer_cast(d_avY.data()),
+                thrust::raw_pointer_cast(d_avZ.data()), thrust::raw_pointer_cast(d_rowOff.data()),
+                thrust::raw_pointer_cast(d_colInd.data()), thrust::raw_pointer_cast(d_vals.data()), startEl, numLocal);
+            assembleRhieChowAppKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+                c0, c1, c2, c3, nx, ny, nz, thrust::raw_pointer_cast(d_avX.data()),
+                thrust::raw_pointer_cast(d_avY.data()), thrust::raw_pointer_cast(d_avZ.data()),
+                thrust::raw_pointer_cast(d_invApV.data()), thrust::raw_pointer_cast(d_rowOff.data()),
+                thrust::raw_pointer_cast(d_colInd.data()), thrust::raw_pointer_cast(d_vals.data()), startEl, numLocal);
+        } else {
+            assembleCoupledStokesKernel<KeyType, RealType><<<eBlocks, blockSize>>>(
+                c0, c1, c2, c3, nx, ny, nz,
+                thrust::raw_pointer_cast(d_rowOff.data()),
+                thrust::raw_pointer_cast(d_colInd.data()),
+                thrust::raw_pointer_cast(d_vals.data()),
+                nu, tau, avxp, avyp, avzp, startEl, numLocal);
+        }
         cudaError_t aerr = cudaDeviceSynchronize();
         if (aerr != cudaSuccess) {
             std::cerr << "[phase0][assemble] kernel failed: " << cudaGetErrorString(aerr) << "\n";
@@ -441,6 +617,17 @@ int main(int argc, char** argv)
         } else {
             std::cout << "[phase0][assemble] a_uu symmetric: " << e4 << "  " << pf(e4 < atol) << "\n";
             assemblePass = (e1 < atol) && (e2 < atol) && (e3 < atol) && (e4 < atol);
+        }
+        if (doRhieChow) {   // G2: a^pp is a Rhie-Chow d_f-Laplacian M-matrix (diag>0, off<=0)
+            RealType mdiagMin = RealType(1e30), moffMax = RealType(-1e30);
+            for (size_t i = 0; i < nNodes; ++i) {
+                mdiagMin = std::min(mdiagMin, get(4 * i + 3, 4 * i + 3));
+                for (int j : ring[i]) if (j != (int)i) moffMax = std::max(moffMax, get(4 * i + 3, 4 * j + 3));
+            }
+            bool mok = (mdiagMin > RealType(0)) && (moffMax <= atol);
+            std::cout << "[phase0][assemble] a_pp M-matrix : diag_min=" << mdiagMin << " off_max=" << moffMax
+                      << "  " << pf(mok) << " (Rhie-Chow, no tau)\n";
+            assemblePass = assemblePass && mok;
         }
         std::cout << "[phase0][assemble] -> " << (assemblePass ? "ALL PASS" : "FAIL") << "\n";
 
@@ -768,7 +955,22 @@ int main(int argc, char** argv)
                 hrhs[4 * i + 1] = std::sin(RealType(3) * hy[i] + RealType(2));
                 hrhs[4 * i + 2] = std::sin(RealType(3) * hz[i] + RealType(0.5));
             }
-            bcF[3] = 1;   // pin pressure at node 0
+            // pin ONE pressure per connected component of the fluid node-graph. A multiply-connected
+            // domain (separate passages/chambers) has one constant-pressure null mode per component, so a
+            // single global pin leaves the rest near-null -> near-singular. Union-find over the 1-ring.
+            std::vector<int> cc(nNodes);
+            for (size_t i = 0; i < nNodes; ++i) cc[i] = static_cast<int>(i);
+            auto findRoot = [&](int x) { while (cc[x] != x) { cc[x] = cc[cc[x]]; x = cc[x]; } return x; };
+            for (size_t i = 0; i < nNodes; ++i)
+                for (int j : ring[i]) { int a = findRoot((int)i), b = findRoot(j); if (a != b) cc[a] = b; }
+            std::vector<char> rootPinned(nNodes, 0);
+            int nComp = 0;
+            for (size_t i = 0; i < nNodes; ++i) {
+                int r = findRoot((int)i);
+                if (!rootPinned[r]) { rootPinned[r] = 1; bcF[4 * i + 3] = 1; ++nComp; }
+            }
+            std::cout << "[phase0][acm-pump] fluid-graph components=" << nComp << " (one pressure pin per component)\n";
+
             thrust::device_vector<uint8_t>  d_bcF(bcF.begin(), bcF.end());
             thrust::device_vector<RealType> d_bcV(ND, RealType(0));
             thrust::device_vector<RealType> d_rhs(hrhs.begin(), hrhs.end());

--- a/scripts/rhie_chow_replica.py
+++ b/scripts/rhie_chow_replica.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Rhie-Chow coupled operator -- host replica / Stage-0 algebra gate (darwish2008a collocated FV).
+
+Replaces the PSPG a^pp = tau*K (the split-method pressure-Poisson folded into a block) with the
+collocated Rhie-Chow d_f-weighted graph-Laplacian, the inf-sup remedy. Validates the four coupled
+blocks BEFORE any GPU code, on BOTH a uniform and a deliberately SKEWED tet -- because the two
+highest-risk pieces (the Ef orthogonal coefficient and the smooth-vs-compact discrepancy) are
+INVISIBLE on a uniform mesh (compact == smooth there) and only bite on stretched/skewed cells.
+
+Per SCS face f=(L,R), area vector S_f (median-dual, oriented L->R, matching mars_cvfem_tet_area.hpp),
+dx = x_R - x_L, Ef = |S_f|^2/(S_f.dx), D_f = 0.5*(V_P/a_P^u + V_N/a_N^u) harvested from the assembled
+momentum diagonal (a_P^u = nu*K_PP for the Stokes core), rho=1:
+  a^uu = nu*K (component-diagonal)
+  a^up : momentum row (P,d) gets +0.5*S_f[d] at p_P and p_N ; (N,d) gets -0.5*S_f[d] at both
+  a^pu : continuity row P gets +0.5*rho*S_f[d] at u_P[d],u_N[d] ; N gets -0.5*rho*S_f[d] at both  (= -rho*(a^up)^T)
+  a^pp : w_f = rho*D_f*Ef ;  [P,P]+=w [P,N]-=w [N,N]+=w [N,P]-=w   (M-matrix graph-Laplacian, NO tau)
+"""
+import numpy as np
+
+RHO, NU = 1.0, 1.0
+EDGES = [(0, 1), (1, 2), (0, 2), (0, 3), (1, 3), (2, 3)]          # ip order == precomputeTetAreaVectorsKernel
+OTHER = [(2, 3), (0, 3), (1, 3), (1, 2), (0, 2), (0, 1)]
+
+
+def tet_grad(X):
+    J = np.array([X[1] - X[0], X[2] - X[0], X[3] - X[0]]).T       # 3x3, columns = edge vectors
+    detJ = np.linalg.det(J)
+    Jinv = np.linalg.inv(J)
+    dN = np.zeros((4, 3))
+    dN[1], dN[2], dN[3] = Jinv[0], Jinv[1], Jinv[2]               # grad of barycentric coords
+    dN[0] = -(dN[1] + dN[2] + dN[3])
+    return detJ / 6.0, dN
+
+
+def scs_areas(X):
+    C = X.mean(axis=0)
+    A = np.zeros((6, 3))
+    for ip, (L, R) in enumerate(EDGES):
+        a, b = OTHER[ip]
+        M = 0.5 * (X[L] + X[R]); Fa = (X[L] + X[R] + X[a]) / 3.0; Fb = (X[L] + X[R] + X[b]) / 3.0
+        Av = 0.5 * (np.cross(Fa - M, C - M) + np.cross(C - M, Fb - M))   # quad M->Fa->C->Fb
+        if np.dot(Av, X[R] - X[L]) < 0: Av = -Av                        # orient L->R
+        A[ip] = Av
+    return A
+
+
+def assemble(X):
+    V, dN = tet_grad(X)
+    K = np.zeros((4, 4))
+    for a in range(4):
+        for b in range(4):
+            K[a, b] = V * float(dN[a] @ dN[b])
+    aPu = np.array([NU * K[i, i] for i in range(4)])               # momentum diagonal, harvested
+    Vp = np.full(4, V / 4.0)                                       # node dual CV (single tet -> V/4)
+    A = np.zeros((16, 16))
+    # a^uu = nu*K (component-diagonal over u,v,w)
+    for a in range(4):
+        for b in range(4):
+            for d in range(3):
+                A[4 * a + d, 4 * b + d] += NU * K[a, b]
+    S = scs_areas(X)
+    diag = []
+    for ip, (L, R) in enumerate(EDGES):
+        Sf = S[ip]; dx = X[R] - X[L]
+        asq = float(Sf @ Sf); axdx = float(Sf @ dx)
+        Ef = asq / axdx
+        Df = 0.5 * (Vp[L] / aPu[L] + Vp[R] / aPu[R])
+        w = RHO * Df * Ef
+        diag.append((ip, Ef, w))
+        for d in range(3):
+            # a^pu = FV divergence of the interpolated face velocity (v_f = avg); S_f out of L (+), of R (-)
+            A[4 * L + 3, 4 * L + d] += 0.5 * RHO * Sf[d]; A[4 * L + 3, 4 * R + d] += 0.5 * RHO * Sf[d]
+            A[4 * R + 3, 4 * L + d] -= 0.5 * RHO * Sf[d]; A[4 * R + 3, 4 * R + d] -= 0.5 * RHO * Sf[d]
+        # a^pp (Rhie-Chow d_f-Laplacian)
+        A[4 * L + 3, 4 * L + 3] += w; A[4 * L + 3, 4 * R + 3] -= w
+        A[4 * R + 3, 4 * R + 3] += w; A[4 * R + 3, 4 * L + 3] -= w
+    # enforce G = -D^T by construction: a^up = -(1/rho)*(a^pu)^T (the consistent discrete gradient;
+    # the averaged "pressure force" form does NOT satisfy this on the neighbor term).
+    for i in range(4):
+        for j in range(4):
+            for d in range(3):
+                A[4 * j + d, 4 * i + 3] = -(1.0 / RHO) * A[4 * i + 3, 4 * j + d]
+    return A, S, diag
+
+
+def smooth_vs_compact(X, S, pfun):
+    """compact (p_N-p_P)*Ef vs smooth (gradp_bar . S): equal on uniform, differ on skewed (deferred-RHS term)."""
+    V, dN = tet_grad(X)
+    p = np.array([pfun(x) for x in X])
+    gp = sum(p[i] * dN[i] for i in range(4))                       # constant nodal gradient on a linear tet
+    worst = 0.0
+    for ip, (L, R) in enumerate(EDGES):
+        Sf = S[ip]; dx = X[R] - X[L]
+        compact = (p[R] - p[L]) * (Sf @ Sf) / (Sf @ dx)
+        smooth = gp @ Sf
+        worst = max(worst, abs(compact - smooth))
+    return worst
+
+
+def gates(name, X):
+    A, S, diag = assemble(X)
+    # G1: skew-transpose  a^pu == -rho*(a^up)^T
+    e_skew = 0.0
+    for i in range(4):
+        for j in range(4):
+            for d in range(3):
+                e_skew = max(e_skew, abs(A[4 * i + 3, 4 * j + d] + RHO * A[4 * j + d, 4 * i + 3]))
+    # G2: a^pp M-matrix (diag>0, off<=0) + row-sum 0 + null(1)
+    App = A[3::4, 3::4]
+    diag_ok = all(App[i, i] > 0 for i in range(4))
+    off_ok = all(App[i, j] <= 1e-14 for i in range(4) for j in range(4) if i != j)
+    rowsum = float(np.abs(App.sum(axis=1)).max())
+    null1 = float(np.abs(App @ np.ones(4)).max())
+    # G3 (linear pressure): smooth vs compact discrepancy (the deferred-RHS term)
+    disc = smooth_vs_compact(X, S, lambda x: 1.0 + 2.0 * x[0] - x[1] + 0.5 * x[2])
+    Efs = [d[1] for d in diag]
+    print(f"\n=== {name} ===")
+    print(f"  G1 a^pu == -rho*(a^up)^T : {e_skew:.2e}  {'PASS' if e_skew < 1e-12 else 'FAIL'}")
+    print(f"  G2 a^pp M-matrix         : diag>0={diag_ok} off<=0={off_ok} rowsum={rowsum:.2e} null(1)={null1:.2e}"
+          f"  {'PASS' if (diag_ok and off_ok and rowsum < 1e-12 and null1 < 1e-12) else 'FAIL'}")
+    print(f"  Ef per face (orthog coeff): min={min(Efs):.3e} max={max(Efs):.3e}")
+    print(f"  G3 |compact - smooth| (linear p): {disc:.3e}  "
+          f"{'~0 (uniform: deferred term invisible)' if disc < 1e-10 else 'NONZERO -> deferred smooth-grad RHS is REQUIRED here'}")
+
+
+if __name__ == "__main__":
+    # uniform-ish reference tet
+    reg = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], float)
+    gates("uniform tet", reg)
+    # skewed / stretched tet: squash z hard + shear -> S_f nearly perpendicular to some edges (Ef blows up)
+    skew = np.array([[0, 0, 0], [1, 0, 0], [0.4, 1.0, 0], [0.45, 0.5, 0.02]], float)
+    gates("skewed/stretched tet", skew)
+    print("\n[note] G1/G2 are structural (must PASS on both). The Ef spread + nonzero G3 on the skewed tet")
+    print("       are the pieces invisible on uniform meshes -> the deferred smooth-grad RHS + Ef cap are")
+    print("       mandatory before a stretched/pump run, exactly as the design's verify flagged.")


### PR DESCRIPTION
- **fix(pump): revive the pressure outlet (the REAL through-flow fix). outletU was set unconditionally -> always velocity-Dirichlet outlet -> both-ends-Dirichlet admits a flat-pressure tank-recirculation div=0 solution -> NO flow through the passage (confirmed: 1e-10 pressure solve gave identical flat-p, so it's structural not convergence -- AMG would NOT help). Gate outletU on !outletDoNothing so do-nothing (default) leaves outletU<=0 -> solver masks the WHOLE outlet face p=0 + frees outlet velocity (singlePin=false, solver:4080) -> inlet flux against fixed-p outlet FORCES the outlet->suction gradient -> through-flow. The dead --outlet flag now actually works**
- **fix(pump): default outlet back to MASS-CONSERVING (the correct design). Root cause found: the divergence operator only loops interior faces (sum(div)==0 always), so the pressure solve is NEVER told mass enters at the inlet -> a velocity-inlet + free pressure-outlet is UNPROJECTABLE -> no through-flow (flow dies at inlet, pressure parks in body). The code's own comment (solver:2295) flags this. My prior do-nothing default was backwards: the mass-conserving outlet (vel outflow removes Q + single pin) BALANCES the flux so the projection builds the inlet->outlet gradient that drives flow through the passage. The dead-flag gate stays so do-nothing is still selectable (needs a boundary-flux source term to be correct -- separate work)**
- **pump through-flow: (1) default to do-nothing outlet = whole-face p=0 + FREE outlet velocity (the channel-proven pairing that builds the inlet->outlet pressure head; both-ends-velocity-Dirichlet + single pin gave a flat-pressure dead-passage solution). (2) --inlet-flux-source (GUARDED, off): add the prescribed inlet flux as a boundary divergence source -- the exterior opening flux is in no interior SCS so it's never integrated (verified not a double-count); A/B it. (3) [through-flow] Q_in/Q_out/ratio diagnostic each step so we MEASURE through-flow (ratio->1) instead of eyeballing uMax. mass-conserving still selectable. cavity/channel/TGV unaffected**
- **pump: REMOVE the broken --inlet-flux-source (double-counted the inlet flux already registered via interior SCS scatter; full-opening-area x rho/dt -> instant blowup, ratio=garbage) and revert default to MASS-CONSERVING outlet. Verified high-confidence: the inlet flux is already in the divergence for a velocity-Dirichlet inlet, so the only correct inlet boundary source is ZERO. do-nothing (whole-face p=0 + free outlet) does NOT self-drive a small interior outlet -> ratio=0 (no through-flow); the prior do-nothing-default + comments were disproven by the A/B. mass-conserving (U_out=Uin*Ain/Aout + single pin) forces Q_out=Q_in by construction. Kept the [through-flow] Q diagnostic (correct + useful)**
- **pump through-flow REWORK (verified root cause): the reference flows through the pump with ANY scheme (bj/upwind) so the dead passage is OUR bug, not Re/scheme. TWO real defects fixed: FIX1 --opening-flux-source (GUARDED off): inlet/outlet OPENING faces are exterior, in no interior SCS, so the prescribed opening flux never reaches the pressure RHS -> pressure flat -> no through-flow. Add it as a COMPATIBLE surface integral (u.n)*A_share, SAME scale as interior scatter, NOT x rho/dt (RHS does it), net~0 -- verified NOT a double-count (telescoping interior pairs never touch the opening face). FIX2 --dirichlet-lift (default ON): velocity-diffusion col-zero had no Dirichlet lift -> inlet momentum never diffused inward -> jet died at inlet. Add b-=K[row,bdry]*uTarget. FIX3: replace TAUTOLOGICAL Q_out (relocked to prescribed outletU) with an INTERIOR cut-plane flux probe at 25/50/75% -- measures SOLVED through-flow, can't be faked. old line relabeled [bc-sanity]**
- **pump FIX B: pressure-drop drive via --pump-dp=VALUE (gated, off by default -> existing pump byte-identical). Root cause: the divergence operator integrates only INTERIOR SCS faces, so a VELOCITY prescribed on the interior inlet opening is invisible to the pressure solver (exterior opening face never integrated) + the corrector freezes velocity-Dirichlet nodes -> no through-flow (proven: interior-flux mid-cut=0). FIX B masks BOTH openings as pressure-Dirichlet (p=dP inlet, p=0 outlet), frees both velocities, seeds the dP head in d_p -> flow EMERGES from the interior gradient (SCS-captured, VISIBLE). Startup-safe: two Dirichlet faces make the matrix NONSINGULAR -> no compatibility condition -> no FIX-1 source-blowup. inlet velocity becomes an OUTPUT (tune dP to hit ~0.5 m/s). Keeps interior-flux probe to verify mid-cut goes nonzero**
- **pump FIX B phi-lift (the piece that makes dP actually drive flow). Bug: FIX B seeded a one-node dP spike + pinned the phi increment to 0 at both faces -> interior never relaxed into the inlet->outlet gradient -> dP didn't drive flow (identical tiny flow at dP=1000 vs 30000). FIX: pin the SOLVED pressure to the target via rhs=target-p^n at masked DOFs (clamp to constant, NOT additive -> steady+bounded), so the Poisson solve imposes dP->0 Dirichlet data + relaxes the spanning gradient; the already-live predictor grad(p^n) then drives through-flow. LOAD-BEARING: pump runs DDT matrix-free, so the lift goes in solvePressureDDT's boundary-pin lambda (not the K-path). All gated pumpDp>0; pumpDp<=0 byte-identical (cavity/channel/TGV untouched)**
- **pump THROUGH-FLOW fix: prescribed-balanced opening-flux source (default ON). The verified root cause: a velocity-inlet's opening flux is invisible to the pressure solver (divergence integrates interior SCS only) -> flat passage -> dead passage (proven: interior-flux cut@50%=0). FIX: inject the opening flux into divAccNode so the projection SEES the inflow and builds the inlet->outlet gradient that drives the passage. KEY over the broken FIX 1: use PRESCRIBED GLOBAL-direction velocities (Uinf*inletDir, outletU*outletDir) not the solved u** -> inlet sums to -Q_in, outlet to +Q_in (outletU=Uin*Ain/Aout) -> total=0 EXACTLY every step incl step0 -> single-pin Neumann stays compatible -> CANNOT blow up like FIX 1 (which used u**=0 at the step0 outlet -> one-sided -> phi=1e36). Config: mass-conserving velocity inlet+outlet (sustains the jet) + this source (makes it visible). No removeMean (pin handles it). FIX B (pumpDp) abandoned, gated off**
- **pump: default opening-flux-source back OFF -- the prescribed-balanced source STILL blows up at step0 (phi=1e7->inf, CG residual grows = incompatible, same FLT_MAX as FIX 1). The 'sum=0 by construction' startup-safety proof was WRONG: the discrete per-node area shares evidently do not sum to exactly Q, so sum!=0, x rho/dt=1e6 -> explodes even at step0. Revert to the STABLE mass-conserving default (no through-flow, but runs). The opening-flux-source remains a flag for debugging but is NOT a working fix. Through-flow is UNRESOLVED -- see scratch/pump_throughflow_HANDOFF.md**
- **pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B**
- **Revert "pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B"**
- **debug: MARS_OFS_DBG -- print divAccNode |max| before/after the opening-flux source + the global net source sum, to SEE if the source is a giant localized spike (divAcc max jumps) and whether net is actually ~0. Instrumentation only, gated on env. Investigating the repeated step0 phi=1e7 blowup**
- **debug: print Qin_raw/Qout_raw separately -- the [ofs-dbg] net=-Q_in (one-sided) proves the OUTLET source contributes ZERO. Need to see Qin_raw vs Qout_raw to find why the outlet half does not fire (area-vec sign? outletDir?)**
- **pump: adjustPhi rescale FOUND THE BUG via debug -- the discrete inlet/outlet fluxes differ ~1.5% (Qin_raw=-5.975e-3, Qout_raw=+5.884e-3), NOT roundoff: the per-node area-vectors sum to a different value than the analytic areaIn/areaOut used for outletU. That 9e-5 residual x rho/dt=1e6 -> incompatible RHS -> phi=1e7 blowup. FIX: oScale=-Qin_raw/Qout_raw, rescale the outlet source so it EXACTLY cancels the inlet (net->0). The reductions now always run (not just debug). [ofs-dbg2] prints the net to confirm it goes to ~0**
- **pump: removeMean for the opening-flux source -- THE ACTUAL FIX. Debug PROVED the blowup is NOT flux imbalance: with the adjustPhi rescale the net source is bit-exactly 0 (8.67e-19) and it STILL blew up to phi=1e7 identically. Real cause (the code's own comments flag it: lines 897/2209/3333/5145): the single p=0 pin weakly controls the DDT constant null space; a boundary source excites that mode and Jacobi-PCG loses pAp>0 (residual GROWS 0.98->1.46 then garbage phi=1e7). FIX: removeMean the RHS + phi (project the null-space component out) when opening-flux is on -- the same cure the periodic path uses. Gated on useOpeningFluxSource**
- **debug: removeMean did NOT fix the blowup (phi=1e7 identical) -> null-space theory also wrong. KEY realization: the CG CONVERGES (3e-8), so phi=1e7 is the TRUE solution -- the operator+RHS are fine, the answer is legitimately huge. Add [ofs-dbg3] b|max and [ofs-dbg4] phi|max split by OPENING vs INTERIOR nodes, to decide: is phi huge only at the opening nodes (tiny DDT boundary-layer diagonal, b/diag=1e6*1e-4/1e-5=1e7 LOCAL) or everywhere (global)? That picks the final fix**
- **pump: --source-ramp-steps=N gentle startup for the opening-flux source. ROOT CAUSE (measured): the source WORKS (real through-flow, step1 cut@50% nonzero) but starting from rest at full strength dumps the whole inlet->outlet pressure head onto a near-singular interior node (sliver cell, DDT diag=1e-5, 600x below bulk) -> phi spikes to 6e6 there -> grad(phi) spike -> corrector velocity spike -> advection 950x/step -> blowup. NOT fixable by clip (preconditioner-only, phi is the true solution), CFL (structural per-step amplification), or balance/removeMean (all already correct). FIX: ramp Uinf 0->full over N steps so the head + phi + grad stay small while flow develops gently. Scales the inlet velocity target (from a base snapshot) AND the opening-flux source (reads Uinf live) -> balance preserved at every ramp level**
- **pump: allow dt to shrink up to 2x/step (was 5%/step). With the ramp, the flow develops stably for ~16 steps (phi=1e4, u_max bounded+growing, cut@50% nonzero) then a CFL violation at u~100 ran away because the 5%/step shrink cap could not drop dt fast enough to catch it. Fast shrink catches the violation in one step; growth stays gentle (5%/step) so BDF2's constant-dt assumption holds at steady state**
- **pump: targeted operator-diagonal floor on the matrix-free DDT (the sliver-node fix). MEASURED: the ramp fixes startup (steps 1-16 stable, flow developing, cut@50% nonzero) but one sliver interior node (tiny SCS face areas -> DDT diag=1e-5, 600x below bulk) makes phi spike there -> corrector velocity spike -> diffusion CG breaks (pAp<0, u**>>u*) -> blowup, even at dt=5e-8 (so NOT CFL). Jacobi clip is preconditioner-only (no-op on phi). FIX: raise ONLY the degenerate rows to epsFloor=0.05*max_diag in the TRUE matrix-free operator via per-node shift out[i]+=shift_i*phi[i]; 0 on the healthy bulk -> byte-identical there -> cavity/channel/cube16 untouched. Caps phi at b/3.3e-4 (~31x smaller) -> below blowup threshold. Pure positive diagonal add -> keeps SPD. Preconditioner diag floored to match. Velocity diffusion needs NO floor (M/dt keeps it conditioned; its divergence was downstream of the phi spike). Env MARS_DDT_OP_FLOOR_FRAC**
- **debug: MARS_CHECKER -- per-element mean-free pressure RMS diagnostic (the checkerboard mode an inf-sup stabilizer penalizes). Lets us SEE the checkerboard grow + SEE a stabilizer kill it in a few steps, instead of inferring from a full-run blowup. Confirms/quantifies the LBB decoupling diagnosis. Env-gated, tet-only, rank0, free in production. NOTE: adjudication confirmed BD-on-DDT is WRONG (breaks div=0 identity, accumulating divergence); the identity-safe path is VMS/RC on the divergence SOURCE (needs a phi-vs-d_p fix). Checkerboard fix != through-flow fix (separate defects)**
- **fix: checker diagnostic compile error -- a pair-returning __device__ lambda in transform_reduce needs its return type proclaimed in host context. Split into two scalar (double) reductions (mean-free energy + total) -- avoids the trait error, same result**
- **pump: replace the div-BREAKING operator-diagonal floor with an identity-safe MASS floor. The operator floor (out[i]+=shift*phi in applyDDTPerNode) only the OPERATOR saw, not the corrector -> solving (A+S)phi=b left div(u^{n+1})=(dt/rho)*S*phi un-projected -> accumulating residual -> smooth |p| 1e3->1e34 blowup (the SAME div=0-breaking class the code warns against for BD-on-DDT, lines 5602-5610). FIX: floor the lumped mass d_massNode instead -- A=D M^-1 D^T and the corrector ALSO applies M^-1 from the same d_massNode, so flooring mass changes operator AND corrector consistently -> div=0 PRESERVED. Removed d_shiftDDTNode + its apply + the operator-floor build. Env MARS_MASS_FLOOR_FRAC (default 1e-3*max_mass)**
- **pump: implicit PSPG pressure stabilization (--pspg) -- the CORRECT equal-order checkerboard fix. VERIFIED root cause of the checkerboard blowup: the existing VMS adds tau*(-lap p^n) to the RHS = an EXPLICIT forward-Euler Laplacian-of-p update -> unconditionally amplifies the high-freq mode at ANY tau (why 1e-6/1e-5/1e-3 all blew up). FIX: add tau*L*phi IMPLICITLY inside applyDDTPerNode so CG solves (A+tau*L)phi=b. L=sum_e V_e G^T G is symmetric PSD, shares A's constant null mode (removed by the pin) -> SPD, damps checkerboard at ALL tau>0. Acts on phi (the correction, ->0) so it self-extinguishes; post-corrector div relaxes to ~tau*lap(phi)=O(h^2), a CONSISTENT residual that vanishes under refinement -- the textbook PSPG, NOT the inconsistent div-breaking BD/floor. tau=h^2/24 (a LENGTH^2, not dt/rho). Confirm via MARS_CHECKER: frac must shrink. New kernel applyPSPGLaplacianTetKernel; gated --pspg, tau auto or --pspg-tau**
- **pump PSPG: FIX THE SIGN. The DDT operator outAcc = D M^-1 D^T phi ~ -lap(phi) (SPD-positive; A=-lap, matches b=-coef*div). My PSPG scattered +div(grad phi)=+lap(phi) = OPPOSITE sign -> SUBTRACTED definiteness (made conditioning worse, no damping). Flip: scatter -s to iL / +s to iR so it adds +tau*(-lap)phi = positive energy, same orientation as A. This is why the first PSPG run showed frac still growing + cg_p=-2 (wrong-sign term de-conditioned the operator). NOTE: that run ALSO lost the Jacobi clip (diag=6.5e-12) -- must pass MARS_DDT_JACOBI_CLIP_FRAC for the sliver**
- **pump PSPG: add tau*L diagonal to the Jacobi preconditioner (the REAL bug). Numerically verified (host dense-matrix replica): my PSPG sign was CORRECT (-s/+s -> L=+Vol*G^T*G, same sign as A=-lap, A+tau*L more SPD). The cg_p=-2 failure was the PRECONDITIONER mismatch: operator ran A+tau*L but d_diagDDT was built from A only -> worst on the sliver rows (tiny A-diag, large tau*L-diag) -> CG stalls. FIX: computeTetPSPGDiagonalKernel scatters tau*Vol*|dNdx_i|^2 into d_diagAccNode (before halo/gather) so the preconditioner matches the stabilized operator. Gated usePSPG, tet-only. Sign left unchanged (verified correct)**
- **pump: pin the degenerate sliver DOF(s) -- the identity-safe fix for the unsolvable pressure (cg_p=-2). A near-zero-volume tet gives a DDT diagonal ~9 OOM below bulk (1e-12 vs 6e-3); Jacobi-PCG cannot solve it. FIX: mask any owned DOF with diag < MARS_SLIVER_PIN_FRAC*max_diag (default 1e-6) into d_isPressureBdryDof -> the operator forces out=phi (identity row) AND the RHS forces b=0, exactly like the outflow/pin DOFs (verified both paths check maskPtr). One removed equation, div-safe. Makes the pressure solvable so the real physics + PSPG become readable. The mass floor was the wrong lever (sliver diag is AREA-driven, not mass); this pins the node directly**
- **poiseuille validation example: channel-fork NS solver with balanced opening-flux source; parabola matches analytic profile within reference tolerance (RMS 5.8e-3 < 6e-3, interior flux ratio ~1). Plus tutorial.**
- **pump: assembled tet DDT operator + FlexGMRES (toward Hypre AMG pressure solve). (1) ASSEMBLE the matrix-free D M^-1 D^T into CSR for tet (buildDDTSparsityTet + assembleDDTPerNodeKernelTet, node-driven so the per-node M^-1 cross-element face pairs are captured; tet nodeFaces[4][3]={{0,2,3},{0,1,4},{1,2,5},{3,4,5}} derived from d_tetLRSCV). Same operator as matrix-free (verify bit-identical via MARS_DDT_PROBE_DIFF, PSPG off) -> corrector stays div=0-exact. GPU-resident; only host touch is the rank0 setup [DDT-health] print. Matrix-free path UNTOUCHED (gated, additive -- can return to it). (2) FlexGMRES in the Hypre wrapper (default for BoomerAMG, the right Krylov for a varying AMG preconditioner; env MARS_HYPRE_FLEXGMRES). NOT YET COMPILED (no nvcc locally)**
- **pump: assemble PSPG tau*L into the DDT CSR (assemblePSPGStiffnessTetKernel). Element-driven 4x4 tet stiffness tau*Vol*(dNdx_i.dNdx_j) scattered via atomicAddSparseEntry into the existing DDT two-hop sparsity (subset, no new entries). Same tau*L the matrix-free path adds -> assembled A+tau*L == matrix-free A+tau*L. Iterates halo elements (elementCount includes halo) so owned boundary rows get cross-rank stiffness; writes owned rows only. Gated usePSPG. This (a) keeps PSPG on the assembled/Hypre path and (b) regularizes the Gram-form DDT toward diagonal dominance so Jacobi/BoomerAMG can precondition the 9-OOM operator. GPU-resident**
- **pump: activate the assembled DDT pressure solve on --solver=hypre. Re-gate the assembled-DDT block (was MARS_DDT_USE_ASSEMBLED_CG && CG only) to ALSO fire on solverKind==Hypre && nnzDDT>0 -> the SAME operator (D M^-1 D^T + assembled PSPG tau*L) is solved by Hypre FlexGMRES+BoomerAMG instead of matrix-free Jacobi-CG. Matrix-free path UNTOUCHED as the default (no --solver=hypre -> byte-identical). The wrapIntoSparseMatrix(s.AddT) now fires for tet automatically (nnzDDT>0). Global-DOF numbering + MPI partitioning already built at setup for the Hypre path. End-to-end: --solver=hypre -> assembled gate -> solveOneComponent(GMRES) -> FlexGMRES+AMG. Validate via MARS_DDT_PROBE_DIFF (PSPG off) first**
- **fix(pump): remove duplicate template clause before assembleDDTPerNodeKernelTet (my PSPG-kernel insert left an orphan template<> -> 'multiple template clauses' compile error)**
- **pump driver: parse --solver=hypre (was hardcoded SolverKind::CG -> the assembled Hypre path could never activate; explains why --solver=hypre runs were silently matrix-free CG). Sets SolverKind::Hypre -> the assembled DDT + FlexGMRES+BoomerAMG gate fires. --solver=cg restores default. Banner prints the active pressure path**
- **fix(pump hypre): skip the sliver-pin on the Hypre/assembled path. The pin reads the matrix-free d_diagDDT (tiny entries floored to 1 -> globalMax=1 -> 1e-6 threshold pinned ~220k DOFs), and enforcePressureBcRhsKernel then ZEROED b at all those rows -> RHS~0 -> phi=0 every step (no flow: u stuck at 0, div never projected). BoomerAMG handles the conditioning without pinning, so gate the pin on solverKind!=Hypre. This was why --solver=hypre ran stable but produced phi=0**
- **fix(pump hypre): force the VELOCITY solve onto in-house CG even under --solver=hypre. Root cause of the dead u=0 run: solverKind==Hypre routed the velocity matrix (M/dt + nu*K, mass-dominated / near-diagonal) through BoomerAMG-PCG, which is the wrong tool for a non-elliptic mass matrix -> exits ~1 iter returning x~0 -> u**=0 -> div(u**) RHS=0 -> phi=0 -> nothing develops. FIX: add forceCG param to solveOneComponent; velocity solves pass forceCG=true so they use the in-house CG (~14 iters, works) regardless of solverKind. Hypre/AMG stays reserved for the ill-conditioned DDT PRESSURE operator -- the only thing that needs it. (Also: pres_r0=0 under hypre is a stale-diagnostic artifact, lastPressR0 only written in the matrix-free path)**
- **poiseuille: --check regression mode + ctest entry, velocity-fit G closure (100.8% of exact), single-station profile CSV + plot script, u-field render script; fix wall-eps node pinning; document the incremental-p artifact (visualize u, not umag/p)**
- **debug(pump hypre): add MARS_SOLVE_TRACE -- prints converged/iters/|xVec|max right after the Hypre solve, to pin down whether phi=0 is (a) converged=false so xVec never scattered to qOut, or (b) xVec~0 itself. The verbose run showed BoomerAMG sets up + runs (b nonzero, L2=15) but only ~2 cycles at conv factor 0.43 -> likely final_res>tol -> converged=false -> no scatter -> phi=0**
- **poiseuille render: pump-style 3-panel validation layout (field + animated profile-vs-exact + centerline development), PIL composite + header**
- **fix(pump hypre): enforce the single pin into the ASSEMBLED DDT matrix (d_valuesDDT), not just the K-path d_valuesPre. ROOT CAUSE of phi=0: the pin row was only applied to d_valuesPre (K-path), so the assembled DDT operator s.AddT stayed SINGULAR (pure-Neumann pump pressure has a constant null mode). BoomerAMG/FlexGMRES on a singular operator returned the null-space solution = 0 -> 'converged in 2 iters', x=0, phi=0 (proven by MARS_SOLVE_TRACE: pressure solve converged=1 iters=2 |xVec|max=0 while velocity solves gave real nonzero x). FIX: enforcePinRowKeepDiagKernel on d_rowPtrDDT/d_colIndDDT/d_valuesDDT too (keepDiag = AMG-friendly). Single pin is the correct null-space removal for the pure-Neumann pump (matches the reference's 'single pressure reference')**
- **fix(pump hypre): accept a best-effort pressure solve (rel-res < MARS_HYPRE_ACCEPT_RES, default 1e-2) instead of requiring final_res<1e-8. Diagnosis via MARS_SOLVE_TRACE+Jacobi: FlexGMRES+Jacobi runs full 2000 iters and produces a NONZERO xVec (1930, growing) but stalls at res~7e-3 -> the strict converged gate rejected it -> not scattered -> phi=0 -> dead. A projection step does not need machine-precision phi; a partial solve removes most divergence. Now accept it. (AMG still falsely converges at x=0 on this near-singular op -- separate, retune next; Jacobi is the working floor)**
- **poiseuille tutorial: starter-level Part 2 (equations, parabola derivation, CVFEM discretization, projection, solvers) + output-files table**
- **pump hypre: make BoomerAMG actually converge (fix the x=0 false convergence). Root cause: (1) the pump single-pin set the pinned DDT row diagonal to 1.0 (10-25x the native ~0.04-0.14), a documented PMIS-coarsening killer -> AMG V-cycle collapses onto the constant null mode -> FlexGMRES exits at 2 iters with x=0; (2) weak AMG settings (l1-Jacobi relax, strong=0.5, aggressive coarsening) for a 3D near-singular Poisson. FIXES: symmetric pin in the assembled DDT (zero row AND column, restore NATIVE diagonal via read/setRowDiagonalKernel -> no spike); AMG retune relax 18->8 (l1 hybrid SSOR), strong 0.5->0.25 (3D), agg 1->0, all env-overridable (MARS_AMG_*); GMRES min-iter floor + optional abstol; null-mode guard (reject converged-but-x=0). Best-effort acceptance now rejects null x**
- **pump hypre: harden the acceptance against the 1e7-phi blowup (multi-agent verification confirmed: cause = convergence/conditioning + loose accept gate admitting under-resolved huge phi; sign correct, removeMean NOT needed/refuted). (BUG2) upper-bound x reject in the Hypre wrapper: reject converged-but-|x|>>|b| (MARS_HYPRE_MAXX_RATIO default 1e6) -- the null-guard only caught x~0, not the observed x=huge. (accept) tighten default MARS_HYPRE_ACCEPT_RES 1e-2 -> 1e-6 so a res~2e-4 partial solve is rejected (phi stays warm-started) instead of scattering garbage. (BUG3) fix misleading 'opening-flux on by default' comments (it is OFF). Path to bounded solve: --pspg (AMG-friendly operator) + retuned BoomerAMG + these guards**
- **fix(pump hypre): BoomerAMG RelaxType 8 -> 18 (l1-Jacobi) -- the cause of AMG returning x=0 with a garbage 1.1e-315 residual. The retune to RelaxType=8 (l1-hybrid-SSOR, GS-family) is NOT GPU-functional: the cuda Hypre build does not implement GS-family smoothers as a real sweep (they no-op / go non-symmetric on GPU), so the V-cycle does nothing -> x=0 on the first cycle. The WORKING PCG wrapper (mars_hypre_pcg_solver.hpp:362-373) uses 18 for exactly this reason ('default GS becomes non-symmetric on GPU'), not merely PCG symmetry -- the GMRES comment misread that. l1-Jacobi-AMG-FlexGMRES is the standard GPU pressure solver. Verified pin/PSPG order is correct (pin enforced after PSPG). Testable via MARS_AMG_RELAX=18 (now the default)**
- **pump hypre: complete the AMG fix -- (1) NumSweeps 1->2 (l1-Jacobi is weaker than SSOR; 2 sweeps restore the smoothing strength). (2) Route the --pspg DDT pressure solve to Hypre PCG instead of GMRES: PSPG's tau*L makes A = D M^-1 D^T + tau*L SPD and the symmetric pin removes the null mode, so CG+AMG (the textbook pressure-Poisson solver, what deal.II/MFEM/Nalu use) is valid and more stable than FlexGMRES. Gated on s.usePSPG -> PCG; pure-DDT SPSD stays GMRES (Hypre PCG rejects SPSD with error 1). The PCG wrapper already uses GPU-safe RelaxType=18. MARS_HYPRE_KRYLOV still overrides for debug. Combined with the RelaxType 8->18 fix, this should give a converging bounded AMG pressure solve**
- **TGV: MARS_PRED_PERSLOT_GRADP toggle -- match predictor grad(p) seam reduction to corrector (Fable wdxg6s3ce: predictor folds, corrector per-slot -> dt-independent feedback gain 1.17)**
- **revert(pump hypre): route pressure back to FlexGMRES (not PCG). Routing --pspg to PCG was a regression: the PCG wrapper has NEITHER the null-mode guard NOR the upper-bound-x reject (only the GMRES wrapper does), so a converged-but-huge phi (PCG 'converged' in 14 iters at |phi|=1e123 on the still-ill-conditioned operator) was scattered -> corrector blew up -> inf predictor -> velocity Hypre-PCG errors downstream. GMRES carries the guards that keep it bounded. The RelaxType=18 fix (AMG now functional) stays. PCG can return once its wrapper has the same guards**
- **TGV: MARS_TGV_NONINCREMENTAL toggle (Fable fallback #3 -- p=phi non-incremental, severs pressure-accumulation feedback, loop gain exactly 0)**
- **pump hypre: PCG+AMG is the working --pspg path (port the guards). EMPIRICAL: on our GPU, PCG+BoomerAMG CONVERGES (16 iters, flow develops steps 1-3, div drops) while GMRES+AMG no-ops to x=0 (separate GMRES-wrapper GPU bug, debug later). PSPG makes the operator SPD + the pin removes the null mode, so CG+AMG is valid + textbook. Ported the null-mode + upper-bound-x guards (+ getEnvDouble, lastSolutionMax_, nullSolutionReturned_, accessors) from the GMRES wrapper to the PCG wrapper so a huge/near-null phi is rejected not scattered. Re-route --pspg pressure to PCG (PSPG off stays GMRES for SPSD). solveOneComponent picks up the guard via the solve() return**
- **pump hypre: GMRES+AMG is the pressure path (per the reference: GMRES + AMG-preconditioner). (1) Route --pspg pressure to GMRES, not PCG: GMRES tolerates the assembled DDT+tau*L operator's near-indefiniteness (tiny passage-cell diagonals) where PCG breaks down (pAp<0, HYPRE error 256). (2) Default to PLAIN GMRES (HYPRE_GMRESSetPrecond), not FlexGMRES: a 1-V-cycle AMG is a FIXED linear op so plain GMRES is valid AND is the battle-tested GPU path; FlexGMRES's precond-apply appeared to no-op on our GPU build (x=0, denormal residual). MARS_HYPRE_FLEXGMRES=1 / MARS_HYPRE_KRYLOV=pcg still available. All prior work kept (assembled DDT, PSPG-CSR, guards on both wrappers, symmetric pin, velocity-on-CG, RelaxType=18)**
- **TGV: MARS_TGV_USTART_BCAST toggle -- force start-of-step u broadcast on reduced path so skew advection mdot is seam-consistent (secondary loop is advective: --skew=0 bounds it, --skew=1 doesn't)**
- **pump hypre: pin tiny-diagonal rows of the ASSEMBLED DDT operator (the REAL fix for the 1e6 phi). DIAGNOSIS via plain GMRES+AMG: AMG now CONVERGES tight (40 iters, final_res=8e-9) -- FlexGMRES was the no-op -- but the CONVERGED solution is |phi|~1e6*|b| because the degenerate passage/sliver cells give the operator near-zero diagonals -> near-zero eigenvalues -> A^-1 amplifies ~1e6 -> physically-huge phi -> blowup feedback (b grows with div). FIX: pinTinyDiagonalRowsKernel makes every owned row with diag < MARS_DDT_ASM_PIN_FRAC*max_diag (default 1e-4) an identity row + marks it in d_isPressureBdryDof (RHS zeroed there) -> removes the near-zero eigenvalues so phi is physical. Runs on the assembled matrix before the s.AddT wrap, Hypre-path only. This is the assembled analogue of the matrix-free sliver-pin, reading the ACTUAL assembled diagonal**
- **docs: TGV breakthrough -- primary feedback loop (predictor/corrector grad(p) seam mismatch) FIXED via MARS_PRED_PERSLOT_GRADP; secondary loop localized to skew advection mdot at periodic seam. Baseline step-40 blowup -> step-160. Flags stay opt-in until secondary loop fixed.**
- **TGV: MARS_PRED_PERSLOT_ADV toggle -- make predictor advN per-slot to match per-slot grad(p) (predictor RHS seam-consistency; secondary loop is the advN-folded/gradP-perslot mismatch)**
- **pump hypre: use the GALERKIN LAPLACIAN K (s.Apre), not the Gram form D M^-1 D^T (s.AddT), for the assembled pressure solve -- THE STRUCTURAL FIX. Verified (agent + scaling argument): the DDT diagonal 0.25*|sum sigma_g A_g|^2/V is a square of a CANCELLING signed area-vector sum -> near-zero on GOOD cells (a real sliver gives a HUGE diagonal here, not tiny) -> near-zero eigenvalues -> 1e6 phi amplification -> blowup. Collaborator was RIGHT: no bad mesh cells; it's our Gram construction. The Galerkin K_ij=integral grad N_i.grad N_j has diagonal ~h (sum of squares, no cancellation) -> well-conditioned, AMG-friendly, no near-zero eigenvalue -- and is what the reference assembles. K is SPD so default to PCG+AMG (textbook pressure solver, now valid). MARS_HYPRE_USE_DDT=1 reverts to DDT+GMRES for comparison. Corrector stays M^-1 D^T (div relaxes, acceptable). All prior infra kept**
- **pump hypre: use GMRES (not PCG) for the Galerkin K pressure solve too. K (Apre) is SPD in principle but PCG broke down (pAp<0, HYPRE error 256, ~3 iters) -- BoomerAMG-as-preconditioner is non-symmetric on GPU (GS-family relax) + the pin-row diag=1 spike disturbs coarsening, so the preconditioned operator isn't SPD for CG. GMRES tolerates it (the proven-converging path). RESULT of the K switch: |phi| dropped from 1e6 to ~6000-30000 -- the Galerkin operator IS far better conditioned than DDT (no near-zero eigenvalue), confirming the artifact diagnosis. MARS_HYPRE_KRYLOV=pcg to force CG**
- **TGV: per-slot grad(p) divides by per-slot half-CV mass (d_massNodePerSlot), not merged (workflow w7bapvkdt: per-slot numerator/merged mass = half gradient = the residual factor-of-2 keeping feedback gain >1)**
- **Revert "TGV: per-slot grad(p) divides by per-slot half-CV mass (d_massNodePerSlot), not merged (workflow w7bapvkdt: per-slot numerator/merged mass = half gradient = the residual factor-of-2 keeping feedback gain >1)"**
- **pump: --pressure-k flag = the reference collocated Galerkin setup (the K-path fix). Solves the well-conditioned Galerkin stiffness K (s.Apre, AMG-able, physical phi) AND corrects with the CONJUGATE SCS Green-Gauss gradient (useLegacyGradient=true -> useDivT=false) -- the pairing that makes the K projection consistent. The old 'nearly orthogonal' K-failure was K solved but corrected with D^T (the gradient conjugate to DDT, not K). Pair with --vms-stab (divergence-side checkerboard stabilization, keeps K clean) + --solver=hypre -> the trifecta: well-conditioned + checkerboard-stable + projection-consistent, exactly what the reference does. DDT stays the default (no flag = byte-identical). Workflow-verified high-confidence**
- **fix(pump K-path): use GMRES for the Hypre K pressure solve. The PressureSolveKind::K branch called solveOneComponent with the default KrylovHint (PCG); under --solver=hypre that routes to Hypre PCG, which false-converges in ~2 iters (cg_p=2) on this operator (BoomerAMG non-symmetric on GPU + pin spike) -> garbage phi -> the (now conjugate) corrector amplifies it -> blowup. Pass KrylovHint::GMRES when solverKind==Hypre, matching the DDT branch (cg_p=33-60, converges). This was why --pressure-k --vms-stab blew up despite all 3 fixes being active: the K solve never actually solved**
- **pump: FEM-consistent weak div/grad projection (--pressure-k v2). The SCS divergence/gradient pair has cancellation null modes (the verified artifact), so part of the divergence is INVISIBLE to the correction -> accumulates ~1.2x/step -> blowup ~step 15 regardless of solver (falsified pairings: DDT+D^T exact but 1e6 phi; K+D^T leaks; K+SCS-grad 44x/step). FIX: standard P1 weak-form pair, matched to K -- divergence b_i=-(V/4)dNdx_i.sum(u_j) per element (boundary term = existing opening-flux source), corrector gradient = mass-normalized (V/4)-weighted element-gradient average (the exact adjoint). D_fem M^-1 D_fem^T is a no-cancellation Gram form spectrally equivalent to K -> per-step divergence removal is a contraction on ALL modes. Numerically verified (host replica): exact weak integrals, +grad sign, adjointness. Predictor grad(p^n) switched too. K+Hypre GMRES solve unchanged. New mars_fem_projection.hpp; gated useFemProjection; no flag = byte-identical**
- **pump: consistent P1 face-quadrature opening flux for the FEM projection (the destabilizer fix). DISCRIMINATOR: source OFF -> first STABLE run (phi 219->51 decaying, u bounded, div falling); source ON -> geometric blowup from step 1. The weak form requires oint(N_i u.n) as a consistent face integral; the lumped per-node source (u_i.areaVec_i, global dir) mismatches it node-by-node (rim + per-node-normal curvature) -> fixed-location spurious mass source -> hot spot. FIX: host-side setup weights w_i = (1/12)(2u_i+u_j+u_k).A_f over the side-set triangles using the velocity the BC ACTUALLY imposes per node, uploaded once (d_femFluxWin/Wout); per step divAcc += ramp*w_in + oScale*w_out (net=0 machine-exact, same ramp/oScale algebra). Gated useFemProjection; lumped path untouched otherwise. Verified: exact integral, signs, balance, uniform-velocity == lumped**
- **poiseuille multirank: fix DDT pressure solve across the streamwise rank seam. Three matrix-free fixes (column-zero for SPD, per-iter ghost exchange of p, Jacobi diagonal built matrix-free with reverse-halo fold) + route inlet BCs through the pump path (built inside setup, rank-consistent). 4-rank pressure CG now converges (was non-SPD/diverging). Single-rank byte-identical.**
- **pump: PISO inner pressure corrections (--correctors=N, FEM-projection path). Measured defect: one K-solve contracts the weak divergence only ~0.5-0.6x (K vs the D_fem M^-1 D_fem^T Gram spectral gap), so the un-removed residual + the re-presented boundary flux compound ~1.2-1.3x/step -> blowup ~step 12. FIX: iterate div->solve->correct on the CURRENT velocity iterate within the step; the interior divergence progressively cancels the (constant) boundary source so the SUM shrinks ~0.5x/pass (2-3 passes -> ~10-25% leftover -> contraction). runPressureSolveStep takes optional velocity-iterate ptrs (default u**); computeGradPhi/runCorrector extracted to lambdas, phiTotal accumulated + published so p+=phi and predictor grad(p^n) see the full increment. Honest [fem-div k=..] residual print (the SCS [CORR] div_max mismeasures the FEM path). N=1 byte-identical. gated useFemProjection+TetTag. NOT YET COMPILED**
- **pump: assemble the FEM-Gram pressure operator A_fem = D_fem M^-1 D_fem^T (the EXACT conjugate of the FEM div/grad corrector). Root cause of the un-removable divergence (flat PISO): K != D_fem M^-1 D_fem^T, so solving K leaves a residual the FEM corrector cannot project out. A_fem is the operator the projection identity requires: solve A_fem phi = (rho/dt) D_fem u**, correct u^{n+1}=u**-(dt/rho)M^-1 D_fem^T phi -> D_fem u^{n+1}=0 EXACTLY in one pass (host replica: div 0.173 -> 2.4e-16). Built from the FEM stencil a_i=-(V/4)dNdx_i (NOT SCS area-vectors -> NO cancellation, healthy SPD diagonal ~K/valence, AMG-friendly -- unlike the abandoned SCS DDT). Node-driven assembly factored as sum_i (1/M_i)(S_a.S_b), reuses buildDDTSparsityTet (same two-hop pattern), symmetric pin, wrapped s.AFemGram, solved with Hypre GMRES instead of s.Apre when useFemProjection. [FemGram-health] diag print. Gated; no flag byte-identical. NOT YET COMPILED**
- **pump --pressure-k: solve K + SCS Green-Gauss corrector + rely on --vms-stab (the reference collocated method). PROVEN this session: exact projection is impossible with a well-conditioned operator -- ANY conjugate D M^-1 D^T Gram form (SCS or FEM-Gram) has near-zero interior diagonals because sum_e grad N_a = 0 on a closed 1-ring (divergence theorem); FEM-Gram failed identically to SCS (diag 0.00, |x|=2.3e6, guard-rejected; host 2-tet replica missed it -- no closed-ring node). The reference does NOT drive div=0; it solves the well-conditioned K and stabilizes the residual divergence (--vms-stab). So --pressure-k now = K + useLegacyGradient=true (SCS corrector, K-consistent) + useFemProjection=false (FEM-Gram off). Pair with --vms-stab + --solver=hypre. FEM-Gram/projection kernels kept in tree (gated off) but no longer used by --pressure-k**
- **pump: scale-aware [FemGram-health] diagnostic. The old print flagged diag range [0.00, 0.02] as a fault, but A_fem = D_gal M^-1 D_gal^T is a Gram-Laplacian that correctly scales O(h) in 3D -- 0.02 IS healthy on a fine mesh, not near-zero. Host replica (closed-ring interior node, octahedron) verified: the kernel computes the correct operator to machine precision (brute-force D M^-1 D^T == factored form, diff 0); A_fem[0][0]=h exactly; one correction drops weak div 1e-1 -> 3e-17. The self-term (j==a) IS the cancelling closed-ring sum (~0) but the off-intermediate neighbor terms keep the diagonal positive O(h). New invariants: minDiag/sum|offdiag| (~1 healthy, <<1 = SCS collapse) + max|rowsum|/diag (~0 = constant null mode). Route A (FEM-Gram, --pressure-k) is structurally CORRECT; the earlier blowup was NOT the operator**
- **fix(pump): --pressure-k = Route A (FEM-Gram), the VERIFIED-correct config -- not the proven-bad K+SCS. Host replica proved A_fem = D_gal M^-1 D_gal^T is the correct SPD operator (assembly==brute-force diff 0; one correction drops div 1e-1->3e-17; the [0.00] diagonal was a MISREAD of the healthy O(h) scale). K+SCS gradient AMPLIFIES divergence 100x (25.9->2637, measured) -- that mix is what blew up. Now --pressure-k sets useFemProjection=true -> solver routes to s.AFemGram (GMRES+AMG) + FEM corrector gradient. Consistent weak-Galerkin family throughout**
- **fix(pump): silent neighbor-cap overflow made A_fem near-singular on the real mesh (the actual bug -- NOT the mesh). On the production tet mesh, high-valence interior nodes (40-70+, tets are high-valence) exceeded the hardcoded 48-neighbor caps in buildDDTSparsityTet + assembleFemGramPerNodeKernelTet, which SILENTLY DROPPED couplings -> A_fem rows lost off-diagonals -> near-singular (minDiag/sum|offdiag|=0.02) -> Hypre converges to |x|=2.3e6 for |b|=1.7 (eigenvalue ~1e-6) -> guard-rejects -> phi=0 -> blowup. Host replica (small clean patches, low valence) never hit it. FIX: (1) restructured assembleFemGramPerNodeKernelTet to scatter-direct into the CSR via atomicAddSparseEntry (element-pair double sum, math bit-identical to the verified Sum_i(1/M_i)S_a.S_b) -- NO partner buffer, cannot overflow at any valence, no register pressure; setup-only so the O(m^2) atomics cost nothing. (2) sparsity cap 48->96 (shared macro MARS_DDT_TET_MAX_OTHERS, single source of truth) + overflow COUNTER that prints [FemGram-assembly] N nodes exceeded cap (max valence) -- never silent again. Expect minDiag/sum|offdiag|~1, physical phi, div_max drops**
- **poiseuille: strip failed fork-local multirank seam attempts (ghost-row fold, promoted-ownership assembly, debug probes); keep the working pressure-solve seam fixes + --bdf1. Velocity multirank seam needs element-halo widening in domain.cu (proven: off-rank stiffness lives in elements this rank lacks; not foldable).**
- **pump: symmetric Jacobi scaling of A_fem so AMG solves it on the BIG mesh. A/B PROVED the method works (small mesh: minDiag/sum|offdiag|=0.07, phi physical 74, div_max contracts 9->5, flow develops) but the BIG mesh is near-singular (minDiag=0.02, |x|=2.3e6 for |b|=1.7, accepting it -> div 7->22->161->29869 blowup). The near-zero eigenvalue is from the lumped mass M^-1 spanning a wider range on the bigger non-uniform (but VALID, production-run) mesh -- pure operator conditioning. FIX (textbook for variable-mass B M^-1 B^T): solve A_hat y = b_hat, A_hat = D^-1/2 A_fem D^-1/2 (unit diagonal), recover x = D^-1/2 y (solution identical, just AMG-conditionable). Scale CSR in place at setup (col factor via dofToNode + halo for ghosts), scale b / unscale x per solve, gated useFemGramSolve, MARS_FEMGRAM_NOSCALE for A/B. Expect big-mesh minDiag~1, physical phi, div_max contracts like small. NOT YET COMPILED**
- **docs: confirm secondary loop = skew advection KE injection at non-solenoidal seam (hand-derived energy identity mdot*(qR^2-qL^2))**
- **TGV: MARS_TGV_EMAC -- energy-stable advection correction (advN -= q*div(u)) for non-solenoidal periodic seam; cancels the skew KE-injection (hand-derived residual mdot*(qR^2-qL^2)) without touching u or mass**
- **TGV EMAC: tunable coefficient MARS_TGV_EMAC_C (default -1) to sweep the q*div correction sign/magnitude empirically**
- **pump: --pressure-k default = K-solve + FEM weak gradient (drop the AMG-hostile Gram operator)**
- **docs: node-EMAC negative result; real fix is per-face mdot reconcile at periodic seam (skew is per-element energy-conserving; leak is cross-element mdot mismatch at the shared periodic face)**
- **TGV: MARS_TGV_SEAM_UPWIND -- seam-localized upwind dissipation for the periodic advective loop. PROVEN: per-face energy-zero impossible for conservative flux (production F*(qR-qL)); skew needs div u=0 to telescope; reduced projection leaves per-slot seam div by design -> must dissipate. Surgical upwind blend at seam faces only (derived coeff 0.5a|mdot|(qL-qR), production -0.5a|mdot|(qL-qR)^2<=0). --skew=0 (result 9) proves it bounds; this localizes it.**
- **docs: CORE WALL identified -- reduced periodic projection leaves per-slot seam divergence by design (proven: upwind delays but cannot cure -> continuous div source). NOT advection/corrector/feedback. Same 'boundary-complete divergence' open item as wing/pump. Feedback loops fixed (step40->190). Next = projection completeness, not more correction terms.**
- **docs: final handoff -- most promising untested fix is fold+broadcast CORRECTOR gradPhi (single-rank does this and is clean; differs from result-7 u-broadcast). Plus DOF over-collapse + per-slot residual r_M=-r_S leads. Core wall = projection leaves per-slot seam div.**
- **pump: AMG-on-K preconditioned solve of the Gram operator A_fem (Schur fix)**
- **pump: scale K by A_fem's D^-1/2 for the Schur preconditioner (the consistent fix)**
- **pump: stabilized-K pressure path -- add PSPG tau*L into K (the production method)**
- **pump: GMRES for both Hypre pressure paths (fixes cg_p=3 PCG false-convergence)**
- **pump: ramp the FIX-B pressure head (--pump-dp) with --source-ramp-steps**
- **pump: open-face momentum closure for FIX-B (fixes the advection detonation)**
- **multirank velocity solve: force Jacobi preconditioner diagonal positive (|diag|) so rho=(r,z)>0 -- seam DOFs had negative assembled diagonal, breaking CG conjugacy. Plus domain.hpp halo-factor knob (MARS_HALO_FACTOR, default 1.0) and MARS_NS_DEBUG_STEPS/MARS_CG_TRACE diagnostics. Channel multirank velocity operator still asymmetric at seam (pAp<0) -- next.**
- **pump: cap dt by the pressure-gradient kick too (fixes the head-ramp blowup)**
- **pump: MARS_NS_DEBUG_STEPS env to extend the [ns-dbg] window (watch late-step transitions)**
- **pump: clamp open-face grad(p)/grad(phi) in the predictor+corrector (closes the head-runaway)**
- **render: --side-set-io marks inlet/outlet from the side_set_id field (reliable, not the flow auto-detect)**
- **pump: FIX-B #3 open-face normal-velocity projection (--open-normal-proj)**
- **pump: FIX-B #2 dynamic-head inlet target (--total-pressure, totalPressure BC)**
- **pump: FIX-B #1 flux-consistent pressure BC (--flux-pressure-bc, closes the high-head div-creep)**
- **pump: exempt --flux-pressure-bc from the do-nothing-outlet source guard (the bug that no-op'd #1)**
- **docs: update pump tutorial to the implemented solver + add private deep-dive**
- **docs: privatize pump tutorial (move to gitignored internal-notes/ + correct stale DDT->K+tauL pressure path)**
- **docs: remove pump_cfd_tutorial nav entry + inbound links (NDA hazard + broken publish)**
- **docs: fix fabricated APIs, stale clone URLs, kernel list, multi-rank honesty**
- **channel: add [vel-pap-probe] single consistent-p pAp=(u,Au) diagnostic**
- **docs: use 'summation by parts' for the SCS flux-cancellation property**
- **coupled solver Phase 0: GPU model operator + thin-3D mesh gen, validated vs Erturk-Dursun**
- **coupled solver Phase 1: opt-in point-block BoomerAMG + GPU iter study (existential YES, smoother ceiling)**
- **ACM host Stages 0-2: Galerkin gate + V-cycle faithfulness + decisive stretched-mesh GO (directional beats smoothed-SA on anisotropic meshes)**
- **ACM Stage 3: GPU coarse-operator (sum-of-fine == P^T A P) + injection/restrict transfers, validated on H100 (4 gates exact, n16/32/64)**
- **ACM Stage 4a: GPU multilevel V-cycle (SpMV + point-Jacobi + sum-of-fine hierarchy), validated vs host replica to round-off (n16/32/64)**
- **ACM Stage 4b: native FlexGMRES (Z-basis) + pluggable Preconditioner + GpuAcmPreconditioner; single-rank ACM solver converges coupled saddle system on H100 (Z-basis exact, ACM-FlexGMRES 54/106/97 matches QR ref)**
- **ACM Stage 5: directional (Mavriplis) aggregation + direct QR coarsest + mesh-agnostic --acm-pump + MARS_QUIET_MESH gating (directional 3.4x over isotropic on real anisotropic mesh, converges where BoomerAMG fails)**
- **Rhie-Chow coupled operator: host Stage-0 algebra gate (a^pp M-matrix Laplacian, G=-D^T via a^up=-(a^pu)^T, tet non-orthogonality => deferred smooth-grad mandatory)**
- **Rhie-Chow coupled operator on GPU (--rhie-chow): FV a^pu/a^up=-(a^pu)^T + RC a^pp d_f-Laplacian (no tau), validated on H100 (G=-D^T, a^pp M-matrix); + coupled 4x4 block-Jacobi smoother + per-component pressure pinning**
- **Rhie-Chow operator -> ACM solve (--rhie-chow --acm-pump): converges large pump (197 iters, res 9e-9) where PSPG stalled (res 0.96); ACM beats BoomerAMG (still fails on RC operator)**
- **Rhie-Chow coupled NS matches Erturk-Dursun cavity (Re=100 b45): max|err|=1.24% (PSPG 1.8%), compact-only -- RC operator accurate, deferred smooth-grad not needed at this accuracy**
