### PR TITLE
cstone

### DIFF
--- a/backend/distributed/unstructured/CMakeLists.txt
+++ b/backend/distributed/unstructured/CMakeLists.txt
@@ -6,13 +6,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_library(mars_unstructured STATIC)
 
 # Set include directories
+# Build-tree paths must be $<BUILD_INTERFACE:> so mars_unstructured is export-safe;
+# installed consumers get headers from $<INSTALL_INTERFACE:include>.
 target_include_directories(mars_unstructured PUBLIC
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/base
-    ${CMAKE_SOURCE_DIR}/core
-    ${CMAKE_SOURCE_DIR}/backend/distributed
-    ${CMAKE_BINARY_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/backend/distributed>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
 )
 
 # Add all distributed backend subdirectories for header dependencies
@@ -27,10 +30,11 @@ target_include_directories(mars_unstructured PRIVATE
     ${CMAKE_SOURCE_DIR}/backend/distributed/unstructured/utils
 )
 
-# System includes (won't propagate warnings)
+# System includes (won't propagate warnings). Build-only: installed consumers get
+# cornerstone headers from the recreated cornerstone::cornerstone target (MarsConfig).
 target_include_directories(mars_unstructured SYSTEM PUBLIC
-    ${CMAKE_BINARY_DIR}/cornerstone_includes
-    ${CORNERSTONE_INCLUDE_DIRS}
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/cornerstone_includes>
+    $<BUILD_INTERFACE:${CORNERSTONE_INCLUDE_DIRS}>
 )
 
 # Add the implementation files to the target


### PR DESCRIPTION
- **track HO matfree + AMR-tet example drivers (fix fresh-clone build)**
- **KNOWN_LIMITATIONS: module status + kernel-variant guidance**
- **install self-test: self-contained Mars::mars link smoke**
- **HO matfree: halo overlap + ownership headers (driver deps)**
- **tet full/full-perip assembly + jacobian_and_dNdx helper**
- **scripts: portable build dir + -n cube shorthand, redact paths**
- **MarsConfig: resolve CUDA/MPI deps + skip bundled cxxopts**
- **MarsConfig: drop bundled-cxxopts find_dependency**
- **cxxopts is internal: drop from Mars install/export**
- **make Mars consumable: bundle cornerstone headers + cstone_gpu, export mars_unstructured**
- **MarsConfig: recreate PkgConfig::NETCDF for consumers**
- **cxxopts: link BUILD-only so it doesn't leak into the installed interface**
- **v0.1.0: align release date to 2026-07-01**
- **mars_unstructured: BUILD_INTERFACE-wrap public includes so it is export-safe**
