### PR TITLE
cstone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,9 +509,10 @@ if(TARGET cstone_gpu)
                     RENAME "${GPU_LIB_NAME}")
         endif()
     else()
-        # For locally built targets, add to export set
-        list(APPEND MARS_TARGETS cstone_gpu)
-        set_property(TARGET cstone_gpu PROPERTY EXPORT_NAME Mars::cstone_gpu)
+        # Locally built (FetchContent): install the library file so a downstream
+        # find_package(Mars) consumer can link the cstone_gpu imported target that
+        # MarsConfig.cmake recreates.
+        install(FILES "$<TARGET_FILE:cstone_gpu>" DESTINATION lib)
     endif()
 else()
     # Fallback for when target doesn't exist but we have a path
@@ -542,6 +543,23 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/base/mars_config.hpp.in
                ${CMAKE_BINARY_DIR}/mars_config.hpp)
 install(FILES ${MARS_HEADERS} DESTINATION include)
 install(FILES ${CMAKE_BINARY_DIR}/mars_config.hpp DESTINATION include)
+
+# Export the unstructured backend (mars links it PUBLICLY, so consumers need it).
+if(TARGET mars_unstructured)
+    install(TARGETS mars_unstructured
+        EXPORT MarsTargets
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        INCLUDES DESTINATION include)
+endif()
+
+# Bundle the vendored cornerstone headers so downstream find_package(Mars) consumers
+# can compile against Mars's public headers (ElementDomain exposes cstone types).
+if(CORNERSTONE_INCLUDE_DIRS AND IS_DIRECTORY "${CORNERSTONE_INCLUDE_DIRS}")
+    install(DIRECTORY "${CORNERSTONE_INCLUDE_DIRS}/" DESTINATION include
+            FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp" PATTERN "*.cuh" PATTERN "*.inc")
+endif()
 
 install(
     EXPORT MarsTargets

--- a/cmake/MarsConfig.cmake.in
+++ b/cmake/MarsConfig.cmake.in
@@ -32,4 +32,21 @@ endif()
 ########## end of old style variables ####################################################################################
 
 
+# Mars bundles the vendored cornerstone-octree (its headers, and for GPU builds the
+# cstone_gpu library) into its own install prefix. Recreate cornerstone's targets so
+# the Mars::mars / Mars::mars_unstructured references in MarsTargets resolve without a
+# separate cornerstone install. Guarded by NOT TARGET so an in-tree build (where the
+# real targets already exist) is left untouched.
+if (NOT TARGET cornerstone::cornerstone)
+    add_library(cornerstone::cornerstone INTERFACE IMPORTED)
+    set_target_properties(cornerstone::cornerstone PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/include")
+endif()
+
+if (@MARS_ENABLE_CUDA@ AND NOT TARGET cstone_gpu)
+    add_library(cstone_gpu STATIC IMPORTED)
+    set_target_properties(cstone_gpu PROPERTIES
+        IMPORTED_LOCATION "${PACKAGE_PREFIX_DIR}/lib/libcstone_gpu.a")
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/MarsTargets.cmake")


### PR DESCRIPTION
- **track HO matfree + AMR-tet example drivers (fix fresh-clone build)**
- **KNOWN_LIMITATIONS: module status + kernel-variant guidance**
- **install self-test: self-contained Mars::mars link smoke**
- **HO matfree: halo overlap + ownership headers (driver deps)**
- **tet full/full-perip assembly + jacobian_and_dNdx helper**
- **scripts: portable build dir + -n cube shorthand, redact paths**
- **MarsConfig: resolve CUDA/MPI deps + skip bundled cxxopts**
- **MarsConfig: drop bundled-cxxopts find_dependency**
- **cxxopts is internal: drop from Mars install/export**
- **make Mars consumable: bundle cornerstone headers + cstone_gpu, export mars_unstructured**
