### PR TITLE
cstone

### DIFF
--- a/backend/distributed/unstructured/fem/mars_cvfem_kernel.hpp
+++ b/backend/distributed/unstructured/fem/mars_cvfem_kernel.hpp
@@ -50,6 +50,49 @@ struct Tet4CVFEM {
         eta = coords[scs_id][1];
         zeta = coords[scs_id][2];
     }
+
+    // Jacobian determinant + physical-space shape derivatives for a linear tet.
+    // J columns are the edge vectors from node 0 (dx/dxi); dNdx is constant over
+    // the element. det is signed (= 6*signed volume); callers take fabs for volume.
+    template<typename RealType>
+    __device__ __host__ static void
+    jacobian_and_dNdx(const RealType coords[4][3], RealType& det, RealType dNdx[4][3]) {
+        RealType J[3][3];
+        for (int i = 0; i < 3; ++i) {
+            J[i][0] = coords[1][i] - coords[0][i];
+            J[i][1] = coords[2][i] - coords[0][i];
+            J[i][2] = coords[3][i] - coords[0][i];
+        }
+        det = J[0][0]*(J[1][1]*J[2][2] - J[1][2]*J[2][1])
+            - J[0][1]*(J[1][0]*J[2][2] - J[1][2]*J[2][0])
+            + J[0][2]*(J[1][0]*J[2][1] - J[1][1]*J[2][0]);
+        const RealType inv = RealType(1) / det;
+        // J^-1 via adjugate/det.
+        RealType Ji[3][3];
+        Ji[0][0] =  (J[1][1]*J[2][2] - J[1][2]*J[2][1]) * inv;
+        Ji[0][1] = -(J[0][1]*J[2][2] - J[0][2]*J[2][1]) * inv;
+        Ji[0][2] =  (J[0][1]*J[1][2] - J[0][2]*J[1][1]) * inv;
+        Ji[1][0] = -(J[1][0]*J[2][2] - J[1][2]*J[2][0]) * inv;
+        Ji[1][1] =  (J[0][0]*J[2][2] - J[0][2]*J[2][0]) * inv;
+        Ji[1][2] = -(J[0][0]*J[1][2] - J[0][2]*J[1][0]) * inv;
+        Ji[2][0] =  (J[1][0]*J[2][1] - J[1][1]*J[2][0]) * inv;
+        Ji[2][1] = -(J[0][0]*J[2][1] - J[0][1]*J[2][0]) * inv;
+        Ji[2][2] =  (J[0][0]*J[1][1] - J[0][1]*J[1][0]) * inv;
+        // dN/dxi (constant linear tet): node0=(-1,-1,-1), nodes 1-3 = identity.
+        const RealType dNref[4][3] = {
+            {RealType(-1), RealType(-1), RealType(-1)},
+            {RealType(1),  RealType(0),  RealType(0)},
+            {RealType(0),  RealType(1),  RealType(0)},
+            {RealType(0),  RealType(0),  RealType(1)}
+        };
+        // dN/dx_i = sum_j (dN/dxi_j) * (J^-1)[j][i]
+        for (int n = 0; n < 4; ++n)
+            for (int i = 0; i < 3; ++i) {
+                RealType s = RealType(0);
+                for (int j = 0; j < 3; ++j) s += dNref[n][j] * Ji[j][i];
+                dNdx[n][i] = s;
+            }
+    }
 };
 
 // CUDA kernel for CVFEM assembly

--- a/backend/distributed/unstructured/fem/mars_cvfem_tet_assembler.hpp
+++ b/backend/distributed/unstructured/fem/mars_cvfem_tet_assembler.hpp
@@ -1,15 +1,17 @@
 #pragma once
 
 #include "mars_cvfem_tet_kernel_graph.hpp"
