### PR TITLE
cstone

### DIFF
--- a/cmake/MarsConfig.cmake.in
+++ b/cmake/MarsConfig.cmake.in
@@ -25,6 +25,13 @@ if (@MARS_ENABLE_MPI@)
     find_dependency(MPI COMPONENTS CXX)
 endif()
 
+# mars_unstructured links netcdf (Exodus mesh reading) as the imported target
+# PkgConfig::NETCDF; recreate it the same way the build did so the consumer resolves it.
+if (@MARS_ENABLE_UNSTRUCTURED@ AND NOT TARGET PkgConfig::NETCDF)
+    find_dependency(PkgConfig)
+    pkg_check_modules(NETCDF QUIET IMPORTED_TARGET netcdf)
+endif()
+
 @PACKAGE_INIT@
 
 ########## old style variables. Preferably you should use target_link_libraries(my_target Mars::mars) ################


### PR DESCRIPTION
- **track HO matfree + AMR-tet example drivers (fix fresh-clone build)**
- **KNOWN_LIMITATIONS: module status + kernel-variant guidance**
- **install self-test: self-contained Mars::mars link smoke**
- **HO matfree: halo overlap + ownership headers (driver deps)**
- **tet full/full-perip assembly + jacobian_and_dNdx helper**
- **scripts: portable build dir + -n cube shorthand, redact paths**
- **MarsConfig: resolve CUDA/MPI deps + skip bundled cxxopts**
- **MarsConfig: drop bundled-cxxopts find_dependency**
- **cxxopts is internal: drop from Mars install/export**
- **make Mars consumable: bundle cornerstone headers + cstone_gpu, export mars_unstructured**
- **MarsConfig: recreate PkgConfig::NETCDF for consumers**
