### PR TITLE
cstone

### DIFF
--- a/docs/TUTORIAL_matfree.md
+++ b/docs/TUTORIAL_matfree.md
@@ -268,6 +268,24 @@ What to notice:
 - `Btil` interpolates from GLL nodes to the flux points; `Dtil` takes the derivative there;
   `D` differentiates GLL-to-GLL; `W` integrates a flux over a subcontrol interval.
 
+Precise definitions (`L_j` = the Lagrange basis through the GLL nodes `ζ`):
+
+| operator | size | what it does | formula |
+|---|---|---|---|
+| `zeta` (ζ) | p+1 | GLL solution nodes = the DOF | — |
+| `xi` (ξ) | p | Gauss points = the SCS flux faces | — |
+| `Btil` (B̃) | p×(p+1) | interpolate node values → flux points | `B̃[i][j] = L_j(ξ_i)` |
+| `Dtil` (D̃) | p×(p+1) | derivative at the flux points | `D̃[i][j] = L_j′(ξ_i)` |
+| `D` | (p+1)² | derivative at the nodes themselves | `D[i][j] = L_j′(ζ_i)` |
+| `W` | (p+1)² | histopolation: integrate flux back to nodes (Knaus Eq 5–6) | `W = (edge-function matrix)⁻¹` |
+| `Deltatil` (Δ̃) | (p+1)×p | ±1 subcontrol-face incidence (Knaus Eq 7) | `Δ̃[i][i] = −1, Δ̃[i][i−1] = +1` |
+
+The `til` (tilde) marks the operators evaluated **at the Gauss flux points** `ξ` (B̃, D̃, Δ̃), versus
+`D`/`W` which act at the GLL nodes. All of them are built **once** on the host by
+`buildHoCvfemOperators(P)` from `p` alone — pure 1D quadrature/interpolation math, **no element
+geometry enters**. They are *not* an element stiffness matrix `K_e`; the matrix-free apply never
+forms `K_e`.
+
 This follows Knaus' high-order CVFEM formulation ([Knaus 2022](#references), SAND2022-3366J). At `p=1` it collapses to
 ordinary linear CVFEM: `zeta={-1,1}`, `xi={0}`, `Btil=[1/2,1/2]`, `Dtil=[-1/2,1/2]`.
 
@@ -383,6 +401,35 @@ arithmetic cheap. The constraint is **shared-memory bandwidth and occupancy**. T
    exchange data, through small shared face buffers.
 3. **Pack `E` elements per block** at low order, so a `p=1` element (only 4 face slots) does
    not starve an SM.
+
+> **Why "identical for every element" — and why that still holds for distorted, unstructured hexes.**
+> This is the crux. Every hex — a perfect cube, a sheared cell, or a fully irregular one — is the
+> image of the **one reference hex** `[−1,1]³` under an isoparametric map `x = Φ_e(ξ)`. The reference
+> operators depend **only on `p`**, never on the element's shape, so they are the same bytes for
+> every element → one copy in `__constant__`. The element's *geometry* lives entirely in the
+> Jacobian `J` of that map, folded into the **per-element metric** `d_G = detJ · J⁻¹J⁻ᵀ` at the quad
+> points (§2.4). So:
+>
+> - **reference operators (B̃, D̃, D, W, Δ̃)** — depend only on `p` → identical for every element → built once, stored once in `__constant__`.
+> - **`d_G`** — depends on each element's corner coordinates → different per element → the only per-element data.
+>
+> An apply is: gather DOF → apply B̃/D̃ (shared operators, sum-factorized) → multiply by *this*
+> element's `d_G` → apply D̃ᵀ → scatter. A distorted/unstructured hex mesh changes every `d_G` and
+> changes the operators by **zero** — that is why "same operators for every element" is true on a
+> genuine unstructured mesh, not just a cube. The only requirement is that elements are **hexes**
+> (so the tensor-product structure holds), not that they are cubes.
+>
+> **This is the libCEED/CEED decomposition that MFEM's partial assembly also uses:** `A = Pᵀ Gᵀ Bᵀ D B G P`.
+>
+> | CEED operator | MARS equivalent |
+> |---|---|
+> | **P** — subdomain (global→rank-local) restriction | the distributed DOF ownership + halo exchange |
+> | **G** — element restriction (rank-local→per-element gather) | the `elemDof` gather in the apply kernel |
+> | **B** — basis evaluator (DOFs→quad points) | **B̃ (`Btil`) + D̃ (`Dtil`)** (value + gradient); `W` on the integration side |
+> | **D** — operator at quad points | **`d_G`** (the metric `detJ·J⁻¹J⁻ᵀ`) |
+>
+> ⚠️ Name clash: CEED's **`D`** (quadrature-point operator) is MARS's **`d_G`**, *not* MARS's `D`
+> (the GLL-node derivative `L_j′(ζ_i)`). Same letter, different object.
 
 **Code jump — the gather (and what `dof < 0` means).**
 `mars_cvfem_ho_matfree.hpp`, `ho_cvfem_apply_kernel`:

--- a/docs/TUTORIAL_matfree.md
+++ b/docs/TUTORIAL_matfree.md
@@ -1234,6 +1234,14 @@ transfers to a real warped hex mesh at zero extra cost (and is conservative — 
 above would only help structured regions). The cube in the test driver is a convenience for
 generating elements, not a shortcut the kernel relies on.
 
+**Validated, not just argued.** The driver's `--irregular` flag jitters interior nodes
+(deterministic per integer grid index, so a shared node moves *identically* on every rank — no
+mesh tearing) into a genuinely distorted partition with **~30–40% more cross-rank sharing** than
+the clean cube. On 8 GPUs at p=4 (625M DOF/rank), the GPU DOF ownership comes back **bit-identical
+to the all-peer reference** (`MARS_HO_VERIFY_OWNERSHIP`) on **both** the regular and the irregular
+partition, and the distributed matvec gate passes **A·1 = 1.0e-18**. So "distorted hexes work" is
+a measured result on a deliberately irregular partition, not just a property of the Jacobian.
+
 **Tets: no — they need a different kernel.** The entire speed argument rests on the **tensor-
 product** structure: GLL nodes on a `(p+1)³` lattice are what let sum-factorization split a 3D
 contraction into three 1D sweeps (§2.3). A tetrahedron has no such product structure, so this

--- a/docs/TUTORIAL_matfree.md
+++ b/docs/TUTORIAL_matfree.md
@@ -1333,8 +1333,10 @@ shown it bit-equivalent to the one you trust.
   harness proved it — is now the **default**, with the host path kept as an opt-in fallback.
 - **Trillion is in progress, not done.** The >4.3B-element domain-build crash turned out to be a
   2 GiB Allreduce message in cstone's global tree (not a count-value overflow); the fix is a
-  coarser global `bucketSize` (`MARS_GLOBAL_BUCKETSIZE`), free for the apply. The remaining gap to
-  a demonstrated trillion is the distributed *solve*, not the operator (Chapter 6).
+  coarser global `bucketSize` (`MARS_GLOBAL_BUCKETSIZE`), free for the apply, and is now
+  **setup-validated at 640B elements / 1024 GPUs** (full decomposition + DOF numbering + halo, no
+  Allreduce failure — a setup milestone, not a 640B matvec). The remaining gap to a demonstrated
+  trillion is the distributed *solve* plus the trillion apply itself, not the operator (Chapter 6).
 
 ---
 
@@ -1484,6 +1486,15 @@ domain decomposition. The lesson for distributed scale: a collective that worked
 silently die at a few billion purely on **message bytes**, and the cheapest fix is often to make
 the *replicated* structure coarser, not to widen a type.
 
+**Validated at 640B-element scale (setup only).** The overnight run carried the fix well past the
+4.3B wall: the full distributed **setup** — domain decomposition + GPU-native DOF numbering
+(numDof = 628,857,939 per rank) + ownership + halo — completed on **640 billion DOF / 1024 GH200**
+with **no Allreduce failure** (global bucketSize = 256, `extractDistDof` 4.2 s,
+`buildDistributedGpu` 7.858 s). This is a **setup/build milestone, not a matvec**: the run then
+timed out in the host-side `A·1` cross-check before the apply (since fixed by a host-gate skip).
+It proves the blocker is gone at scale; it is *not* a 640B matvec result. The full trillion apply
+is queued for the next overnight.
+
 ### 6.6 Where MARS sits: the Gordon Bell yardstick
 
 For calibration: MFEM won **Gordon Bell 2025** with **55.5 trillion DOF on 43,520 MI300A GPUs**
@@ -1529,13 +1540,17 @@ halo-correct. What exists today versus what remains:
      operator (cheap and AMG-friendly), and use AMG on it to precondition the high-order
      matrix-free solve. None of this is built yet.
   3. **Robust domain build past 4.3B elements** — the 2 GiB Allreduce blocker is fixed with the
-     auto-scaling global `bucketSize` (§6.5); larger-scale validation runs are the remaining work.
+     auto-scaling global `bucketSize` (§6.5) and **validated at 640B-element scale** (the full
+     setup ran on 1024 GH200, §6.5). What remains is the trillion-scale *apply* itself, queued for
+     the next overnight; the build is no longer the gate.
 
 The intellectually honest framing for the talk: MARS has a **trillion-class operator** —
 bit-exact, sum-factorized, weak-scaling, in the ~1B DOF/GPU density band of the Gordon Bell
 winner. The trillion-DOF *solve* is the next milestone, and its critical path is FlexGMRES +
-LOR-AMG over the operator we already trust, plus hardening the cstone domain build at the
-4-billion-element frontier. **We claim the operator. We do not yet claim the trillion.**
+LOR-AMG over the operator we already trust. The cstone domain build is no longer on that path: it
+is fixed and **setup-validated at 640B elements / 1024 GPUs** (§6.5), with the trillion *apply*
+queued. **We claim the operator and the setup scaling. We do not yet claim a trillion-DOF — or a
+640B — matvec.**
 
 ---
 


