### PR TITLE
cstone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to MARS are documented here. The format follows
 [Semantic Versioning](https://semver.org/). While the major version is `0`, the
 public API may change between minor releases.
 
-## [0.1.0] — 2026-06-29
+## [0.1.0] — 2026-07-01
 
 First tagged public release. MARS is a GPU-native mesh management and finite-element
 assembly library for N-dimensional elements (N ≤ 4), built in C++20 on CUDA / HIP and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,4 +18,4 @@ repository-code: "https://github.com/dganellari/mars"
 url: "https://github.com/dganellari/mars"
 license: BSD-3-Clause
 version: 0.1.0
-date-released: "2026-06-29"
+date-released: "2026-07-01"

--- a/cxxopts/cxxopts.cmake
+++ b/cxxopts/cxxopts.cmake
@@ -14,8 +14,11 @@ if(MARS_ENABLE_CXXOPTS)
         message(STATUS "Found cxxopts")
     endif()
 
-    # Add cxxopts to the list of dependencies
-    list(APPEND MARS_DEP_LIBRARIES cxxopts::cxxopts)
+    # cxxopts is header-only CLI tooling used only by in-tree example drivers, not by the
+    # mars library or its public API. Link it BUILD-only so examples get it transitively,
+    # while it never leaks into the installed Mars::mars interface (cxxopts ships no
+    # library, so a leaked reference becomes a broken -lcxxopts for consumers).
+    list(APPEND MARS_DEP_LIBRARIES $<BUILD_INTERFACE:cxxopts::cxxopts>)
     list(APPEND MARS_DEP_INCLUDES ${cxxopts_INCLUDE_DIRS})
 
     set(MARS_ENABLE_CXXOPTS ON)


### PR DESCRIPTION
- **track HO matfree + AMR-tet example drivers (fix fresh-clone build)**
- **KNOWN_LIMITATIONS: module status + kernel-variant guidance**
- **install self-test: self-contained Mars::mars link smoke**
- **HO matfree: halo overlap + ownership headers (driver deps)**
- **tet full/full-perip assembly + jacobian_and_dNdx helper**
- **scripts: portable build dir + -n cube shorthand, redact paths**
- **MarsConfig: resolve CUDA/MPI deps + skip bundled cxxopts**
- **MarsConfig: drop bundled-cxxopts find_dependency**
- **cxxopts is internal: drop from Mars install/export**
- **make Mars consumable: bundle cornerstone headers + cstone_gpu, export mars_unstructured**
- **MarsConfig: recreate PkgConfig::NETCDF for consumers**
- **cxxopts: link BUILD-only so it doesn't leak into the installed interface**
- **v0.1.0: align release date to 2026-07-01**