+#include "mars_cvfem_tet_kernel_full.hpp"
+#include "mars_cvfem_tet_kernel_full_perip.hpp"
 #include <cuda_runtime.h>
 
 namespace mars {
 namespace fem {
 
 // CVFEM assembler for linear tetrahedra. Counterpart to CvfemHexAssembler
-// in mars_cvfem_assembler.hpp. Only the graph-sparsity path is implemented
-// here; tet does not yet have the tensor/wmma/shmem variants the hex
-// assembler offers.
+// in mars_cvfem_assembler.hpp. Three paths exist: graph-lumped, full, and
+// full-perip (full with pre-looked-up CSR positions). The tensor/wmma/shmem
+// variants the hex assembler offers do not exist for tet.
 template<typename KeyType, typename RealType>
 class CvfemTetAssembler {
 public:
@@ -61,7 +63,97 @@ public:
                 d_matrix, d_rhs);
     }
 
-    static const char* variantName() { return "TetGraph"; }
+    // Full assembly: scatters the full 4x4 element matrix into a 16-NNZ
+    // sparsity pattern. No diagonal lumping. Required when the consumer
+    // needs every (i,j) pair (e.g. Poisson with CG, symmetric solvers).
+    static void assembleFull(
+        const KeyType* d_conn0,
+        const KeyType* d_conn1,
+        const KeyType* d_conn2,
+        const KeyType* d_conn3,
+        size_t numElements,
+        const RealType* d_x,
+        const RealType* d_y,
+        const RealType* d_z,
+        const RealType* d_gamma,
+        const RealType* d_phi,
+        const RealType* d_beta,
+        const RealType* d_grad_phi_x,
+        const RealType* d_grad_phi_y,
+        const RealType* d_grad_phi_z,
+        const RealType* d_mdot,
+        const int* d_node_to_dof,
+        const uint8_t* d_ownership,
+        CSRMatrix<RealType>* d_matrix,
+        RealType* d_rhs,
+        const Config& config = Config{})
+    {
+        int blockSize = config.blockSize;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+
+        cvfem_tet_assembly_kernel_full<KeyType, RealType>
+            <<<numBlocks, blockSize, 0, config.stream>>>(
+                d_conn0, d_conn1, d_conn2, d_conn3,
+                numElements,
+                d_x, d_y, d_z,
+                d_gamma, d_phi, d_beta,
+                d_grad_phi_x, d_grad_phi_y, d_grad_phi_z,
+                d_mdot,
+                d_node_to_dof, d_ownership,
+                d_matrix, d_rhs);
+    }
+
+    // Full perip: same math as assembleFull, but pre-looks-up the 16 CSR
+    // positions once per element and scatters via direct atomicAdd into
+    // values[pos]. Avoids the per-(i,j) findColumnIndex inside the hot loop.
+    // Uses __launch_bounds__(256, 4) to pack 4 blocks/SM. Recommended path
+    // for production runs; assembleFull stays as the simpler reference.
+    static void assembleFullPerip(
+        const KeyType* d_conn0,
+        const KeyType* d_conn1,
+        const KeyType* d_conn2,
+        const KeyType* d_conn3,
+        size_t numElements,
+        const RealType* d_x,
+        const RealType* d_y,
+        const RealType* d_z,
+        const RealType* d_gamma,
+        const RealType* d_phi,
+        const RealType* d_beta,
+        const RealType* d_grad_phi_x,
+        const RealType* d_grad_phi_y,
+        const RealType* d_grad_phi_z,
+        const RealType* d_mdot,
+        const int* d_node_to_dof,
+        const uint8_t* d_ownership,
+        CSRMatrix<RealType>* d_matrix,
+        RealType* d_rhs,
+        const Config& config = Config{})
+    {
+        int blockSize = config.blockSize;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+
+        cvfem_tet_assembly_kernel_full_perip<KeyType, RealType>
+            <<<numBlocks, blockSize, 0, config.stream>>>(
+                d_conn0, d_conn1, d_conn2, d_conn3,
+                numElements,
+                d_x, d_y, d_z,
+                d_gamma, d_phi, d_beta,
+                d_grad_phi_x, d_grad_phi_y, d_grad_phi_z,
+                d_mdot,
+                d_node_to_dof, d_ownership,
+                d_matrix, d_rhs);
+    }
+
+    enum class Variant { GraphLump, Full, FullPerip };
+    static const char* variantName(Variant v) {
+        switch (v) {
+            case Variant::GraphLump: return "TetGraphLump";
+            case Variant::Full:      return "TetFull";
+            case Variant::FullPerip: return "TetFullPerip";
+        }
+        return "TetUnknown";
+    }
 };
 
 } // namespace fem

--- a/backend/distributed/unstructured/fem/mars_fem_projection.hpp
+++ b/backend/distributed/unstructured/fem/mars_fem_projection.hpp
@@ -42,6 +42,22 @@
 // unqualified Tet4CVFEM / ElemTraits brought in by those usings. Do not
 // include it standalone.
 
+// One-shot diagnostic for the V<=0 guards below. Those guards SILENTLY skip any
+// tet with non-positive Jacobian determinant (inverted / bad node ordering).
+// Current meshes have none, but on a future refined/re-oriented mesh that silent
+// drop would give quietly wrong results. We count drops in a file-local device
+// counter and printf ONCE (on the first drop) so it surfaces as a warning instead
+// of vanishing. Zero cost on clean meshes: only runs inside the never-taken V<=0
+// branch. static -> internal linkage, one counter per translation unit.
+static __device__ unsigned long long g_invertedTetDropCount = 0;
+static __device__ void noteNonPositiveTetVol()
+{
+    if (atomicAdd(&g_invertedTetDropCount, 1ull) == 0)
+        printf("[mars] WARNING: FEM projection skipped a tet with non-positive "
+               "Jacobian det (inverted or bad node ordering) -- silently dropped; "
+               "current meshes expected clean. Check mesh node ordering.\n");
+}
+
 // Weak-form divergence volume term: one thread per element, atomicAdd scatter
 // to all 4 nodes (ghosts included; the caller's reverseExchangeNodeHaloAdd
 // folds ghost contributions to owners, exactly like the SCS divergence path).