### PR DESCRIPTION
- **fix(pump): revive the pressure outlet (the REAL through-flow fix). outletU was set unconditionally -> always velocity-Dirichlet outlet -> both-ends-Dirichlet admits a flat-pressure tank-recirculation div=0 solution -> NO flow through the passage (confirmed: 1e-10 pressure solve gave identical flat-p, so it's structural not convergence -- AMG would NOT help). Gate outletU on !outletDoNothing so do-nothing (default) leaves outletU<=0 -> solver masks the WHOLE outlet face p=0 + frees outlet velocity (singlePin=false, solver:4080) -> inlet flux against fixed-p outlet FORCES the outlet->suction gradient -> through-flow. The dead --outlet flag now actually works**
- **fix(pump): default outlet back to MASS-CONSERVING (the correct design). Root cause found: the divergence operator only loops interior faces (sum(div)==0 always), so the pressure solve is NEVER told mass enters at the inlet -> a velocity-inlet + free pressure-outlet is UNPROJECTABLE -> no through-flow (flow dies at inlet, pressure parks in body). The code's own comment (solver:2295) flags this. My prior do-nothing default was backwards: the mass-conserving outlet (vel outflow removes Q + single pin) BALANCES the flux so the projection builds the inlet->outlet gradient that drives flow through the passage. The dead-flag gate stays so do-nothing is still selectable (needs a boundary-flux source term to be correct -- separate work)**
- **pump through-flow: (1) default to do-nothing outlet = whole-face p=0 + FREE outlet velocity (the channel-proven pairing that builds the inlet->outlet pressure head; both-ends-velocity-Dirichlet + single pin gave a flat-pressure dead-passage solution). (2) --inlet-flux-source (GUARDED, off): add the prescribed inlet flux as a boundary divergence source -- the exterior opening flux is in no interior SCS so it's never integrated (verified not a double-count); A/B it. (3) [through-flow] Q_in/Q_out/ratio diagnostic each step so we MEASURE through-flow (ratio->1) instead of eyeballing uMax. mass-conserving still selectable. cavity/channel/TGV unaffected**
- **pump: REMOVE the broken --inlet-flux-source (double-counted the inlet flux already registered via interior SCS scatter; full-opening-area x rho/dt -> instant blowup, ratio=garbage) and revert default to MASS-CONSERVING outlet. Verified high-confidence: the inlet flux is already in the divergence for a velocity-Dirichlet inlet, so the only correct inlet boundary source is ZERO. do-nothing (whole-face p=0 + free outlet) does NOT self-drive a small interior outlet -> ratio=0 (no through-flow); the prior do-nothing-default + comments were disproven by the A/B. mass-conserving (U_out=Uin*Ain/Aout + single pin) forces Q_out=Q_in by construction. Kept the [through-flow] Q diagnostic (correct + useful)**
- **pump through-flow REWORK (verified root cause): the reference flows through the pump with ANY scheme (bj/upwind) so the dead passage is OUR bug, not Re/scheme. TWO real defects fixed: FIX1 --opening-flux-source (GUARDED off): inlet/outlet OPENING faces are exterior, in no interior SCS, so the prescribed opening flux never reaches the pressure RHS -> pressure flat -> no through-flow. Add it as a COMPATIBLE surface integral (u.n)*A_share, SAME scale as interior scatter, NOT x rho/dt (RHS does it), net~0 -- verified NOT a double-count (telescoping interior pairs never touch the opening face). FIX2 --dirichlet-lift (default ON): velocity-diffusion col-zero had no Dirichlet lift -> inlet momentum never diffused inward -> jet died at inlet. Add b-=K[row,bdry]*uTarget. FIX3: replace TAUTOLOGICAL Q_out (relocked to prescribed outletU) with an INTERIOR cut-plane flux probe at 25/50/75% -- measures SOLVED through-flow, can't be faked. old line relabeled [bc-sanity]**
- **pump FIX B: pressure-drop drive via --pump-dp=VALUE (gated, off by default -> existing pump byte-identical). Root cause: the divergence operator integrates only INTERIOR SCS faces, so a VELOCITY prescribed on the interior inlet opening is invisible to the pressure solver (exterior opening face never integrated) + the corrector freezes velocity-Dirichlet nodes -> no through-flow (proven: interior-flux mid-cut=0). FIX B masks BOTH openings as pressure-Dirichlet (p=dP inlet, p=0 outlet), frees both velocities, seeds the dP head in d_p -> flow EMERGES from the interior gradient (SCS-captured, VISIBLE). Startup-safe: two Dirichlet faces make the matrix NONSINGULAR -> no compatibility condition -> no FIX-1 source-blowup. inlet velocity becomes an OUTPUT (tune dP to hit ~0.5 m/s). Keeps interior-flux probe to verify mid-cut goes nonzero**
- **pump FIX B phi-lift (the piece that makes dP actually drive flow). Bug: FIX B seeded a one-node dP spike + pinned the phi increment to 0 at both faces -> interior never relaxed into the inlet->outlet gradient -> dP didn't drive flow (identical tiny flow at dP=1000 vs 30000). FIX: pin the SOLVED pressure to the target via rhs=target-p^n at masked DOFs (clamp to constant, NOT additive -> steady+bounded), so the Poisson solve imposes dP->0 Dirichlet data + relaxes the spanning gradient; the already-live predictor grad(p^n) then drives through-flow. LOAD-BEARING: pump runs DDT matrix-free, so the lift goes in solvePressureDDT's boundary-pin lambda (not the K-path). All gated pumpDp>0; pumpDp<=0 byte-identical (cavity/channel/TGV untouched)**
- **pump THROUGH-FLOW fix: prescribed-balanced opening-flux source (default ON). The verified root cause: a velocity-inlet's opening flux is invisible to the pressure solver (divergence integrates interior SCS only) -> flat passage -> dead passage (proven: interior-flux cut@50%=0). FIX: inject the opening flux into divAccNode so the projection SEES the inflow and builds the inlet->outlet gradient that drives the passage. KEY over the broken FIX 1: use PRESCRIBED GLOBAL-direction velocities (Uinf*inletDir, outletU*outletDir) not the solved u** -> inlet sums to -Q_in, outlet to +Q_in (outletU=Uin*Ain/Aout) -> total=0 EXACTLY every step incl step0 -> single-pin Neumann stays compatible -> CANNOT blow up like FIX 1 (which used u**=0 at the step0 outlet -> one-sided -> phi=1e36). Config: mass-conserving velocity inlet+outlet (sustains the jet) + this source (makes it visible). No removeMean (pin handles it). FIX B (pumpDp) abandoned, gated off**
- **pump: default opening-flux-source back OFF -- the prescribed-balanced source STILL blows up at step0 (phi=1e7->inf, CG residual grows = incompatible, same FLT_MAX as FIX 1). The 'sum=0 by construction' startup-safety proof was WRONG: the discrete per-node area shares evidently do not sum to exactly Q, so sum!=0, x rho/dt=1e6 -> explodes even at step0. Revert to the STABLE mass-conserving default (no through-flow, but runs). The opening-flux-source remains a flag for debugging but is NOT a working fix. Through-flow is UNRESOLVED -- see scratch/pump_throughflow_HANDOFF.md**
- **pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B**
- **Revert "pump: adjustPhi exact-balance for the opening-flux source (the established OpenFOAM/deal.II-step35 fix). Prior source blew up because analytic inlet+outlet sums cancel only in EXACT arithmetic; the FP leftover x rho/dt=1e6 exploded the single-pin Neumann solve. NOW: measure discrete Qin_d, Qout_d (MPI_Allreduce, same idiom as fluxThroughOwned), rescale outlet by scale=-Qin_d/Qout_d. IEEE: scale*Qout_d == -Qin_d to the last bit -> net added source is BIT-EXACT 0 -> RHS compatible regardless of mesh imperfection -> CANNOT blow up (the pin makes A nonsingular; exact balance makes RHS compatible; both needed). Still gated --opening-flux-source for A/B"**
- **debug: MARS_OFS_DBG -- print divAccNode |max| before/after the opening-flux source + the global net source sum, to SEE if the source is a giant localized spike (divAcc max jumps) and whether net is actually ~0. Instrumentation only, gated on env. Investigating the repeated step0 phi=1e7 blowup**
- **debug: print Qin_raw/Qout_raw separately -- the [ofs-dbg] net=-Q_in (one-sided) proves the OUTLET source contributes ZERO. Need to see Qin_raw vs Qout_raw to find why the outlet half does not fire (area-vec sign? outletDir?)**
- **pump: adjustPhi rescale FOUND THE BUG via debug -- the discrete inlet/outlet fluxes differ ~1.5% (Qin_raw=-5.975e-3, Qout_raw=+5.884e-3), NOT roundoff: the per-node area-vectors sum to a different value than the analytic areaIn/areaOut used for outletU. That 9e-5 residual x rho/dt=1e6 -> incompatible RHS -> phi=1e7 blowup. FIX: oScale=-Qin_raw/Qout_raw, rescale the outlet source so it EXACTLY cancels the inlet (net->0). The reductions now always run (not just debug). [ofs-dbg2] prints the net to confirm it goes to ~0**
- **pump: removeMean for the opening-flux source -- THE ACTUAL FIX. Debug PROVED the blowup is NOT flux imbalance: with the adjustPhi rescale the net source is bit-exactly 0 (8.67e-19) and it STILL blew up to phi=1e7 identically. Real cause (the code's own comments flag it: lines 897/2209/3333/5145): the single p=0 pin weakly controls the DDT constant null space; a boundary source excites that mode and Jacobi-PCG loses pAp>0 (residual GROWS 0.98->1.46 then garbage phi=1e7). FIX: removeMean the RHS + phi (project the null-space component out) when opening-flux is on -- the same cure the periodic path uses. Gated on useOpeningFluxSource**
- **debug: removeMean did NOT fix the blowup (phi=1e7 identical) -> null-space theory also wrong. KEY realization: the CG CONVERGES (3e-8), so phi=1e7 is the TRUE solution -- the operator+RHS are fine, the answer is legitimately huge. Add [ofs-dbg3] b|max and [ofs-dbg4] phi|max split by OPENING vs INTERIOR nodes, to decide: is phi huge only at the opening nodes (tiny DDT boundary-layer diagonal, b/diag=1e6*1e-4/1e-5=1e7 LOCAL) or everywhere (global)? That picks the final fix**
- **pump: --source-ramp-steps=N gentle startup for the opening-flux source. ROOT CAUSE (measured): the source WORKS (real through-flow, step1 cut@50% nonzero) but starting from rest at full strength dumps the whole inlet->outlet pressure head onto a near-singular interior node (sliver cell, DDT diag=1e-5, 600x below bulk) -> phi spikes to 6e6 there -> grad(phi) spike -> corrector velocity spike -> advection 950x/step -> blowup. NOT fixable by clip (preconditioner-only, phi is the true solution), CFL (structural per-step amplification), or balance/removeMean (all already correct). FIX: ramp Uinf 0->full over N steps so the head + phi + grad stay small while flow develops gently. Scales the inlet velocity target (from a base snapshot) AND the opening-flux source (reads Uinf live) -> balance preserved at every ramp level**
- **pump: allow dt to shrink up to 2x/step (was 5%/step). With the ramp, the flow develops stably for ~16 steps (phi=1e4, u_max bounded+growing, cut@50% nonzero) then a CFL violation at u~100 ran away because the 5%/step shrink cap could not drop dt fast enough to catch it. Fast shrink catches the violation in one step; growth stays gentle (5%/step) so BDF2's constant-dt assumption holds at steady state**
- **pump: targeted operator-diagonal floor on the matrix-free DDT (the sliver-node fix). MEASURED: the ramp fixes startup (steps 1-16 stable, flow developing, cut@50% nonzero) but one sliver interior node (tiny SCS face areas -> DDT diag=1e-5, 600x below bulk) makes phi spike there -> corrector velocity spike -> diffusion CG breaks (pAp<0, u**>>u*) -> blowup, even at dt=5e-8 (so NOT CFL). Jacobi clip is preconditioner-only (no-op on phi). FIX: raise ONLY the degenerate rows to epsFloor=0.05*max_diag in the TRUE matrix-free operator via per-node shift out[i]+=shift_i*phi[i]; 0 on the healthy bulk -> byte-identical there -> cavity/channel/cube16 untouched. Caps phi at b/3.3e-4 (~31x smaller) -> below blowup threshold. Pure positive diagonal add -> keeps SPD. Preconditioner diag floored to match. Velocity diffusion needs NO floor (M/dt keeps it conditioned; its divergence was downstream of the phi spike). Env MARS_DDT_OP_FLOOR_FRAC**
- **debug: MARS_CHECKER -- per-element mean-free pressure RMS diagnostic (the checkerboard mode an inf-sup stabilizer penalizes). Lets us SEE the checkerboard grow + SEE a stabilizer kill it in a few steps, instead of inferring from a full-run blowup. Confirms/quantifies the LBB decoupling diagnosis. Env-gated, tet-only, rank0, free in production. NOTE: adjudication confirmed BD-on-DDT is WRONG (breaks div=0 identity, accumulating divergence); the identity-safe path is VMS/RC on the divergence SOURCE (needs a phi-vs-d_p fix). Checkerboard fix != through-flow fix (separate defects)**
- **fix: checker diagnostic compile error -- a pair-returning __device__ lambda in transform_reduce needs its return type proclaimed in host context. Split into two scalar (double) reductions (mean-free energy + total) -- avoids the trait error, same result**
- **pump: replace the div-BREAKING operator-diagonal floor with an identity-safe MASS floor. The operator floor (out[i]+=shift*phi in applyDDTPerNode) only the OPERATOR saw, not the corrector -> solving (A+S)phi=b left div(u^{n+1})=(dt/rho)*S*phi un-projected -> accumulating residual -> smooth |p| 1e3->1e34 blowup (the SAME div=0-breaking class the code warns against for BD-on-DDT, lines 5602-5610). FIX: floor the lumped mass d_massNode instead -- A=D M^-1 D^T and the corrector ALSO applies M^-1 from the same d_massNode, so flooring mass changes operator AND corrector consistently -> div=0 PRESERVED. Removed d_shiftDDTNode + its apply + the operator-floor build. Env MARS_MASS_FLOOR_FRAC (default 1e-3*max_mass)**
- **pump: implicit PSPG pressure stabilization (--pspg) -- the CORRECT equal-order checkerboard fix. VERIFIED root cause of the checkerboard blowup: the existing VMS adds tau*(-lap p^n) to the RHS = an EXPLICIT forward-Euler Laplacian-of-p update -> unconditionally amplifies the high-freq mode at ANY tau (why 1e-6/1e-5/1e-3 all blew up). FIX: add tau*L*phi IMPLICITLY inside applyDDTPerNode so CG solves (A+tau*L)phi=b. L=sum_e V_e G^T G is symmetric PSD, shares A's constant null mode (removed by the pin) -> SPD, damps checkerboard at ALL tau>0. Acts on phi (the correction, ->0) so it self-extinguishes; post-corrector div relaxes to ~tau*lap(phi)=O(h^2), a CONSISTENT residual that vanishes under refinement -- the textbook PSPG, NOT the inconsistent div-breaking BD/floor. tau=h^2/24 (a LENGTH^2, not dt/rho). Confirm via MARS_CHECKER: frac must shrink. New kernel applyPSPGLaplacianTetKernel; gated --pspg, tau auto or --pspg-tau**
- **pump PSPG: FIX THE SIGN. The DDT operator outAcc = D M^-1 D^T phi ~ -lap(phi) (SPD-positive; A=-lap, matches b=-coef*div). My PSPG scattered +div(grad phi)=+lap(phi) = OPPOSITE sign -> SUBTRACTED definiteness (made conditioning worse, no damping). Flip: scatter -s to iL / +s to iR so it adds +tau*(-lap)phi = positive energy, same orientation as A. This is why the first PSPG run showed frac still growing + cg_p=-2 (wrong-sign term de-conditioned the operator). NOTE: that run ALSO lost the Jacobi clip (diag=6.5e-12) -- must pass MARS_DDT_JACOBI_CLIP_FRAC for the sliver**
- **pump PSPG: add tau*L diagonal to the Jacobi preconditioner (the REAL bug). Numerically verified (host dense-matrix replica): my PSPG sign was CORRECT (-s/+s -> L=+Vol*G^T*G, same sign as A=-lap, A+tau*L more SPD). The cg_p=-2 failure was the PRECONDITIONER mismatch: operator ran A+tau*L but d_diagDDT was built from A only -> worst on the sliver rows (tiny A-diag, large tau*L-diag) -> CG stalls. FIX: computeTetPSPGDiagonalKernel scatters tau*Vol*|dNdx_i|^2 into d_diagAccNode (before halo/gather) so the preconditioner matches the stabilized operator. Gated usePSPG, tet-only. Sign left unchanged (verified correct)**
- **pump: pin the degenerate sliver DOF(s) -- the identity-safe fix for the unsolvable pressure (cg_p=-2). A near-zero-volume tet gives a DDT diagonal ~9 OOM below bulk (1e-12 vs 6e-3); Jacobi-PCG cannot solve it. FIX: mask any owned DOF with diag < MARS_SLIVER_PIN_FRAC*max_diag (default 1e-6) into d_isPressureBdryDof -> the operator forces out=phi (identity row) AND the RHS forces b=0, exactly like the outflow/pin DOFs (verified both paths check maskPtr). One removed equation, div-safe. Makes the pressure solvable so the real physics + PSPG become readable. The mass floor was the wrong lever (sliver diag is AREA-driven, not mass); this pins the node directly**
- **poiseuille validation example: channel-fork NS solver with balanced opening-flux source; parabola matches analytic profile within reference tolerance (RMS 5.8e-3 < 6e-3, interior flux ratio ~1). Plus tutorial.**
- **pump: assembled tet DDT operator + FlexGMRES (toward Hypre AMG pressure solve). (1) ASSEMBLE the matrix-free D M^-1 D^T into CSR for tet (buildDDTSparsityTet + assembleDDTPerNodeKernelTet, node-driven so the per-node M^-1 cross-element face pairs are captured; tet nodeFaces[4][3]={{0,2,3},{0,1,4},{1,2,5},{3,4,5}} derived from d_tetLRSCV). Same operator as matrix-free (verify bit-identical via MARS_DDT_PROBE_DIFF, PSPG off) -> corrector stays div=0-exact. GPU-resident; only host touch is the rank0 setup [DDT-health] print. Matrix-free path UNTOUCHED (gated, additive -- can return to it). (2) FlexGMRES in the Hypre wrapper (default for BoomerAMG, the right Krylov for a varying AMG preconditioner; env MARS_HYPRE_FLEXGMRES). NOT YET COMPILED (no nvcc locally)**
- **pump: assemble PSPG tau*L into the DDT CSR (assemblePSPGStiffnessTetKernel). Element-driven 4x4 tet stiffness tau*Vol*(dNdx_i.dNdx_j) scattered via atomicAddSparseEntry into the existing DDT two-hop sparsity (subset, no new entries). Same tau*L the matrix-free path adds -> assembled A+tau*L == matrix-free A+tau*L. Iterates halo elements (elementCount includes halo) so owned boundary rows get cross-rank stiffness; writes owned rows only. Gated usePSPG. This (a) keeps PSPG on the assembled/Hypre path and (b) regularizes the Gram-form DDT toward diagonal dominance so Jacobi/BoomerAMG can precondition the 9-OOM operator. GPU-resident**
- **pump: activate the assembled DDT pressure solve on --solver=hypre. Re-gate the assembled-DDT block (was MARS_DDT_USE_ASSEMBLED_CG && CG only) to ALSO fire on solverKind==Hypre && nnzDDT>0 -> the SAME operator (D M^-1 D^T + assembled PSPG tau*L) is solved by Hypre FlexGMRES+BoomerAMG instead of matrix-free Jacobi-CG. Matrix-free path UNTOUCHED as the default (no --solver=hypre -> byte-identical). The wrapIntoSparseMatrix(s.AddT) now fires for tet automatically (nnzDDT>0). Global-DOF numbering + MPI partitioning already built at setup for the Hypre path. End-to-end: --solver=hypre -> assembled gate -> solveOneComponent(GMRES) -> FlexGMRES+AMG. Validate via MARS_DDT_PROBE_DIFF (PSPG off) first**
- **fix(pump): remove duplicate template clause before assembleDDTPerNodeKernelTet (my PSPG-kernel insert left an orphan template<> -> 'multiple template clauses' compile error)**
- **pump driver: parse --solver=hypre (was hardcoded SolverKind::CG -> the assembled Hypre path could never activate; explains why --solver=hypre runs were silently matrix-free CG). Sets SolverKind::Hypre -> the assembled DDT + FlexGMRES+BoomerAMG gate fires. --solver=cg restores default. Banner prints the active pressure path**
- **fix(pump hypre): skip the sliver-pin on the Hypre/assembled path. The pin reads the matrix-free d_diagDDT (tiny entries floored to 1 -> globalMax=1 -> 1e-6 threshold pinned ~220k DOFs), and enforcePressureBcRhsKernel then ZEROED b at all those rows -> RHS~0 -> phi=0 every step (no flow: u stuck at 0, div never projected). BoomerAMG handles the conditioning without pinning, so gate the pin on solverKind!=Hypre. This was why --solver=hypre ran stable but produced phi=0**
- **fix(pump hypre): force the VELOCITY solve onto in-house CG even under --solver=hypre. Root cause of the dead u=0 run: solverKind==Hypre routed the velocity matrix (M/dt + nu*K, mass-dominated / near-diagonal) through BoomerAMG-PCG, which is the wrong tool for a non-elliptic mass matrix -> exits ~1 iter returning x~0 -> u**=0 -> div(u**) RHS=0 -> phi=0 -> nothing develops. FIX: add forceCG param to solveOneComponent; velocity solves pass forceCG=true so they use the in-house CG (~14 iters, works) regardless of solverKind. Hypre/AMG stays reserved for the ill-conditioned DDT PRESSURE operator -- the only thing that needs it. (Also: pres_r0=0 under hypre is a stale-diagnostic artifact, lastPressR0 only written in the matrix-free path)**
- **poiseuille: --check regression mode + ctest entry, velocity-fit G closure (100.8% of exact), single-station profile CSV + plot script, u-field render script; fix wall-eps node pinning; document the incremental-p artifact (visualize u, not umag/p)**
- **debug(pump hypre): add MARS_SOLVE_TRACE -- prints converged/iters/|xVec|max right after the Hypre solve, to pin down whether phi=0 is (a) converged=false so xVec never scattered to qOut, or (b) xVec~0 itself. The verbose run showed BoomerAMG sets up + runs (b nonzero, L2=15) but only ~2 cycles at conv factor 0.43 -> likely final_res>tol -> converged=false -> no scatter -> phi=0**
- **poiseuille render: pump-style 3-panel validation layout (field + animated profile-vs-exact + centerline development), PIL composite + header**
- **fix(pump hypre): enforce the single pin into the ASSEMBLED DDT matrix (d_valuesDDT), not just the K-path d_valuesPre. ROOT CAUSE of phi=0: the pin row was only applied to d_valuesPre (K-path), so the assembled DDT operator s.AddT stayed SINGULAR (pure-Neumann pump pressure has a constant null mode). BoomerAMG/FlexGMRES on a singular operator returned the null-space solution = 0 -> 'converged in 2 iters', x=0, phi=0 (proven by MARS_SOLVE_TRACE: pressure solve converged=1 iters=2 |xVec|max=0 while velocity solves gave real nonzero x). FIX: enforcePinRowKeepDiagKernel on d_rowPtrDDT/d_colIndDDT/d_valuesDDT too (keepDiag = AMG-friendly). Single pin is the correct null-space removal for the pure-Neumann pump (matches the reference's 'single pressure reference')**
- **fix(pump hypre): accept a best-effort pressure solve (rel-res < MARS_HYPRE_ACCEPT_RES, default 1e-2) instead of requiring final_res<1e-8. Diagnosis via MARS_SOLVE_TRACE+Jacobi: FlexGMRES+Jacobi runs full 2000 iters and produces a NONZERO xVec (1930, growing) but stalls at res~7e-3 -> the strict converged gate rejected it -> not scattered -> phi=0 -> dead. A projection step does not need machine-precision phi; a partial solve removes most divergence. Now accept it. (AMG still falsely converges at x=0 on this near-singular op -- separate, retune next; Jacobi is the working floor)**
- **poiseuille tutorial: starter-level Part 2 (equations, parabola derivation, CVFEM discretization, projection, solvers) + output-files table**
- **pump hypre: make BoomerAMG actually converge (fix the x=0 false convergence). Root cause: (1) the pump single-pin set the pinned DDT row diagonal to 1.0 (10-25x the native ~0.04-0.14), a documented PMIS-coarsening killer -> AMG V-cycle collapses onto the constant null mode -> FlexGMRES exits at 2 iters with x=0; (2) weak AMG settings (l1-Jacobi relax, strong=0.5, aggressive coarsening) for a 3D near-singular Poisson. FIXES: symmetric pin in the assembled DDT (zero row AND column, restore NATIVE diagonal via read/setRowDiagonalKernel -> no spike); AMG retune relax 18->8 (l1 hybrid SSOR), strong 0.5->0.25 (3D), agg 1->0, all env-overridable (MARS_AMG_*); GMRES min-iter floor + optional abstol; null-mode guard (reject converged-but-x=0). Best-effort acceptance now rejects null x**
- **pump hypre: harden the acceptance against the 1e7-phi blowup (multi-agent verification confirmed: cause = convergence/conditioning + loose accept gate admitting under-resolved huge phi; sign correct, removeMean NOT needed/refuted). (BUG2) upper-bound x reject in the Hypre wrapper: reject converged-but-|x|>>|b| (MARS_HYPRE_MAXX_RATIO default 1e6) -- the null-guard only caught x~0, not the observed x=huge. (accept) tighten default MARS_HYPRE_ACCEPT_RES 1e-2 -> 1e-6 so a res~2e-4 partial solve is rejected (phi stays warm-started) instead of scattering garbage. (BUG3) fix misleading 'opening-flux on by default' comments (it is OFF). Path to bounded solve: --pspg (AMG-friendly operator) + retuned BoomerAMG + these guards**
- **fix(pump hypre): BoomerAMG RelaxType 8 -> 18 (l1-Jacobi) -- the cause of AMG returning x=0 with a garbage 1.1e-315 residual. The retune to RelaxType=8 (l1-hybrid-SSOR, GS-family) is NOT GPU-functional: the cuda Hypre build does not implement GS-family smoothers as a real sweep (they no-op / go non-symmetric on GPU), so the V-cycle does nothing -> x=0 on the first cycle. The WORKING PCG wrapper (mars_hypre_pcg_solver.hpp:362-373) uses 18 for exactly this reason ('default GS becomes non-symmetric on GPU'), not merely PCG symmetry -- the GMRES comment misread that. l1-Jacobi-AMG-FlexGMRES is the standard GPU pressure solver. Verified pin/PSPG order is correct (pin enforced after PSPG). Testable via MARS_AMG_RELAX=18 (now the default)**
- **pump hypre: complete the AMG fix -- (1) NumSweeps 1->2 (l1-Jacobi is weaker than SSOR; 2 sweeps restore the smoothing strength). (2) Route the --pspg DDT pressure solve to Hypre PCG instead of GMRES: PSPG's tau*L makes A = D M^-1 D^T + tau*L SPD and the symmetric pin removes the null mode, so CG+AMG (the textbook pressure-Poisson solver, what deal.II/MFEM/Nalu use) is valid and more stable than FlexGMRES. Gated on s.usePSPG -> PCG; pure-DDT SPSD stays GMRES (Hypre PCG rejects SPSD with error 1). The PCG wrapper already uses GPU-safe RelaxType=18. MARS_HYPRE_KRYLOV still overrides for debug. Combined with the RelaxType 8->18 fix, this should give a converging bounded AMG pressure solve**
- **TGV: MARS_PRED_PERSLOT_GRADP toggle -- match predictor grad(p) seam reduction to corrector (Fable wdxg6s3ce: predictor folds, corrector per-slot -> dt-independent feedback gain 1.17)**
- **revert(pump hypre): route pressure back to FlexGMRES (not PCG). Routing --pspg to PCG was a regression: the PCG wrapper has NEITHER the null-mode guard NOR the upper-bound-x reject (only the GMRES wrapper does), so a converged-but-huge phi (PCG 'converged' in 14 iters at |phi|=1e123 on the still-ill-conditioned operator) was scattered -> corrector blew up -> inf predictor -> velocity Hypre-PCG errors downstream. GMRES carries the guards that keep it bounded. The RelaxType=18 fix (AMG now functional) stays. PCG can return once its wrapper has the same guards**
- **TGV: MARS_TGV_NONINCREMENTAL toggle (Fable fallback #3 -- p=phi non-incremental, severs pressure-accumulation feedback, loop gain exactly 0)**
- **pump hypre: PCG+AMG is the working --pspg path (port the guards). EMPIRICAL: on our GPU, PCG+BoomerAMG CONVERGES (16 iters, flow develops steps 1-3, div drops) while GMRES+AMG no-ops to x=0 (separate GMRES-wrapper GPU bug, debug later). PSPG makes the operator SPD + the pin removes the null mode, so CG+AMG is valid + textbook. Ported the null-mode + upper-bound-x guards (+ getEnvDouble, lastSolutionMax_, nullSolutionReturned_, accessors) from the GMRES wrapper to the PCG wrapper so a huge/near-null phi is rejected not scattered. Re-route --pspg pressure to PCG (PSPG off stays GMRES for SPSD). solveOneComponent picks up the guard via the solve() return**
- **pump hypre: GMRES+AMG is the pressure path (per the reference: GMRES + AMG-preconditioner). (1) Route --pspg pressure to GMRES, not PCG: GMRES tolerates the assembled DDT+tau*L operator's near-indefiniteness (tiny passage-cell diagonals) where PCG breaks down (pAp<0, HYPRE error 256). (2) Default to PLAIN GMRES (HYPRE_GMRESSetPrecond), not FlexGMRES: a 1-V-cycle AMG is a FIXED linear op so plain GMRES is valid AND is the battle-tested GPU path; FlexGMRES's precond-apply appeared to no-op on our GPU build (x=0, denormal residual). MARS_HYPRE_FLEXGMRES=1 / MARS_HYPRE_KRYLOV=pcg still available. All prior work kept (assembled DDT, PSPG-CSR, guards on both wrappers, symmetric pin, velocity-on-CG, RelaxType=18)**
- **TGV: MARS_TGV_USTART_BCAST toggle -- force start-of-step u broadcast on reduced path so skew advection mdot is seam-consistent (secondary loop is advective: --skew=0 bounds it, --skew=1 doesn't)**
- **pump hypre: pin tiny-diagonal rows of the ASSEMBLED DDT operator (the REAL fix for the 1e6 phi). DIAGNOSIS via plain GMRES+AMG: AMG now CONVERGES tight (40 iters, final_res=8e-9) -- FlexGMRES was the no-op -- but the CONVERGED solution is |phi|~1e6*|b| because the degenerate passage/sliver cells give the operator near-zero diagonals -> near-zero eigenvalues -> A^-1 amplifies ~1e6 -> physically-huge phi -> blowup feedback (b grows with div). FIX: pinTinyDiagonalRowsKernel makes every owned row with diag < MARS_DDT_ASM_PIN_FRAC*max_diag (default 1e-4) an identity row + marks it in d_isPressureBdryDof (RHS zeroed there) -> removes the near-zero eigenvalues so phi is physical. Runs on the assembled matrix before the s.AddT wrap, Hypre-path only. This is the assembled analogue of the matrix-free sliver-pin, reading the ACTUAL assembled diagonal**
- **docs: TGV breakthrough -- primary feedback loop (predictor/corrector grad(p) seam mismatch) FIXED via MARS_PRED_PERSLOT_GRADP; secondary loop localized to skew advection mdot at periodic seam. Baseline step-40 blowup -> step-160. Flags stay opt-in until secondary loop fixed.**
- **TGV: MARS_PRED_PERSLOT_ADV toggle -- make predictor advN per-slot to match per-slot grad(p) (predictor RHS seam-consistency; secondary loop is the advN-folded/gradP-perslot mismatch)**
- **pump hypre: use the GALERKIN LAPLACIAN K (s.Apre), not the Gram form D M^-1 D^T (s.AddT), for the assembled pressure solve -- THE STRUCTURAL FIX. Verified (agent + scaling argument): the DDT diagonal 0.25*|sum sigma_g A_g|^2/V is a square of a CANCELLING signed area-vector sum -> near-zero on GOOD cells (a real sliver gives a HUGE diagonal here, not tiny) -> near-zero eigenvalues -> 1e6 phi amplification -> blowup. Collaborator was RIGHT: no bad mesh cells; it's our Gram construction. The Galerkin K_ij=integral grad N_i.grad N_j has diagonal ~h (sum of squares, no cancellation) -> well-conditioned, AMG-friendly, no near-zero eigenvalue -- and is what the reference assembles. K is SPD so default to PCG+AMG (textbook pressure solver, now valid). MARS_HYPRE_USE_DDT=1 reverts to DDT+GMRES for comparison. Corrector stays M^-1 D^T (div relaxes, acceptable). All prior infra kept**
- **pump hypre: use GMRES (not PCG) for the Galerkin K pressure solve too. K (Apre) is SPD in principle but PCG broke down (pAp<0, HYPRE error 256, ~3 iters) -- BoomerAMG-as-preconditioner is non-symmetric on GPU (GS-family relax) + the pin-row diag=1 spike disturbs coarsening, so the preconditioned operator isn't SPD for CG. GMRES tolerates it (the proven-converging path). RESULT of the K switch: |phi| dropped from 1e6 to ~6000-30000 -- the Galerkin operator IS far better conditioned than DDT (no near-zero eigenvalue), confirming the artifact diagnosis. MARS_HYPRE_KRYLOV=pcg to force CG**
- **TGV: per-slot grad(p) divides by per-slot half-CV mass (d_massNodePerSlot), not merged (workflow w7bapvkdt: per-slot numerator/merged mass = half gradient = the residual factor-of-2 keeping feedback gain >1)**
- **Revert "TGV: per-slot grad(p) divides by per-slot half-CV mass (d_massNodePerSlot), not merged (workflow w7bapvkdt: per-slot numerator/merged mass = half gradient = the residual factor-of-2 keeping feedback gain >1)"**
- **pump: --pressure-k flag = the reference collocated Galerkin setup (the K-path fix). Solves the well-conditioned Galerkin stiffness K (s.Apre, AMG-able, physical phi) AND corrects with the CONJUGATE SCS Green-Gauss gradient (useLegacyGradient=true -> useDivT=false) -- the pairing that makes the K projection consistent. The old 'nearly orthogonal' K-failure was K solved but corrected with D^T (the gradient conjugate to DDT, not K). Pair with --vms-stab (divergence-side checkerboard stabilization, keeps K clean) + --solver=hypre -> the trifecta: well-conditioned + checkerboard-stable + projection-consistent, exactly what the reference does. DDT stays the default (no flag = byte-identical). Workflow-verified high-confidence**
- **fix(pump K-path): use GMRES for the Hypre K pressure solve. The PressureSolveKind::K branch called solveOneComponent with the default KrylovHint (PCG); under --solver=hypre that routes to Hypre PCG, which false-converges in ~2 iters (cg_p=2) on this operator (BoomerAMG non-symmetric on GPU + pin spike) -> garbage phi -> the (now conjugate) corrector amplifies it -> blowup. Pass KrylovHint::GMRES when solverKind==Hypre, matching the DDT branch (cg_p=33-60, converges). This was why --pressure-k --vms-stab blew up despite all 3 fixes being active: the K solve never actually solved**
- **pump: FEM-consistent weak div/grad projection (--pressure-k v2). The SCS divergence/gradient pair has cancellation null modes (the verified artifact), so part of the divergence is INVISIBLE to the correction -> accumulates ~1.2x/step -> blowup ~step 15 regardless of solver (falsified pairings: DDT+D^T exact but 1e6 phi; K+D^T leaks; K+SCS-grad 44x/step). FIX: standard P1 weak-form pair, matched to K -- divergence b_i=-(V/4)dNdx_i.sum(u_j) per element (boundary term = existing opening-flux source), corrector gradient = mass-normalized (V/4)-weighted element-gradient average (the exact adjoint). D_fem M^-1 D_fem^T is a no-cancellation Gram form spectrally equivalent to K -> per-step divergence removal is a contraction on ALL modes. Numerically verified (host replica): exact weak integrals, +grad sign, adjointness. Predictor grad(p^n) switched too. K+Hypre GMRES solve unchanged. New mars_fem_projection.hpp; gated useFemProjection; no flag = byte-identical**
- **pump: consistent P1 face-quadrature opening flux for the FEM projection (the destabilizer fix). DISCRIMINATOR: source OFF -> first STABLE run (phi 219->51 decaying, u bounded, div falling); source ON -> geometric blowup from step 1. The weak form requires oint(N_i u.n) as a consistent face integral; the lumped per-node source (u_i.areaVec_i, global dir) mismatches it node-by-node (rim + per-node-normal curvature) -> fixed-location spurious mass source -> hot spot. FIX: host-side setup weights w_i = (1/12)(2u_i+u_j+u_k).A_f over the side-set triangles using the velocity the BC ACTUALLY imposes per node, uploaded once (d_femFluxWin/Wout); per step divAcc += ramp*w_in + oScale*w_out (net=0 machine-exact, same ramp/oScale algebra). Gated useFemProjection; lumped path untouched otherwise. Verified: exact integral, signs, balance, uniform-velocity == lumped**
- **poiseuille multirank: fix DDT pressure solve across the streamwise rank seam. Three matrix-free fixes (column-zero for SPD, per-iter ghost exchange of p, Jacobi diagonal built matrix-free with reverse-halo fold) + route inlet BCs through the pump path (built inside setup, rank-consistent). 4-rank pressure CG now converges (was non-SPD/diverging). Single-rank byte-identical.**
- **pump: PISO inner pressure corrections (--correctors=N, FEM-projection path). Measured defect: one K-solve contracts the weak divergence only ~0.5-0.6x (K vs the D_fem M^-1 D_fem^T Gram spectral gap), so the un-removed residual + the re-presented boundary flux compound ~1.2-1.3x/step -> blowup ~step 12. FIX: iterate div->solve->correct on the CURRENT velocity iterate within the step; the interior divergence progressively cancels the (constant) boundary source so the SUM shrinks ~0.5x/pass (2-3 passes -> ~10-25% leftover -> contraction). runPressureSolveStep takes optional velocity-iterate ptrs (default u**); computeGradPhi/runCorrector extracted to lambdas, phiTotal accumulated + published so p+=phi and predictor grad(p^n) see the full increment. Honest [fem-div k=..] residual print (the SCS [CORR] div_max mismeasures the FEM path). N=1 byte-identical. gated useFemProjection+TetTag. NOT YET COMPILED**
- **pump: assemble the FEM-Gram pressure operator A_fem = D_fem M^-1 D_fem^T (the EXACT conjugate of the FEM div/grad corrector). Root cause of the un-removable divergence (flat PISO): K != D_fem M^-1 D_fem^T, so solving K leaves a residual the FEM corrector cannot project out. A_fem is the operator the projection identity requires: solve A_fem phi = (rho/dt) D_fem u**, correct u^{n+1}=u**-(dt/rho)M^-1 D_fem^T phi -> D_fem u^{n+1}=0 EXACTLY in one pass (host replica: div 0.173 -> 2.4e-16). Built from the FEM stencil a_i=-(V/4)dNdx_i (NOT SCS area-vectors -> NO cancellation, healthy SPD diagonal ~K/valence, AMG-friendly -- unlike the abandoned SCS DDT). Node-driven assembly factored as sum_i (1/M_i)(S_a.S_b), reuses buildDDTSparsityTet (same two-hop pattern), symmetric pin, wrapped s.AFemGram, solved with Hypre GMRES instead of s.Apre when useFemProjection. [FemGram-health] diag print. Gated; no flag byte-identical. NOT YET COMPILED**
- **pump --pressure-k: solve K + SCS Green-Gauss corrector + rely on --vms-stab (the reference collocated method). PROVEN this session: exact projection is impossible with a well-conditioned operator -- ANY conjugate D M^-1 D^T Gram form (SCS or FEM-Gram) has near-zero interior diagonals because sum_e grad N_a = 0 on a closed 1-ring (divergence theorem); FEM-Gram failed identically to SCS (diag 0.00, |x|=2.3e6, guard-rejected; host 2-tet replica missed it -- no closed-ring node). The reference does NOT drive div=0; it solves the well-conditioned K and stabilizes the residual divergence (--vms-stab). So --pressure-k now = K + useLegacyGradient=true (SCS corrector, K-consistent) + useFemProjection=false (FEM-Gram off). Pair with --vms-stab + --solver=hypre. FEM-Gram/projection kernels kept in tree (gated off) but no longer used by --pressure-k**
- **pump: scale-aware [FemGram-health] diagnostic. The old print flagged diag range [0.00, 0.02] as a fault, but A_fem = D_gal M^-1 D_gal^T is a Gram-Laplacian that correctly scales O(h) in 3D -- 0.02 IS healthy on a fine mesh, not near-zero. Host replica (closed-ring interior node, octahedron) verified: the kernel computes the correct operator to machine precision (brute-force D M^-1 D^T == factored form, diff 0); A_fem[0][0]=h exactly; one correction drops weak div 1e-1 -> 3e-17. The self-term (j==a) IS the cancelling closed-ring sum (~0) but the off-intermediate neighbor terms keep the diagonal positive O(h). New invariants: minDiag/sum|offdiag| (~1 healthy, <<1 = SCS collapse) + max|rowsum|/diag (~0 = constant null mode). Route A (FEM-Gram, --pressure-k) is structurally CORRECT; the earlier blowup was NOT the operator**
- **fix(pump): --pressure-k = Route A (FEM-Gram), the VERIFIED-correct config -- not the proven-bad K+SCS. Host replica proved A_fem = D_gal M^-1 D_gal^T is the correct SPD operator (assembly==brute-force diff 0; one correction drops div 1e-1->3e-17; the [0.00] diagonal was a MISREAD of the healthy O(h) scale). K+SCS gradient AMPLIFIES divergence 100x (25.9->2637, measured) -- that mix is what blew up. Now --pressure-k sets useFemProjection=true -> solver routes to s.AFemGram (GMRES+AMG) + FEM corrector gradient. Consistent weak-Galerkin family throughout**
- **fix(pump): silent neighbor-cap overflow made A_fem near-singular on the real mesh (the actual bug -- NOT the mesh). On the production tet mesh, high-valence interior nodes (40-70+, tets are high-valence) exceeded the hardcoded 48-neighbor caps in buildDDTSparsityTet + assembleFemGramPerNodeKernelTet, which SILENTLY DROPPED couplings -> A_fem rows lost off-diagonals -> near-singular (minDiag/sum|offdiag|=0.02) -> Hypre converges to |x|=2.3e6 for |b|=1.7 (eigenvalue ~1e-6) -> guard-rejects -> phi=0 -> blowup. Host replica (small clean patches, low valence) never hit it. FIX: (1) restructured assembleFemGramPerNodeKernelTet to scatter-direct into the CSR via atomicAddSparseEntry (element-pair double sum, math bit-identical to the verified Sum_i(1/M_i)S_a.S_b) -- NO partner buffer, cannot overflow at any valence, no register pressure; setup-only so the O(m^2) atomics cost nothing. (2) sparsity cap 48->96 (shared macro MARS_DDT_TET_MAX_OTHERS, single source of truth) + overflow COUNTER that prints [FemGram-assembly] N nodes exceeded cap (max valence) -- never silent again. Expect minDiag/sum|offdiag|~1, physical phi, div_max drops**
- **poiseuille: strip failed fork-local multirank seam attempts (ghost-row fold, promoted-ownership assembly, debug probes); keep the working pressure-solve seam fixes + --bdf1. Velocity multirank seam needs element-halo widening in domain.cu (proven: off-rank stiffness lives in elements this rank lacks; not foldable).**
- **pump: symmetric Jacobi scaling of A_fem so AMG solves it on the BIG mesh. A/B PROVED the method works (small mesh: minDiag/sum|offdiag|=0.07, phi physical 74, div_max contracts 9->5, flow develops) but the BIG mesh is near-singular (minDiag=0.02, |x|=2.3e6 for |b|=1.7, accepting it -> div 7->22->161->29869 blowup). The near-zero eigenvalue is from the lumped mass M^-1 spanning a wider range on the bigger non-uniform (but VALID, production-run) mesh -- pure operator conditioning. FIX (textbook for variable-mass B M^-1 B^T): solve A_hat y = b_hat, A_hat = D^-1/2 A_fem D^-1/2 (unit diagonal), recover x = D^-1/2 y (solution identical, just AMG-conditionable). Scale CSR in place at setup (col factor via dofToNode + halo for ghosts), scale b / unscale x per solve, gated useFemGramSolve, MARS_FEMGRAM_NOSCALE for A/B. Expect big-mesh minDiag~1, physical phi, div_max contracts like small. NOT YET COMPILED**
- **docs: confirm secondary loop = skew advection KE injection at non-solenoidal seam (hand-derived energy identity mdot*(qR^2-qL^2))**
- **TGV: MARS_TGV_EMAC -- energy-stable advection correction (advN -= q*div(u)) for non-solenoidal periodic seam; cancels the skew KE-injection (hand-derived residual mdot*(qR^2-qL^2)) without touching u or mass**
- **TGV EMAC: tunable coefficient MARS_TGV_EMAC_C (default -1) to sweep the q*div correction sign/magnitude empirically**
- **pump: --pressure-k default = K-solve + FEM weak gradient (drop the AMG-hostile Gram operator)**
- **docs: node-EMAC negative result; real fix is per-face mdot reconcile at periodic seam (skew is per-element energy-conserving; leak is cross-element mdot mismatch at the shared periodic face)**
- **TGV: MARS_TGV_SEAM_UPWIND -- seam-localized upwind dissipation for the periodic advective loop. PROVEN: per-face energy-zero impossible for conservative flux (production F*(qR-qL)); skew needs div u=0 to telescope; reduced projection leaves per-slot seam div by design -> must dissipate. Surgical upwind blend at seam faces only (derived coeff 0.5a|mdot|(qL-qR), production -0.5a|mdot|(qL-qR)^2<=0). --skew=0 (result 9) proves it bounds; this localizes it.**
- **docs: CORE WALL identified -- reduced periodic projection leaves per-slot seam divergence by design (proven: upwind delays but cannot cure -> continuous div source). NOT advection/corrector/feedback. Same 'boundary-complete divergence' open item as wing/pump. Feedback loops fixed (step40->190). Next = projection completeness, not more correction terms.**
- **docs: final handoff -- most promising untested fix is fold+broadcast CORRECTOR gradPhi (single-rank does this and is clean; differs from result-7 u-broadcast). Plus DOF over-collapse + per-slot residual r_M=-r_S leads. Core wall = projection leaves per-slot seam div.**
- **pump: AMG-on-K preconditioned solve of the Gram operator A_fem (Schur fix)**
- **pump: scale K by A_fem's D^-1/2 for the Schur preconditioner (the consistent fix)**
- **pump: stabilized-K pressure path -- add PSPG tau*L into K (the production method)**
- **pump: GMRES for both Hypre pressure paths (fixes cg_p=3 PCG false-convergence)**
- **pump: ramp the FIX-B pressure head (--pump-dp) with --source-ramp-steps**
- **pump: open-face momentum closure for FIX-B (fixes the advection detonation)**
- **multirank velocity solve: force Jacobi preconditioner diagonal positive (|diag|) so rho=(r,z)>0 -- seam DOFs had negative assembled diagonal, breaking CG conjugacy. Plus domain.hpp halo-factor knob (MARS_HALO_FACTOR, default 1.0) and MARS_NS_DEBUG_STEPS/MARS_CG_TRACE diagnostics. Channel multirank velocity operator still asymmetric at seam (pAp<0) -- next.**
- **pump: cap dt by the pressure-gradient kick too (fixes the head-ramp blowup)**
- **pump: MARS_NS_DEBUG_STEPS env to extend the [ns-dbg] window (watch late-step transitions)**
- **pump: clamp open-face grad(p)/grad(phi) in the predictor+corrector (closes the head-runaway)**
- **render: --side-set-io marks inlet/outlet from the side_set_id field (reliable, not the flow auto-detect)**
- **pump: FIX-B #3 open-face normal-velocity projection (--open-normal-proj)**
- **pump: FIX-B #2 dynamic-head inlet target (--total-pressure, totalPressure BC)**
- **pump: FIX-B #1 flux-consistent pressure BC (--flux-pressure-bc, closes the high-head div-creep)**
- **pump: exempt --flux-pressure-bc from the do-nothing-outlet source guard (the bug that no-op'd #1)**
- **docs: update pump tutorial to the implemented solver + add private deep-dive**
- **docs: privatize pump tutorial (move to gitignored internal-notes/ + correct stale DDT->K+tauL pressure path)**
- **docs: remove pump_cfd_tutorial nav entry + inbound links (NDA hazard + broken publish)**
- **docs: fix fabricated APIs, stale clone URLs, kernel list, multi-rank honesty**
- **channel: add [vel-pap-probe] single consistent-p pAp=(u,Au) diagnostic**
- **docs: use 'summation by parts' for the SCS flux-cancellation property**
- **coupled solver Phase 0: GPU model operator + thin-3D mesh gen, validated vs Erturk-Dursun**
- **coupled solver Phase 1: opt-in point-block BoomerAMG + GPU iter study (existential YES, smoother ceiling)**
- **ACM host Stages 0-2: Galerkin gate + V-cycle faithfulness + decisive stretched-mesh GO (directional beats smoothed-SA on anisotropic meshes)**
- **ACM Stage 3: GPU coarse-operator (sum-of-fine == P^T A P) + injection/restrict transfers, validated on H100 (4 gates exact, n16/32/64)**
- **ACM Stage 4a: GPU multilevel V-cycle (SpMV + point-Jacobi + sum-of-fine hierarchy), validated vs host replica to round-off (n16/32/64)**
- **ACM Stage 4b: native FlexGMRES (Z-basis) + pluggable Preconditioner + GpuAcmPreconditioner; single-rank ACM solver converges coupled saddle system on H100 (Z-basis exact, ACM-FlexGMRES 54/106/97 matches QR ref)**
- **ACM Stage 5: directional (Mavriplis) aggregation + direct QR coarsest + mesh-agnostic --acm-pump + MARS_QUIET_MESH gating (directional 3.4x over isotropic on real anisotropic mesh, converges where BoomerAMG fails)**
- **Rhie-Chow coupled operator: host Stage-0 algebra gate (a^pp M-matrix Laplacian, G=-D^T via a^up=-(a^pu)^T, tet non-orthogonality => deferred smooth-grad mandatory)**
- **Rhie-Chow coupled operator on GPU (--rhie-chow): FV a^pu/a^up=-(a^pu)^T + RC a^pp d_f-Laplacian (no tau), validated on H100 (G=-D^T, a^pp M-matrix); + coupled 4x4 block-Jacobi smoother + per-component pressure pinning**
- **Rhie-Chow operator -> ACM solve (--rhie-chow --acm-pump): converges large pump (197 iters, res 9e-9) where PSPG stalled (res 0.96); ACM beats BoomerAMG (still fails on RC operator)**
- **Rhie-Chow coupled NS matches Erturk-Dursun cavity (Re=100 b45): max|err|=1.24% (PSPG 1.8%), compact-only -- RC operator accurate, deferred smooth-grad not needed at this accuracy**
- **host replica: open-channel Poiseuille validates the boundary-flux continuity fix (interior-only a^pu collapses flow + wrong-sign dp; +rho*S_bnd.u restores dp->exact 0.48 + propagation, interior transpose exact); channel mesh gen subcommand**
- **Rhie-Chow open-boundary continuity flux (mars_boundary_area.hpp): per-node median-dual S_bnd added to continuity rows -> velocity-flux inlet + open outlet. Channel/Poiseuille on H100: dp=0.471 vs 0.480 (1.8%), flow propagates, gates clean (interior transpose 4e-19, sum(D.const) 1e-17). --channel test path. Fixes the open-flow collapse (was dp=-0.62)**
- **Velocity-flux inlet + open outlet via Exodus side-sets (--inlet-ss/--outlet-ss, --acm-pump): RC operator + ACM-FlexGMRES mass-conserving through-flow on the pump (massErr 1.95%, Qin=-Qout, 46 iters res 9e-9, |u|max~6x inlet). Pin pressure at the OUTLET (arbitrary union-find pin acted as a spurious mass sink under a flux inlet). Shared buildSideSetVelBC for --solve + --acm-pump**
- **NDA-safe stdout by default: invert MARS_QUIET_MESH -> MARS_VERBOSE_MESH (opt-in). Default now suppresses all mesh-identifying prints (path, name, node/elem counts, bbox, side-set names+counts, inlet/outlet node counts+normal, fluid component count). Solver gates/metrics still print.**
- **acm-pump: print explicit mode line (through-flow vs closed-box) so a silently-empty --inlet-ss= (unset env var) no longer falls back to closed-box without warning**
- **acm-pump through-flow: localize the |u| spike (hot-node count, boundary-vs-interior, max-location under verbose) + flag spurious spikes (>50x inlet) as CHECK -- large pump converges + mass-conserves but |u|max=610 (1220x inlet) signals a degenerate-tet/scaling artifact to diagnose**
- **High-order matrix-free CVFEM (Knaus Alg 2) + GPU port + p-sweep comparison + convergence + multi-rank weak-scaling/overlap on GH200**
- **acm-pump pump validation: drop the bogus velocity-cap CHECK -- this pump physically reaches ~430 m/s at its narrowest path (collaborator ref + ParaView 0.03-420), so |u|max=610 is real flow, not a spike. PASS now = ACM converged + inflow sign + mass conserved; |u|max reported as info. Also keeps the authoritative side-set inlet fix.**
- **acm-pump: Picard outer loop with frozen-velocity convection (re-assemble momentum + ACM re-solve each iter) + --nu flag for dimensional viscosity. Confirmed on the pump: d(u) drops ~10x/iter, converges in 7 iters, mass conserved, ACM ~46 iters/iter. Stokes->NS path for the convective regime (SUPG next for high Re)**
- **host SUPG validation (supg_1d_test.py): 1D convection-diffusion confirms the tau + streamline-diffusion algebra -- Galerkin oscillates (min u -> -0.93) above element-Pe 1, SUPG smooth (min u ~0) with bounded, decreasing error. Validates the GPU momentum-SUPG terms before implementation**
- **GPU SUPG momentum stabilization (--supg: in-kernel tau + a^uu streamline diffusion + a^up cross-term, transpose gate scoped) + Picard under-relaxation (--relax) + --nu dimensional flag. SUPG validated: 1D host kills the oscillation, cavity Re=100 matches Erturk-Dursun 1.62%. Under-relax fixes the high-Re Picard limit-cycle; exposes the ACM-smoother-on-convection bottleneck**
- **host ILU(0)-vs-Jacobi smoother study: confirms ILU(0) is the convective smoother -- smoothing factor mu falls 0.16->0.002 with Pe while damped-Jacobi climbs 0.33->0.65 (the high-Re V-cycle stall). Gates the GPU block-ILU0 build**
- **GPU block-ILU(0) ACM smoother (MARS_ACM_SMOOTHER=ilu): level-scheduled block triangular solves replace damped-Jacobi for convection. Host-validated (ILU smoothing factor 0.16->0.002 vs Jacobi ->0.65 as Pe grows). Adversarial-verified: factorization exact to 1e-16; block pattern symmetrized so one lower-graph level schedule serves both L and U solves (robust to nonsymmetric convective stencils) + union-of-comp-rows + diagonal guard + ILU built only on smoothed levels. Default unchanged (block-Jacobi); host-match gate stays Jacobi-only**
- **model operator: std::cout unitbuf for live [phase0] trace (srun block-buffers \n output -> the picard trace + gates now appear as they run, not at exit)**
- **ACM frozen-preconditioner reuse (--acm-rebuild=K): rebuild the hierarchy every K Picard iters, reuse between -- the host block-ILU(0) factorization is heavy on the large pump so per-iter rebuild is impractical. Default K=1 (unchanged). Validated ILU works: picard 0 ACM iters=24 vs Jacobi 86, no 1980-cap**
- **acm-ilu: print nLev (level-schedule serial depth) per build -- diagnose the 8min/Picard V-cycle slowness at Re=1000. Large nLev => launch-bound level-scheduling, the case for multicolor reordering**
- **smoother study: multicolor ILU == DILU (multicoloring zeros within-color fill, ILU collapses to the diagonal recurrence), both ~3x weaker than natural-order at high Pe but still beat Jacobi -> the GPU smoother to build is multicolor block-DILU (= AMGX's)**
- **multicolor block-DILU smoother (MARS_ACM_SMOOTHER=dilu): greedy block-graph coloring + color-order block-diagonal DILU factorization (D_i=A_ii-sum_lowercolor A_ik invD_k A_ki) + color-by-color triangular solves -> 2*numColors launches/sweep vs ILU's 2*nLev=132558. = AMGX's MULTICOLOR_DILU. baseline; optimization pass next**
- **dilu: clarify z:=w comment (w stored by forward sweep, not recomputed -- the exact-by-construction shortcut). verify GO, no critical/major**
- **acm-pump: per-Picard solve timing (time=Xms + rebuild/reuse tag) -- separates host setup (rebuild iters) from FlexGMRES solve (reuse iters) to localize the DILU cost**
- **dilu: split setup vs solve timing (precond.getLastSetupMs). DILU reuse degrades catastrophically -- the weak smoother can't tolerate a stale hierarchy (reuse iters hit 1980-cap, res 1e-4), so DILU must rebuild every Picard like AMGX. Cheap (diagonal-only). Timing localizes rebuild=host-setup vs solve**
- **acm opt step 2: fuse residual (acmResidualKernel = b-Ax in one pass) -> -1 launch + -1 global round-trip per smoother sweep / restrict; removes dead acmSubKernel (acmSpmvKernel kept, used in driver). bit-identical. shrinks the V-cycle for the upcoming CUDA-graph capture**
- **acm opt step 0: stream-thread the V-cycle path (cudaStream_t s=0 default through smoothers/coarse/cycle, all <<<>>> on s) + refactor acmVcycleGpu recursive->iterative (explicit down/coarse/up). bit-identical (default stream); enables CUDA-graph capture by separating the halves around the non-capturable cusolver QR**
- **acm opt step 1: CUDA-graph the V-cycle. Split into capturable acmVcycleDownGpu/UpGpu halves (cudaMemsetAsync zero-fills); preconditioner captures each into a graph (capStream_, warmup+BeginCapture+InstantiateWithFlags), apply replays gDown->eager QR->gUp single-stream-serialized + cross-stream fences. DILU-only (swap-free); graceful eager fallback + sticky-error clear on any capture failure. verify GO (w69bixj2j). target V-cycle 26->~9ms**
- **acm opt step 4: GPU-side DILU value setup. acmDiluExtractKernel (scatter scalar CSR -> 4x4 bblk via device acmBlockSlot) + acmDiluFactorColorKernel (color-parallel block-diagonal factor D_i=A_ii-sum_lowercolor A_ik invD_k A_ki) replace the host extract+factor loops in acmBuildLevelDilu. Host keeps only structure (block-CSR pattern + coloring). Bit-identical to host (convergence-preserving), verify GO (wy6lacp8a). cuts the host-serial chunk of the 2.7s setup**
- **acm opt: factor-once dense-LU coarsest solve (GPU). cusolverDn getrf ONCE/Picard at setup (acmDenseFromCsrKernel scatters coarse CSR->dense col-major) + getrs per V-cycle (in-place RHS, stream-ordered, NO malloc/factor/sync) -- replaces the per-V-cycle cusolverSpDcsrlsvqr that re-factored + did ~47 cudaMallocs on the fixed 876-DOF op 35x/Picard (the profile's V-cycle bottleneck, ~21% GPU + the malloc/sync). Convergence-equivalent (same direct coarse solve). verify GO (w3w6nq9ii)**
- **Matrix-free CVFEM: halo truncation fix + --build-only DD to 108M elem/GPU (trillion-element decomposition)**
- **fgmres opt: batched CGS2 orthogonalization (the 57% sync cost). solveFlexible stores V contiguously (n x m+1 col-major) and replaces the per-iter j+1 host-synced MGS dots with 2-pass classical GS via cublas gemv (h=V^T w, w-=V h, x2 for stability) + ONE D2H of the coeff column -> ~2 syncs/iter not O(k). Convergence-equivalent to MGS (verify GO wtxgxb8f4, within +-1 iter). Standard solve() MGS path untouched (ex0/ex1)**
- **acm (B) stage 1 - GPU-native DILU structure (no host std::set/coloring): acmBuildBlockCsrGpu (symmetrized node block-CSR via emit edge+transpose+diag keys -> sort -> unique -> split, mirrors buildCoarseOperator) + acmColorBlockGraphGpu (Jones-Plassmann on the NODE block graph, not csrcolor). acmBuildLevelDilu now GPU-native, reads only the device CSR. Valid (different) coloring -> iters may shift +-a few. Aggregation still host (stage 2 = GPU agg + drop the D2H). verify+validate at end of (B)**
- **acm (B) stage 2 - GPU-native aggregation + device-only DILU loop (no host work): acmAggregateGpu (block-Frobenius strength + race-free heavy-edge matching [mutual-strongest pairs seed, atomicAdd -> contiguous ids] + 2-kernel leftover-absorb + singletons) replaces host acmDirectionalAggregate on the DILU path; acmBuildHierarchy DILU branch fully device (no std::set, no host-CSR D2H). verify GO after C1 fwd-decl (acmBlockSlot used by §1c before its def at :648) + thrust scan/unique includes + drop dead gE + color bitmask c<64. Aggregation CHANGES -> iters/levels shift (validate). ILU/Jacobi host path untouched**
- **acm aggregation 2nd matching pass (MARS_ACM_AGG_PASSES=2 default; =1 reverts): match pass-1 aggregates pairwise on a summed-strength aggregate graph (pairs->quads, ratio ~4, host-like directional) to fix the early-Picard iter spike from looser pass-1 coarsening. acmBuildAggGraphGpu (emit/sort/reduce_by_key/split) + reuse the match kernels on the aggregate graph + acmRelabelKernel (contiguous). verify GO (wbwcohnec)**
- **acm solve floor RANK1+2 - single-graph V-cycle on stream 0 (kills the 2 cudaStreamSynchronize host-latency floor): capturable acmCoarseTrsmKernel (custom fwd/back-sub, bit-equiv to cusolver getrs on the getrf factors) replaces cusolverDnDgetrs -> whole down->coarse->up captured as ONE gExec_, launched on stream 0 (same stream as FlexGMRES BLAS) -> apply() pure async, both syncs deleted. verify GO (we5j4nviz). Guards: coarseN_>maxCoarseND -> Jacobi fallback (no oversized trsm); skip capture if !coarseLUok_ (Jacobi host-swap not capturable). Dropped dead cusolverSp handle. Bit-equiv -> same iters, V-cycle ~18-28ms -> ~2ms target**
- **revert solve-floor RANK1+2 (a6cbabd): the custom trsm is NOT bit-equiv to cusolver getrs -- on the badly-scaled coarse op (diag~2e-11) the one-thread naive substitution loses precision, blew picard 3 to the 1980 cap (res 3.9e-5) where getrs converged in 201; AND the single graph gave NO speedup (~28-36ms/iter unchanged), so the 2 cudaStreamSynchronize were not the per-iter drain. Restore getrs+2-graph. Real drain is SpMV cudaMalloc/free (RANK3) + CGS2/norm D2H (RANK4) -- pin with nsys timeline before retrying**
- **distributed high-order matrix-free operator (multi-rank HO DOF + device-GPUDirect halo): A*1=1e-18 on 4 ranks p=2-4, apply weak-scales 98%**
- **acm V-cycle sweep knobs MARS_ACM_PRE/POST (default 2/1 unchanged): A/B the smoother sweep count in one binary -- the block-Jacobi smoother is 66% of the GPU-bound solve (cuda_gpu_kern_sum), so fewer sweeps trade smoother cost vs Krylov iters**
- **HO per-GPU ceiling 647M DOF/GPU (p=4, GH200) -> trillion HO DOF on ~1,550 GPUs (~390 nodes); fig_trillion + doc**
- **multirank Increment 1 (gate only, solve still 1-rank): adjointness G=-D^T gate made multi-rank-correct -- reverseExchangeNodeHaloAdd folds ghost-scattered div/grad to owners, owned-masked (getNodeOwnershipMap, globally-unique post-tiebreaker) dots + MPI_Allreduce; guard moved after the gate so it validates at N ranks while the coupled solve refuses >1 rank (operator+Krylov halo = Increment 2). verify GO (wybs09rex), 1-rank bit-preserved**
- **HO halo: key only boundary DOF (dofBoundary), not all numDof -- fixes host OOM at scale; validated 5.0B DOF / 8 GPU p=4 (A*1 1e-18, comm 4%)**
- **acm perf - host-cost removal (single-node, before multirank): DILU is now the DEFAULT smoother (acmUseDilu unset->dilu; block-Jacobi cannot surface silently); RANK2 = V-cycle replays on the NULL stream (same as FlexGMRES) so both cross-stream cudaStreamSynchronize/iter are DELETED (the host-latency floor); RANK3 = persistent cusparse SpMV buffer (no per-iter cudaMalloc/free). verify GO (wna5b3qqg). Stage-4a host-match gate forced to point-Jacobi (its host replica is point-Jacobi)**
- **sbatch scripts for overnight HO trillion ladder: 160B (64 nodes) + 640B->1e12 (400 nodes), p=4 ~625M DOF/GPU**
- **tutorial (beginner->expert) + talk-prep brief for the distributed HO matrix-free operator**
- **GPU-native HO DOF numbering: radix uint64 dedup (fixes merge_sort crash at scale); buildDistributedGpu 8s vs host 80s (~10x), bit-exact A*1=1e-18 @ 625M DOF/rank, 8 GPU**
- **HO matrix-free: bucketSize auto-scale (trillion Allreduce fix) + GPU numbering default; tutorial figs/refs**
- **matfree tutorial: high-order CVFEM motivation, GPU-numbering-is-default fix, 10x setup + sustained-TDOF/s numbers**
- **matfree tutorial: 640B-setup-validated blocker + honest 40B/1T scaling framing + arc polish**
- **matfree tutorial: reference-operator formula table + reference-vs-metric box + CEED/MFEM P/G/B/D mapping**
- **matfree tutorial: empirical regular+irregular ownership validation (verify bit-identical, A.1 1e-18)**
