### PR TITLE
cstone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,16 +524,9 @@ else()
     endif()
 endif()
 
-# Export the cxxopts target if it was fetched
-if(TARGET cxxopts)
-    install(TARGETS cxxopts
-        EXPORT MarsTargets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        INCLUDES DESTINATION include
-    )
-endif()
+# cxxopts is internal CLI tooling for the example drivers, not part of the Mars API.
+# It is NOT exported into the Mars package: examples build it in-tree, and downstream
+# consumers neither need nor receive it.
 
 # Install the main mars library into the export set so downstream
 # find_package(Mars) gets the Mars::mars target (without this the export is empty).


### PR DESCRIPTION
- **track HO matfree + AMR-tet example drivers (fix fresh-clone build)**
- **KNOWN_LIMITATIONS: module status + kernel-variant guidance**
- **install self-test: self-contained Mars::mars link smoke**
- **HO matfree: halo overlap + ownership headers (driver deps)**
- **tet full/full-perip assembly + jacobian_and_dNdx helper**
- **scripts: portable build dir + -n cube shorthand, redact paths**
- **MarsConfig: resolve CUDA/MPI deps + skip bundled cxxopts**
- **MarsConfig: drop bundled-cxxopts find_dependency**
- **cxxopts is internal: drop from Mars install/export**