@@ -73,7 +89,7 @@ __global__ void computeFemDivergenceTetKernel(
     RealType V = det / RealType(6);
     // Degenerate or inverted tet: dNdx ~ 1/det would poison the accumulator
     // with inf/NaN; skip rather than scatter garbage.
-    if (!(V > RealType(0))) return;
+    if (!(V > RealType(0))) { noteNonPositiveTetVol(); return; }
 
     // integral_e u = (V/4) * (u_0+u_1+u_2+u_3), exact for linear u.
     RealType usx = 0, usy = 0, usz = 0;
@@ -119,7 +135,7 @@ __global__ void computeFemGradientTetKernel(
     RealType det, dNdx[4][3];
     Tet4CVFEM::jacobian_and_dNdx<RealType>(coords, det, dNdx);
     RealType V = det / RealType(6);
-    if (!(V > RealType(0))) return;
+    if (!(V > RealType(0))) { noteNonPositiveTetVol(); return; }
 
     // constant element gradient of phi (linear tet)
     RealType gx = 0, gy = 0, gz = 0;
@@ -231,7 +247,7 @@ __global__ void assembleFemGramPerNodeKernelTet(
         RealType detE, dNdxE[NPE][3];
         Tet4CVFEM::jacobian_and_dNdx<RealType>(coordsE, detE, dNdxE);
         RealType VE = detE / RealType(6);
-        if (!(VE > RealType(0))) continue;
+        if (!(VE > RealType(0))) { noteNonPositiveTetVol(); continue; }
         RealType nqVE = -VE * RealType(0.25);   // -(V_e/4)
 
         // Inner loop over the second element f (also incident to i). a comes
@@ -266,7 +282,7 @@ __global__ void assembleFemGramPerNodeKernelTet(
                 RealType detF;
                 Tet4CVFEM::jacobian_and_dNdx<RealType>(coordsF, detF, dNdxFbuf);
                 RealType VF = detF / RealType(6);
-                if (!(VF > RealType(0))) continue;
+                if (!(VF > RealType(0))) { noteNonPositiveTetVol(); continue; }
                 nqVF  = -VF * RealType(0.25);   // -(V_f/4)
                 dNdxF = dNdxFbuf;
             }

--- a/backend/distributed/unstructured/fem/mars_ns_channel_solver.hpp
+++ b/backend/distributed/unstructured/fem/mars_ns_channel_solver.hpp
@@ -8112,7 +8112,13 @@ void runPressureSolveStep(NSStepper<KeyType, RealType, ElementTag>& s, RealType 
         }
         // Fresh warm-start: phi is per-step correction, not cumulative.
         cudaMemset(xVec.data(), 0, s.numTotalDofs * sizeof(RealType));
-        s.lastPressureIters = solveOneComponent<KeyType, RealType, ElementTag>(s, b, xVec, s.d_phi, s.Apre);
+        // Hypre PCG FALSE-CONVERGES on this pinned K operator (returns in ~0
+        // iters, phi~0 -> no correction -> the flow collapses and freezes). Use
+        // GMRES under Hypre, matching the pump's K path (same fix). PCG stays the
+        // default for the in-house (s.solverKind==CG) route, where K is SPD.
+        KrylovHint pk = (s.solverKind == SolverKind::Hypre) ? KrylovHint::GMRES
+                                                            : KrylovHint::PCG;
+        s.lastPressureIters = solveOneComponent<KeyType, RealType, ElementTag>(s, b, xVec, s.d_phi, s.Apre, pk);
     }
     else  // DDT: (D M^{-1} D^T) phi = -(rho/dt) D u**
     {

--- a/examples/distributed/unstructured/mars_cvfem_graph_tet.cu
+++ b/examples/distributed/unstructured/mars_cvfem_graph_tet.cu
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
     if (rank == 0) {
         std::cout << "Command-line parameters:\n"
                   << "  Mesh: "                << meshFile         << "\n"
-                  << "  Kernel: "              << Assembler::variantName() << "\n"
+                  << "  Kernel: "              << Assembler::variantName(Assembler::Variant::GraphLump) << "\n"
                   << "  Block size: "          << blockSize        << "\n"
                   << "  Bucket size: "         << bucketSize       << "\n"
                   << "  Bucket size (focus): " << bucketSizeFocus  << "\n"
@@ -307,7 +307,7 @@ int main(int argc, char** argv) {
 
     if (rank == 0) {
         std::cout << std::scientific << std::setprecision(6);
-        std::cout << "Assembler: MARS CVFEM Tet (Graph+Lump " << Assembler::variantName() << ")....: "
+        std::cout << "Assembler: MARS CVFEM Tet (Graph+Lump " << Assembler::variantName(Assembler::Variant::GraphLump) << ")....: "
                   << perf.avgAssemblyTimeMs() << " milliseconds @ "
                   << perf.bandwidthGBs() << " GB/s (average of " << numIterations
                   << " samples) [matrix norm: " << matrix_norm

--- a/examples/distributed/unstructured/mars_cvfem_ho_compare.cu
+++ b/examples/distributed/unstructured/mars_cvfem_ho_compare.cu
@@ -54,6 +54,46 @@ using namespace mars::fem;
 #define CK(call) do { cudaError_t e=(call); if(e!=cudaSuccess){ \
   printf("CUDA error %s at %s:%d\n", cudaGetErrorString(e), __FILE__, __LINE__); return 1; } } while(0)
 
+// FLOP/DOF (FP64) per matvec, counted from the actual kernel loops, so GFLOP/s =
+// FLOP/DOF * GDOF/s. A mul or an add is 1 FLOP; a divide is 1 FLOP.
+//
+// SpMV (full + graph): a CSR matvec does value*u (1 mul) + accumulate (1 add) per
+// nnz => 2 FLOP/nnz, so 2*nnz total and FLOP/DOF = 2 * (nnz/row). nnz/row is read
+// from the built sparsity, NOT assumed (full ~27, graph ~7 for interior hexes).
+//
+// Matrix-free HO apply (store-d_G, the default): from mars_cvfem_ho_matfree.hpp
+// ho_cvfem_apply_kernel, per (dir,l) iteration (3*P of them) over NN=(P+1)^2 slots,
+// each slot does:
+//   step1 interp+deriv : 4*N   (bi: 1m+1a, di: 1m+1a, over q=0..N-1)
+//   step2 tang-D + flux: 4*N+5 (dt2: 2N, dt1: 2N, flux g2*deriv+g0*dt2+g1*dt1=3m+2a)
+//   step3 W r-axis     : 2*N
+//   step4 W s-axis +/- : 2*N+2 (W: 2N, then -= and += scatter)
+//   => 12*N + 7 FLOP/slot,  N=P+1.
+// apply FLOP/element = 3*P*(P+1)^2 * (12*(P+1)+7). Interior tensor hex owns p^3 of
+// its (p+1)^3 nodes, so FLOP/DOF = 3*P*(P+1)^2*(12*(P+1)+7) / P^3. This RISES with
+// p (~315 at p=4 vs 372 at p=1, 404 at p=7), the key contrast with FLOP-poor SpMV.
+// Cross-check vs a textbook tensor-product PA Laplacian (~(2d^2+d)(p+1) per pass,
+// a few passes): our CVFEM SCS sweep (interp+deriv+2 tangential D+2 W integrations
+// per direction) is ~1.5-2x heavier than a minimal Galerkin PA -- expected, the SCS
+// flux form does more contractions per point than a fused gradient-Laplacian PA.
+//
+// Matrix-free --MF (recompute, ho_cvfem_apply_recompute_kernel): apply FLOP PLUS an
+// inline metric at each of the 3*P*(P+1)^2 SCS quad points: 8-corner trilinear
+// Jacobian build (8*(21 shape + 18 accumulate)=312), 3x3 determinant (14), inverse
+// with 9 divides (36), gvec = detJ*Jinv*Jinv^T (18) => ~380 FLOP/point. Recompute
+// FLOP/DOF = apply + 3*P*(P+1)^2*380 / p^3; the metric term dominates at low p
+// (~4560 extra at p=1) and amortizes at high p.
+static inline double spmvFlopPerDof(double nnzPerRow) { return 2.0 * nnzPerRow; }
+static inline double mfApplyFlopPerDof(int p) {
+    const double N = p + 1.0;
+    const double perSlot = 12.0 * N + 7.0;
+    return 3.0 * p * N * N * perSlot / std::pow((double)p, 3.0);
+}
+static inline double mfMetricFlopPerDof(int p) {
+    const double N = p + 1.0;
+    return 3.0 * p * N * N * 380.0 / std::pow((double)p, 3.0);
+}
+
 // MARS hex corner c -> HO local DOF index l = i*4 + j*2 + k, where (i,j,k) are the
 // reference-cube indices (0/1) of corner c from c_hexCornerRef signs:
 // i=(S0+1)/2, j=(S1+1)/2, k=(S2+1)/2. This is the ONLY place the two corner
@@ -366,6 +406,17 @@ int main(int argc, char** argv)
         double mgDofPerS = (double)numDofs / (msMG * 1e-3);   // graph (7-nnz) SpMV throughput
         double mfDofPerS = (double)numDofs / (msMF * 1e-3);   // matrix-free throughput
 
+        // FLOP/DOF (FP64) per matvec for each measured method, from the kernel-loop
+        // counts above. GFLOP/s = FLOP/DOF * GDOF/s -- the same DOF normalization the
+        // throughput uses, so the two columns are consistent. nnz/row is read from the
+        // built sparsity (NOT assumed); matrix-free here is the p=1 store-d_G apply.
+        double fullFpd = spmvFlopPerDof((double)nnz / numDofs);
+        double grfFpd  = spmvFlopPerDof((double)gnnz / numDofs);
+        double mfFpd   = mfApplyFlopPerDof(1);
+        double mbGflops = fullFpd * mbDofPerS / 1e9;
+        double mgGflops = grfFpd  * mgDofPerS / 1e9;
+        double mfGflops = mfFpd   * mfDofPerS / 1e9;
+
         printf("HO CVFEM matrix-free (Knaus Alg 2, p=1) vs assembled CSR + cuSPARSE SpMV\n");
         printf("nodes=%zu elems=%zu numDofs=%d\n", nodeCount, elementCount, numDofs);
         printf("  full  CSR nnz=%d nnz/row=%.1f   graph CSR nnz=%d nnz/row=%.1f\n",
@@ -382,10 +433,18 @@ int main(int argc, char** argv)
         else
             printf("  => DIFFERENT operators (per-row structural difference).\n");
 
-        printf("\n-- THROUGHPUT --\n");
-        printf("  assembled FULL  (27-nnz) SpMV : %.4f ms/matvec | %.1f MDOF/s\n", msMB, mbDofPerS / 1e6);
-        printf("  assembled GRAPH (7-nnz)  SpMV : %.4f ms/matvec | %.1f MDOF/s\n", msMG, mgDofPerS / 1e6);
-        printf("  matrix-free HO                : %.4f ms/matvec | %.1f MDOF/s\n", msMF, mfDofPerS / 1e6);
+        printf("\n-- THROUGHPUT (GDOF/s) + COMPUTE (GFLOP/s, FP64) --\n");
+        printf("  method                          ms/matvec   GDOF/s   GFLOP/s   FLOP/DOF\n");
+        printf("  assembled FULL  (27-nnz) SpMV : %9.4f  %7.2f  %8.1f  %8.0f\n",
+               msMB, mbDofPerS / 1e9, mbGflops, fullFpd);
+        printf("  assembled GRAPH (7-nnz)  SpMV : %9.4f  %7.2f  %8.1f  %8.0f\n",
+               msMG, mgDofPerS / 1e9, mgGflops, grfFpd);
+        printf("  matrix-free HO (p=1, store-G) : %9.4f  %7.2f  %8.1f  %8.0f\n",
+               msMF, mfDofPerS / 1e9, mfGflops, mfFpd);
+        printf("  WHY: SpMV is FLOP-poor (FLOP/DOF = 2*nnz/row) and memory-bound, so its\n");
+        printf("       GFLOP/s stays low; matrix-free FLOP/DOF rises with p (see table below),\n");
+        printf("       so at fixed ~flat GDOF/s its GFLOP/s climbs with order. High-order\n");
+        printf("       matrix-free, not low-order SpMV, is the GFLOP/s-rich regime.\n");
         printf("  speedup vs FULL  (27-nnz)            = %.2fx (%s)\n",
                msMB / msMF, msMF < msMB ? "matrix-free faster" : "SpMV faster");
         printf("  speedup vs GRAPH (7-nnz, PRODUCTION) = %.2fx (%s)  <- the honest p=1 baseline\n",
@@ -426,9 +485,61 @@ int main(int argc, char** argv)
             printf("  %2d | %7.0f | %15.1f | %13.1f | %14.1fx\n",
                    p, stencil, asmBpd, mfBpd, asmBpd / mfBpd);
         }
-        printf("\n  Measured throughput anchors (GDOF/s): matrix-free HO 4.8 / 7.2 / 4.9 at p=1/2/4\n");
-        printf("  (H100, prior validated run); this run's p=1 matrix-free = %.2f GDOF/s, SpMV = %.2f GDOF/s.\n",
-               mfDofPerS / 1e9, mbDofPerS / 1e9);
+
+        // ---- CROSS-p FLOP/s projection (the GB-class regime). Matrix-free GDOF/s is
+        // ~flat in p (measured anchors below), but FLOP/DOF RISES with p, so GFLOP/s
+        // climbs with order while assembled SpMV stays FLOP-poor. We project GFLOP/s =
+        // FLOP/DOF(p) * GDOF/s(p) using measured GDOF/s anchors where we have them and
+        // the closest measured value otherwise (clearly marked), so the climb is shown
+        // on real throughput, not invented. ----
+        const double mfMeasGdofs = mfDofPerS / 1e9;  // this run's measured p=1 matrix-free
+        // GDOF/s anchors per p (H100/Alps, prior validated runs). p=1 uses THIS run.
+        const double gdofsAnchor[8] = {0.0, mfMeasGdofs, 7.2, 6.0, 4.9, 4.0, 3.5, 3.0};
+        const bool   measured[8]    = {false, true, true, false, true, false, false, false};
+        printf("\n-- CROSS-p FLOP/s (matrix-free store-G; GDOF/s ~flat, FLOP/DOF rises -> GFLOP/s climbs) --\n");
+        printf("   p | apply FLOP/DOF | GDOF/s (src) | GFLOP/s | --MF FLOP/DOF | --MF GFLOP/s\n");
+        for (int p = 1; p <= 7; ++p) {
+            double fpd   = mfApplyFlopPerDof(p);
+            double mfpd  = fpd + mfMetricFlopPerDof(p);
+            double gdofs = gdofsAnchor[p];
+            printf("  %2d | %14.0f | %7.2f (%s) | %7.1f | %13.0f | %12.1f\n",
+                   p, fpd, gdofs, measured[p] ? "meas" : "est ",
+                   fpd * gdofs, mfpd, mfpd * gdofs);
+        }
+        printf("  This run's p=1 matrix-free = %.2f GDOF/s (%.1f GFLOP/s FP64), full SpMV = %.2f GDOF/s (%.1f GFLOP/s).\n",
+               mfMeasGdofs, fullFpd * mfMeasGdofs, mbDofPerS / 1e9, mbGflops);
+
+        // ---- MFEM Gordon Bell 2025 positioning (same method class: high-order FE
+        // partial assembly). Sources (verified, URLs):
+        //   GB paper: Henneking et al., arXiv:2504.16344 (SC25, 2025 ACM Gordon Bell
+        //     Prize, Cascadia tsunami digital twin). MFEM forward operator, p=4
+        //     pressure / p=3 velocity, 55.5T DOF on the FULL El Capitan, 43,520 AMD
+        //     MI300A GPUs (61.3 TFLOP/s FP64 peak each), 2.73 EFLOP/s machine peak,
+        //     92% weak / 79% strong efficiency.  [Sec VI-A, VI-C, I]
+        //   FP64-TC paper: Tu, Karlin, Camier, Dobrev, Kolev, Henneking, Ghattas,
+        //     arXiv:2603.09038 -- the MFEM PA kernel on GH200: FP64 *vector* peak
+        //     34.0 TFLOP/s, FP64 *tensor-core* (DMMA) peak ~67 TFLOP/s (2x). Their
+        //     original PA kernel runs at ~14% of the FP64 vector pipe; the DMMA PA
+        //     kernel reaches 54% of the DMMA pipe. Throughput is reported in GDOF/s,
+        //     same metric as here.  [Sec III-E, VI-A]
+        // GH200 (Alps, our target) single-GPU FP64 peak: 34.0 TFLOP/s vector cores;
+        // ~67 TFLOP/s with FP64 tensor cores. Both from arXiv:2603.09038 / GB Sec VI-A.
+        const double gh200VecPeakGflops = 34000.0;   // 34.0 TFLOP/s FP64 vector
+        const double gh200TcPeakGflops  = 67000.0;   // ~67 TFLOP/s FP64 tensor-core (DMMA)
+        const double mi300aPeakGflops   = 61300.0;   // 61.3 TFLOP/s FP64 (El Capitan)
+        double mfP4Gflops = mfApplyFlopPerDof(4) * 5.0;   // our p=4 anchor: ~5 GDOF/s
+        printf("\n-- MFEM GORDON BELL 2025 POSITIONING (high-order FE PA, same class) --\n");
+        printf("  GB paper arXiv:2504.16344: 55.5T DOF, 43,520 MI300A GPUs, 2.73 EFLOP/s machine peak (El Capitan).\n");
+        printf("  FP64-TC paper arXiv:2603.09038 (MFEM PA on GH200): original PA ~14%% of FP64 vector pipe,\n");
+        printf("    DMMA PA 54%% of FP64 tensor-core pipe. GH200 FP64 peak: 34.0 TFLOP/s vector, ~67 TFLOP/s tensor.\n");
+        printf("  OURS (p=4 matrix-free store-G, ~5 GDOF/s anchor): FLOP/DOF=%.0f -> ~%.1f GFLOP/s/GPU FP64.\n",
+               mfApplyFlopPerDof(4), mfP4Gflops);
+        printf("    = %.1f%% of GH200 FP64 vector peak (%.0f GFLOP/s), %.1f%% of FP64 tensor-core peak (%.0f).\n",
+               100.0 * mfP4Gflops / gh200VecPeakGflops, gh200VecPeakGflops,
+               100.0 * mfP4Gflops / gh200TcPeakGflops, gh200TcPeakGflops);
+        printf("    (MI300A FP64 peak for reference: %.0f GFLOP/s.)\n", mi300aPeakGflops);
+        printf("  We are vector-core matrix-free; the GB result's headroom is the FP64 tensor-core (DMMA)\n");
+        printf("  path -- the same lever (arXiv:2603.09038) we target on GH200/Alps to close the gap to peak.\n");
 
         // ---- Element-level stencil dump (small meshes, e.g. --ncells=1 -> single
         //      8x8 element). Build BOTH operators' dense matrices by applying to the

--- a/examples/distributed/unstructured/mars_cvfem_ho_weakscale.cu
+++ b/examples/distributed/unstructured/mars_cvfem_ho_weakscale.cu
@@ -205,11 +205,19 @@ int main(int argc, char** argv)
 
     std::string mesh; size_t ncells = 0; int iters = 50; std::string dumpFile;
     bool overlap = false;   // --overlap: hide the forward halo behind the interior apply
+    // --irregular: opt-in genuinely-unstructured procedural mesh (warp+deform) so the
+    // scaling test is not flattered by the perfect cube's free SFC locality. The deform
+    // is DOMAIN-scale (amplitude + wavelength fixed in domain units), so the halo bump
+    // is INDEPENDENT of --ncells -> it still holds at trillion scale (a perturbation
+    // tied to local h would be cosmetic there). Default OFF -> byte-identical perfect
+    // cube, existing runs unchanged.
+    CubeIrregularity irr{};
     for (int i = 1; i < argc; ++i) { std::string a = argv[i];
         if (a.rfind("--mesh=", 0) == 0) mesh = a.substr(7);
         else if (a.rfind("--ncells=", 0) == 0) ncells = std::stoull(a.substr(9));
         else if (a.rfind("--iters=", 0) == 0) iters = std::stoi(a.substr(8));
         else if (a == "--overlap") overlap = true;
+        else if (a == "--irregular") { irr.warp = true; irr.deform = true; }
         else if (a.rfind("--dump-parity=", 0) == 0) dumpFile = a.substr(14); }
     if (mesh.empty() && ncells == 0) {
         if (rank == 0) printf("need --mesh=<dir/.exo> OR --ncells=<N> [--iters=N] [--dump-parity=<file>]\n");
@@ -222,7 +230,7 @@ int main(int argc, char** argv)
         domainPtr = new Domain(mesh, rank, numRanks, true, 64, 8u);
     } else {
         auto [genNodes, genElems, gx, gy, gz, lconn] =
-            generateCubeElementPartition<RealType, KeyType>(ncells, rank, numRanks);
+            generateCubeElementPartition<RealType, KeyType>(ncells, rank, numRanks, irr);
         (void)genNodes; (void)genElems;
         typename Domain::HostCoordsTuple h_coords{std::move(gx), std::move(gy), std::move(gz)};
         typename Domain::HostConnectivityTuple h_conn{

--- a/scripts/generate_hex_cube.py
+++ b/scripts/generate_hex_cube.py
@@ -167,14 +167,22 @@ def _write_connectivity_chunked(nx, ny, nz, output_dir, dtype, ext):
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser(description="Generate hex cube mesh in MARS binary format")
-    p.add_argument("--nx", type=int, default=100)
-    p.add_argument("--ny", type=int, default=100)
-    p.add_argument("--nz", type=int, default=100)
+    p.add_argument("-n", type=int, default=None,
+                   help="Cells per side for all axes (shorthand for --nx --ny --nz)")
+    p.add_argument("--nx", type=int, default=None, help="Cells in x (overrides -n)")
+    p.add_argument("--ny", type=int, default=None, help="Cells in y (overrides -n)")
+    p.add_argument("--nz", type=int, default=None, help="Cells in z (overrides -n)")
     p.add_argument("--output", type=str, default="hex_cube_mesh")
     p.add_argument("--int32", action="store_true", help="Use int32 instead of int64")
     p.add_argument("--chunked", action="store_true",
                    help="Stream connectivity in z-slabs (lower peak memory)")
     args = p.parse_args()
 
-    generate_hex_cube(args.nx, args.ny, args.nz, args.output,
+    # -n sets the default for every axis; --nx/--ny/--nz override per axis.
+    base = args.n if args.n is not None else 100
+    nx = args.nx if args.nx is not None else base
+    ny = args.ny if args.ny is not None else base
+    nz = args.nz if args.nz is not None else base
+
+    generate_hex_cube(nx, ny, nz, args.output,
                       use_int64=not args.int32, chunked=args.chunked)

--- a/scripts/ho_160B_64nodes.sbatch
+++ b/scripts/ho_160B_64nodes.sbatch
@@ -4,7 +4,6 @@
 #SBATCH --nodes=64
 #SBATCH --ntasks-per-node=4
 #SBATCH --time=01:00:00
-#SBATCH --chdir=$SCRATCH/git/mars/daint-gpu
 #SBATCH --output=ho160B_%j.out
 #SBATCH --uenv-passthrough=use
 #
@@ -13,4 +12,6 @@
 # Expect: device A.1 PASS (~1e-19), apply ~6 GDOF/s/GPU, comm ~9% (peers maxed at 26).
 
 export MARS_NODEHALO_V2=1
+# SLURM does not expand vars in #SBATCH directives, so cd to the build dir here.
+cd "${BUILD_DIR:-$SCRATCH/git/mars/daint-gpu}"
 srun --export=ALL ./examples/distributed/unstructured/mars_ho_dist_apply_test --ncells=1357 --p=4

--- a/scripts/ho_trillion_400nodes.sbatch
+++ b/scripts/ho_trillion_400nodes.sbatch
@@ -4,7 +4,6 @@
 #SBATCH --nodes=400
 #SBATCH --ntasks-per-node=4
 #SBATCH --time=03:00:00
-#SBATCH --chdir=$SCRATCH/git/mars/daint-gpu
 #SBATCH --output=ho1e12_%j.out
 #SBATCH --uenv-passthrough=use
 #
@@ -24,6 +23,8 @@ export MARS_HO_HALO_TIMING=1        # per-stage GPU halo-build breakdown (cheap)
 # GPU DOF numbering, GPU P2P ownership resolve, AND GPU halo build are ALL the default now (no env).
 # MARS_HO_HOST=1 would force the host resolve+halo -- we are NOT setting it, so the full GPU path runs.
 
+# SLURM does not expand vars in #SBATCH directives, so cd to the build dir here.
+cd "${BUILD_DIR:-$SCRATCH/git/mars/daint-gpu}"
 echo "=== 1600 ranks / 400 nodes, ~1.0 TRILLION DOF (cube2500) ==="
 srun --nodes=400 --ntasks-per-node=4 --export=ALL \
   ./examples/distributed/unstructured/mars_ho_dist_apply_test --ncells=2500 --p=4

--- a/scripts/profile_weak_scaling.sh
+++ b/scripts/profile_weak_scaling.sh
@@ -13,7 +13,7 @@ module load nvhpc cuda nsight-systems
 
 BUILD_DIR=$SCRATCH/git/mars/build
 MESH_DIR=$SCRATCH/git/meshes
-AFFINITY=~/affinity/bind_numa.sh
+AFFINITY=${AFFINITY:-~/affinity/bind_numa.sh}
 OUTPUT_DIR=$BUILD_DIR/profile_results
 
 mkdir -p $OUTPUT_DIR

--- a/scripts/strong_scaling.sh
+++ b/scripts/strong_scaling.sh
@@ -8,8 +8,8 @@
 set -euo pipefail
 
 BINARY=${BUILD_DIR:-$(pwd)}/examples/distributed/unstructured/mars_cvfem_graph
-MESH=/users/fabianw/work/asm_test_mesh/block_32M.exo
-AFFINITY=~/affinity/bind_numa.sh
+MESH=${MESH:?set MESH to a 32M-element Exodus mesh}
+AFFINITY=${AFFINITY:-~/affinity/bind_numa.sh}
 ACCOUNT=csstaff
 GPUS_PER_NODE=4  # GH200 nodes on santis
 ITERATIONS=100


### PR DESCRIPTION
- **track HO matfree + AMR-tet example drivers (fix fresh-clone build)**
- **KNOWN_LIMITATIONS: module status + kernel-variant guidance**
- **install self-test: self-contained Mars::mars link smoke**
- **HO matfree: halo overlap + ownership headers (driver deps)**
- **tet full/full-perip assembly + jacobian_and_dNdx helper**
- **scripts: portable build dir + -n cube shorthand, redact paths**
