### PR TITLE
cstone

### DIFF
--- a/examples/usage_from_external_cmake_project/CMakeLists.txt
+++ b/examples/usage_from_external_cmake_project/CMakeLists.txt
@@ -6,12 +6,12 @@ include(CMakeFindDependencyMacro)
 find_package(Mars 0 REQUIRED)
 
 
-# we use one of our examples here
-add_executable(mars_example ${CMAKE_SOURCE_DIR}/../mars_discretization.cpp)
+# self-contained smoke: compiles against installed headers + links Mars::mars
+add_executable(mars_example main.cpp)
 
 # import all the dependencies and targets
 target_link_libraries(mars_example PUBLIC Mars::mars)
 
 # If you want to test it
 enable_testing()
-add_test(NAME Mars.mars_example COMMAND mars_example ${CMAKE_SOURCE_DIR}/../data)
+add_test(NAME Mars.mars_example COMMAND mars_example)

--- a/examples/usage_from_external_cmake_project/main.cpp
+++ b/examples/usage_from_external_cmake_project/main.cpp
@@ -1,0 +1,14 @@
+// Downstream-consumer smoke test for an installed MARS.
+// Purpose: prove that an external CMake project can find_package(Mars), compile
+// against the installed headers, and link Mars::mars. It deliberately does no
+// real computation (no GPU, no MPI, no mesh) -- if this builds and links, the
+// installed package is consumable, which is all the install gate needs to check.
+#include <mars_config.hpp>
+
+#include <iostream>
+
+int main()
+{
+    std::cout << "MARS install smoke: find_package(Mars) + Mars::mars link OK\n";
+    return 0;
+}


### PR DESCRIPTION
- **track HO matfree + AMR-tet example drivers (fix fresh-clone build)**
- **KNOWN_LIMITATIONS: module status + kernel-variant guidance**
- **install self-test: self-contained Mars::mars link smoke**
