### PR TITLE
cstone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,6 @@ project(
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-enable_testing()
-if(MARS_ENABLE_TESTS)
-    include(cmake/Tests.cmake)
-endif()
-
 
 if(MARS_ENABLE_CUDA)
     check_language(CUDA)
@@ -115,6 +110,16 @@ include(CMakeDependentOption)
 # Cmake imports.
 include(cmake/MarsDefaults.cmake)
 include(cmake/MarsOptions.cmake)
+
+# Tests.cmake defines mars_add_test; include it AFTER MarsOptions sets the
+# MARS_ENABLE_TESTS default. Otherwise a clean configure reads an empty value,
+# skips the include, and the testsuite subdirs call an undefined mars_add_test
+# (works on a dirty rebuild only because the cache masks the ordering).
+enable_testing()
+if(MARS_ENABLE_TESTS)
+    include(cmake/Tests.cmake)
+endif()
+
 include(cmake/MarsCMakeFunctions.cmake)
 include(cmake/MarsDependencies.cmake)
 include(cmake/MarsClangFormat.cmake)
@@ -202,7 +207,12 @@ if(MARS_ENABLE_UNSTRUCTURED)
         if(MARS_ENABLE_CUDA OR MARS_ENABLE_HIP)
             if(TARGET cstone_gpu)
                 message(STATUS "cstone_gpu target will be built from source")
-                set(CORNERSTONE_GPU_LIBRARY "$<TARGET_FILE:cstone_gpu>" CACHE PATH "Path to cstone_gpu library" FORCE)
+                # Do NOT cache $<TARGET_FILE:cstone_gpu> as a path. A generator
+                # expression is not a real path: it leaks verbatim into
+                # IMPORTED_LOCATION and the CUDA device-link rule, which make cannot
+                # parse ("target pattern contains no '%'"). cstone_gpu is a real
+                # target here, so link it directly (target_link_libraries) and use
+                # the $<TARGET_FILE:cstone_gpu> genex only in genex-aware contexts.
             else()
                 message(WARNING "cstone_gpu target not found in Cornerstone build")
             endif()

--- a/backend/distributed/testsuite/unstructured/CMakeLists.txt
+++ b/backend/distributed/testsuite/unstructured/CMakeLists.txt
@@ -95,16 +95,14 @@ function(addMarsGpuMpiTest source exename testname)
     )
 
     if(TARGET cstone_gpu)
-        get_target_property(GPU_LIB cstone_gpu IMPORTED_LOCATION)
-        if(GPU_LIB)
-            message(STATUS "Force-linking GPU library: ${GPU_LIB}")
-            if(UNIX AND NOT APPLE)
-                # Linux syntax
-                target_link_options(${exename} PRIVATE "LINKER:--whole-archive,${GPU_LIB},--no-whole-archive")
-            elseif(APPLE)
-                # macOS syntax
-                target_link_options(${exename} PRIVATE "LINKER:-force_load,${GPU_LIB}")
-            endif()
+        # Whole-archive so cstone_gpu's device symbols aren't dropped. Use the
+        # $<TARGET_FILE:> genex (evaluated at generate time): reading IMPORTED_LOCATION
+        # is empty for a built target, and for an imported one could be an unevaluated
+        # genex that leaks verbatim into the make device-link rule.
+        if(UNIX AND NOT APPLE)
+            target_link_options(${exename} PRIVATE "LINKER:--whole-archive,$<TARGET_FILE:cstone_gpu>,--no-whole-archive")
+        elseif(APPLE)
+            target_link_options(${exename} PRIVATE "LINKER:-force_load,$<TARGET_FILE:cstone_gpu>")
         endif()
     endif()
 


### PR DESCRIPTION
- **track HO matfree + AMR-tet example drivers (fix fresh-clone build)**
- **KNOWN_LIMITATIONS: module status + kernel-variant guidance**
- **install self-test: self-contained Mars::mars link smoke**
- **HO matfree: halo overlap + ownership headers (driver deps)**
- **tet full/full-perip assembly + jacobian_and_dNdx helper**
- **scripts: portable build dir + -n cube shorthand, redact paths**
- **MarsConfig: resolve CUDA/MPI deps + skip bundled cxxopts**
- **MarsConfig: drop bundled-cxxopts find_dependency**
- **cxxopts is internal: drop from Mars install/export**
- **make Mars consumable: bundle cornerstone headers + cstone_gpu, export mars_unstructured**
- **MarsConfig: recreate PkgConfig::NETCDF for consumers**
- **cxxopts: link BUILD-only so it doesn't leak into the installed interface**
- **v0.1.0: align release date to 2026-07-01**
- **mars_unstructured: BUILD_INTERFACE-wrap public includes so it is export-safe**
- **cmake: clean-configure fixes -- Tests.cmake after MarsOptions; drop cstone_gpu genex-as-path**
